### PR TITLE
Make 'fail' better behaved for pattern match failure.

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -287,6 +287,9 @@ instance Monad Vector where
   {-# INLINE (>>=) #-}
   (>>=) = flip concatMap
 
+  {-# INLINE fail #-}
+  fail _ = empty
+
 instance MonadPlus Vector where
   {-# INLINE mzero #-}
   mzero = empty


### PR DESCRIPTION
In particular, this makes `-XMonadComprehensions` work much nicelier:

```
{-# LANGUAGE MonadComprehensions #-}
catMaybes :: Vector (Maybe a) -> Vector a
catMaybes xs = [x | Just x <- xs]
```
