### PR TITLE
Move CPP pragmas outside {-# RULES #-}, re #21.

### DIFF
--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -837,19 +837,27 @@ enumFromTo_intlike x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len 
 "enumFromTo<Int> [Bundle]"
   enumFromTo = enumFromTo_int :: Monad m => Int -> Int -> Bundle m v Int
 
+  #-}
+
 #if WORD_SIZE_IN_BITS > 32
+
+{-# RULES
 
 "enumFromTo<Int64> [Bundle]"
   enumFromTo = enumFromTo_intlike :: Monad m => Int64 -> Int64 -> Bundle m v Int64
 
+  #-}
+
 #else
+
+{-# RULES
 
 "enumFromTo<Int32> [Bundle]"
   enumFromTo = enumFromTo_intlike :: Monad m => Int32 -> Int32 -> Bundle m v Int32
 
-#endif
-
   #-}
+
+#endif
 
 enumFromTo_big_word :: (Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_big_word #-}
@@ -876,13 +884,21 @@ enumFromTo_big_word x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len
   enumFromTo = enumFromTo_big_word
                         :: Monad m => Word64 -> Word64 -> Bundle m v Word64
 
+  #-}
+
 #if WORD_SIZE_IN_BITS == 32
+
+{-# RULES
 
 "enumFromTo<Word32> [Bundle]"
   enumFromTo = enumFromTo_big_word
                         :: Monad m => Word32 -> Word32 -> Bundle m v Word32
 
+ #-}
+
 #endif
+
+{-# RULES
 
 "enumFromTo<Integer> [Bundle]"
   enumFromTo = enumFromTo_big_word

--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -1359,19 +1359,27 @@ enumFromTo_intlike x y = x `seq` y `seq` Stream step x
 "enumFromTo<Int> [Stream]"
   enumFromTo = enumFromTo_int :: Monad m => Int -> Int -> Stream m Int
 
+  #-}
+
 #if WORD_SIZE_IN_BITS > 32
+
+{-# RULES
 
 "enumFromTo<Int64> [Stream]"
   enumFromTo = enumFromTo_intlike :: Monad m => Int64 -> Int64 -> Stream m Int64
 
+  #-}
+
 #else
+
+{-# RULES
 
 "enumFromTo<Int32> [Stream]"
   enumFromTo = enumFromTo_intlike :: Monad m => Int32 -> Int32 -> Stream m Int32
 
-#endif
-
   #-}
+
+#endif
 
 enumFromTo_big_word :: (Integral a, Monad m) => a -> a -> Stream m a
 {-# INLINE_FUSED enumFromTo_big_word #-}
@@ -1390,13 +1398,21 @@ enumFromTo_big_word x y = x `seq` y `seq` Stream step x
   enumFromTo = enumFromTo_big_word
                         :: Monad m => Word64 -> Word64 -> Stream m Word64
 
+  #-}
+
 #if WORD_SIZE_IN_BITS == 32
+
+{-# RULES
 
 "enumFromTo<Word32> [Stream]"
   enumFromTo = enumFromTo_big_word
                         :: Monad m => Word32 -> Word32 -> Stream m Word32
 
+  #-}
+
 #endif
+
+{-# RULES
 
 "enumFromTo<Integer> [Stream]"
   enumFromTo = enumFromTo_big_word


### PR DESCRIPTION
```
#if WORD_SIZE_IN_BITS == 32
#endif
```

Were inside `{-# RULE #-}` and had no effect, this may fix #21. I cannot test this at the moment so this might be bogus, just something github syntax highlighting helped point out.
