### PR TITLE
Moved around `#-}` ending RULES blocks to get Vector to build

### DIFF
--- a/Data/Vector/Fusion/Bundle.hs
+++ b/Data/Vector/Fusion/Bundle.hs
@@ -119,9 +119,9 @@ inplace f g b = b `seq` M.fromStream (f (M.elements b)) (g (M.size b))
   forall (f1 :: forall m. Monad m => S.Stream m a -> S.Stream m a)
          (f2 :: forall m. Monad m => S.Stream m a -> S.Stream m a)
          g1 g2 s.
-  inplace f1 g1 (inplace f2 g2 s) = inplace (f1 . f2) (g1 . g2) s
+  inplace f1 g1 (inplace f2 g2 s) = inplace (f1 . f2) (g1 . g2) s   #-}
 
-  #-}
+
 
 -- | Convert a pure stream to a monadic stream
 lift :: Monad m => Bundle v a -> M.Bundle m v a

--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -324,9 +324,8 @@ zipWithM f Bundle{sElems = sa, sSize = na}
 {-# RULES
 
 "zipWithM xs xs [Vector.Bundle]" forall f xs.
-  zipWithM f xs xs = mapM (\x -> f x x) xs
+  zipWithM f xs xs = mapM (\x -> f x x) xs   #-}
 
-  #-}
 
 zipWithM_ :: Monad m => (a -> b -> m c) -> Bundle m v a -> Bundle m v b -> m ()
 {-# INLINE zipWithM_ #-}
@@ -769,9 +768,9 @@ enumFromTo_small x y = x `seq` y `seq` fromStream (Stream step x) (Exact n)
   enumFromTo = enumFromTo_small :: Monad m => Word8 -> Word8 -> Bundle m v Word8
 
 "enumFromTo<Word16> [Bundle]"
-  enumFromTo = enumFromTo_small :: Monad m => Word16 -> Word16 -> Bundle m v Word16
+  enumFromTo = enumFromTo_small :: Monad m => Word16 -> Word16 -> Bundle m v Word16   #-}
 
-  #-}
+
 
 #if WORD_SIZE_IN_BITS > 32
 
@@ -781,9 +780,9 @@ enumFromTo_small x y = x `seq` y `seq` fromStream (Stream step x) (Exact n)
   enumFromTo = enumFromTo_small :: Monad m => Int32 -> Int32 -> Bundle m v Int32
 
 "enumFromTo<Word32> [Bundle]"
-  enumFromTo = enumFromTo_small :: Monad m => Word32 -> Word32 -> Bundle m v Word32
+  enumFromTo = enumFromTo_small :: Monad m => Word32 -> Word32 -> Bundle m v Word32   #-}
 
-  #-}
+
 
 #endif
 
@@ -840,16 +839,16 @@ enumFromTo_intlike x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len 
 #if WORD_SIZE_IN_BITS > 32
 
 "enumFromTo<Int64> [Bundle]"
-  enumFromTo = enumFromTo_intlike :: Monad m => Int64 -> Int64 -> Bundle m v Int64
+  enumFromTo = enumFromTo_intlike :: Monad m => Int64 -> Int64 -> Bundle m v Int64    #-}
 
 #else
 
 "enumFromTo<Int32> [Bundle]"
-  enumFromTo = enumFromTo_intlike :: Monad m => Int32 -> Int32 -> Bundle m v Int32
+  enumFromTo = enumFromTo_intlike :: Monad m => Int32 -> Int32 -> Bundle m v Int32    #-}
 
 #endif
 
-  #-}
+
 
 enumFromTo_big_word :: (Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_big_word #-}
@@ -886,9 +885,9 @@ enumFromTo_big_word x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len
 
 "enumFromTo<Integer> [Bundle]"
   enumFromTo = enumFromTo_big_word
-                        :: Monad m => Integer -> Integer -> Bundle m v Integer
+                        :: Monad m => Integer -> Integer -> Bundle m v Integer   #-}
 
-  #-}
+
 
 -- FIXME: the "too large" test is totally wrong
 enumFromTo_big_int :: (Integral a, Monad m) => a -> a -> Bundle m v a
@@ -912,9 +911,9 @@ enumFromTo_big_int x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len 
 {-# RULES
 
 "enumFromTo<Int64> [Bundle]"
-  enumFromTo = enumFromTo_big :: Monad m => Int64 -> Int64 -> Bundle m v Int64
+  enumFromTo = enumFromTo_big :: Monad m => Int64 -> Int64 -> Bundle m v Int64   #-}
 
-  #-}
+
 
 #endif
 
@@ -934,9 +933,9 @@ enumFromTo_char x y = x `seq` y `seq` fromStream (Stream step xn) (Exact n)
 {-# RULES
 
 "enumFromTo<Char> [Bundle]"
-  enumFromTo = enumFromTo_char
+  enumFromTo = enumFromTo_char   #-}
 
-  #-}
+
 
 ------------------------------------------------------------------------
 
@@ -967,9 +966,9 @@ enumFromTo_double n m = n `seq` m `seq` fromStream (Stream step n) (Max (len n m
   enumFromTo = enumFromTo_double :: Monad m => Double -> Double -> Bundle m v Double
 
 "enumFromTo<Float> [Bundle]"
-  enumFromTo = enumFromTo_double :: Monad m => Float -> Float -> Bundle m v Float
+  enumFromTo = enumFromTo_double :: Monad m => Float -> Float -> Bundle m v Float   #-}
 
-  #-}
+
 
 ------------------------------------------------------------------------
 
@@ -1092,7 +1091,7 @@ reVector Bundle{sElems = s, sSize = n} = fromStream s n
   reVector = id
 
 "reVector/reVector [Vector]" forall s.
-  reVector (reVector s) = s
+  reVector (reVector s) = s   #-}
 
-  #-}
+
 

--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -502,9 +502,8 @@ zipWithM f (Stream stepa sa) (Stream stepb sb) = Stream step (sa, sb, Nothing)
 {-# RULES
 
 "zipWithM xs xs [Vector.Stream]" forall f xs.
-  zipWithM f xs xs = mapM (\x -> f x x) xs
+  zipWithM f xs xs = mapM (\x -> f x x) xs   #-}
 
-  #-}
 
 zipWithM_ :: Monad m => (a -> b -> m c) -> Stream m a -> Stream m b -> m ()
 {-# INLINE zipWithM_ #-}
@@ -1299,9 +1298,8 @@ enumFromTo_small x y = x `seq` y `seq` Stream step x
   enumFromTo = enumFromTo_small :: Monad m => Word8 -> Word8 -> Stream m Word8
 
 "enumFromTo<Word16> [Stream]"
-  enumFromTo = enumFromTo_small :: Monad m => Word16 -> Word16 -> Stream m Word16
+  enumFromTo = enumFromTo_small :: Monad m => Word16 -> Word16 -> Stream m Word16   #-}
 
-  #-}
 
 #if WORD_SIZE_IN_BITS > 32
 
@@ -1311,9 +1309,8 @@ enumFromTo_small x y = x `seq` y `seq` Stream step x
   enumFromTo = enumFromTo_small :: Monad m => Int32 -> Int32 -> Stream m Int32
 
 "enumFromTo<Word32> [Stream]"
-  enumFromTo = enumFromTo_small :: Monad m => Word32 -> Word32 -> Stream m Word32
+  enumFromTo = enumFromTo_small :: Monad m => Word32 -> Word32 -> Stream m Word32   #-}
 
-  #-}
 
 #endif
 
@@ -1362,16 +1359,16 @@ enumFromTo_intlike x y = x `seq` y `seq` Stream step x
 #if WORD_SIZE_IN_BITS > 32
 
 "enumFromTo<Int64> [Stream]"
-  enumFromTo = enumFromTo_intlike :: Monad m => Int64 -> Int64 -> Stream m Int64
+  enumFromTo = enumFromTo_intlike :: Monad m => Int64 -> Int64 -> Stream m Int64 #-}
 
 #else
 
 "enumFromTo<Int32> [Stream]"
-  enumFromTo = enumFromTo_intlike :: Monad m => Int32 -> Int32 -> Stream m Int32
+  enumFromTo = enumFromTo_intlike :: Monad m => Int32 -> Int32 -> Stream m Int32 #-}
 
-#endif
+#endif 
 
-  #-}
+-- test
 
 enumFromTo_big_word :: (Integral a, Monad m) => a -> a -> Stream m a
 {-# INLINE_FUSED enumFromTo_big_word #-}
@@ -1400,9 +1397,9 @@ enumFromTo_big_word x y = x `seq` y `seq` Stream step x
 
 "enumFromTo<Integer> [Stream]"
   enumFromTo = enumFromTo_big_word
-                        :: Monad m => Integer -> Integer -> Stream m Integer
+                        :: Monad m => Integer -> Integer -> Stream m Integer   #-}
 
-  #-}
+
 
 -- FIXME: the "too large" test is totally wrong
 enumFromTo_big_int :: (Integral a, Monad m) => a -> a -> Stream m a
@@ -1418,9 +1415,9 @@ enumFromTo_big_int x y = x `seq` y `seq` Stream step x
 {-# RULES
 
 "enumFromTo<Int64> [Stream]"
-  enumFromTo = enumFromTo_big :: Monad m => Int64 -> Int64 -> Stream m Int64
+  enumFromTo = enumFromTo_big :: Monad m => Int64 -> Int64 -> Stream m Int64   #-}
 
-  #-}
+
 
 #endif
 
@@ -1438,9 +1435,9 @@ enumFromTo_char x y = x `seq` y `seq` Stream step xn
 {-# RULES
 
 "enumFromTo<Char> [Stream]"
-  enumFromTo = enumFromTo_char
+  enumFromTo = enumFromTo_char   #-}
 
-  #-}
+
 
 ------------------------------------------------------------------------
 
@@ -1463,9 +1460,9 @@ enumFromTo_double n m = n `seq` m `seq` Stream step n
   enumFromTo = enumFromTo_double :: Monad m => Double -> Double -> Stream m Double
 
 "enumFromTo<Float> [Stream]"
-  enumFromTo = enumFromTo_double :: Monad m => Float -> Float -> Stream m Float
+  enumFromTo = enumFromTo_double :: Monad m => Float -> Float -> Stream m Float   #-}
 
-  #-}
+
 
 ------------------------------------------------------------------------
 
@@ -1592,8 +1589,8 @@ reVector (Stream step s, sSize = n} = Stream step s n
   reVector = id
 
 "reVector/reVector [Vector]" forall s.
-  reVector (reVector s) = s
+  reVector (reVector s) = s   #-}
 
-  #-}
+
 -}
 

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -292,9 +292,9 @@ unsafeLast v = unsafeIndex v (length v - 1)
   unsafeHead (new (New.unstream s)) = Bundle.head s
 
 "unsafeLast/unstream [Vector]" forall s.
-  unsafeLast (new (New.unstream s)) = Bundle.last s
+  unsafeLast (new (New.unstream s)) = Bundle.last s  #-}
 
- #-}
+
 
 -- Monadic indexing
 -- ----------------
@@ -372,9 +372,9 @@ unsafeLastM v = unsafeIndexM v (length v - 1)
   unsafeHeadM (new (New.unstream s)) = MBundle.head (lift s)
 
 "unsafeLastM/unstream [Vector]" forall s.
-  unsafeLastM (new (New.unstream s)) = MBundle.last (lift s)
+  unsafeLastM (new (New.unstream s)) = MBundle.last (lift s)   #-}
 
-  #-}
+
 
 -- Extracting subvectors (slicing)
 -- -------------------------------
@@ -489,9 +489,9 @@ unsafeDrop n v = unsafeSlice n (length v - n) v
   unsafeInit (new p) = new (New.unsafeInit p)
 
 "unsafeTail/new [Vector]" forall p.
-  unsafeTail (new p) = new (New.unsafeTail p)
+  unsafeTail (new p) = new (New.unsafeTail p)   #-}
 
-  #-}
+
 
 -- Initialisation
 -- --------------
@@ -1349,9 +1349,9 @@ unstablePartition_new f (New.New p) = runST (
 
 "unstablePartition" forall f p.
   unstablePartition_stream f (stream (new p))
-    = unstablePartition_new f p
+    = unstablePartition_new f p   #-}
 
-  #-}
+
 
 
 -- FIXME: make span and break fusible
@@ -1850,9 +1850,9 @@ thaw v = do
   unsafeThaw (new p) = New.runPrim p
 
 "thaw/new [Vector]" forall p.
-  thaw (new p) = New.runPrim p
+  thaw (new p) = New.runPrim p   #-}
 
-  #-}
+
 
 {-
 -- | /O(n)/ Yield a mutable vector containing copies of each vector in the
@@ -1937,9 +1937,9 @@ unstream s = new (New.unstream s)
 
 "uninplace [Vector]"
   forall (f :: forall m. Monad m => Stream m a -> Stream m a) g m.
-  stream (new (New.transform f g m)) = inplace f g (stream (new m))
+  stream (new (New.transform f g m)) = inplace f g (stream (new m))  #-}
 
- #-}
+
 
 -- | /O(1)/ Convert a vector to a 'Bundle', proceeding from right to left
 streamR :: Vector v a => v a -> Bundle u a
@@ -1979,9 +1979,9 @@ unstreamR s = new (New.unstreamR s)
 
 "uninplace right [Vector]"
   forall (f :: forall m. Monad m => Stream m a -> Stream m a) g m.
-  streamR (new (New.transformR f g m)) = inplace f g (streamR (new m))
+  streamR (new (New.transformR f g m)) = inplace f g (streamR (new m))  #-}
 
- #-}
+
 
 unstreamM :: (Monad m, Vector v a) => MBundle m u a -> m (v a)
 {-# INLINE_FUSED unstreamM #-}
@@ -2005,9 +2005,9 @@ unstreamPrimM_ST = unstreamPrimM
 {-# RULES
 
 "unstreamM[IO]" unstreamM = unstreamPrimM_IO
-"unstreamM[ST]" unstreamM = unstreamPrimM_ST
+"unstreamM[ST]" unstreamM = unstreamPrimM_ST  #-}
 
- #-}
+
 
 
 -- Recycling support

--- a/Data/Vector/Generic/New.hs
+++ b/Data/Vector/Generic/New.hs
@@ -84,9 +84,9 @@ transform f g (New p) = New (MVector.transform f =<< p)
 "transform/unstream [New]"
   forall (f :: forall m. Monad m => Stream m a -> Stream m a)
          g s.
-  transform f g (unstream s) = unstream (Bundle.inplace f g s)
+  transform f g (unstream s) = unstream (Bundle.inplace f g s)  #-}
 
- #-}
+
 
 
 unstreamR :: Vector v a => Bundle v a -> New v a
@@ -111,9 +111,9 @@ transformR f g (New p) = New (MVector.transformR f =<< p)
 "transformR/unstreamR [New]"
   forall (f :: forall m. Monad m => Stream m a -> Stream m a)
          g s.
-  transformR f g (unstreamR s) = unstreamR (Bundle.inplace f g s)
+  transformR f g (unstreamR s) = unstreamR (Bundle.inplace f g s)  #-}
 
- #-}
+
 
 slice :: Vector v a => Int -> Int -> New v a -> New v a
 {-# INLINE_FUSED slice #-}
@@ -171,7 +171,7 @@ unsafeTail m = apply MVector.unsafeTail m
   unsafeInit (unstream s) = unstream (Bundle.init s)
 
 "unsafeTail/unstream [New]" forall s.
-  unsafeTail (unstream s) = unstream (Bundle.tail s)
+  unsafeTail (unstream s) = unstream (Bundle.tail s)   #-}
 
-  #-}
+
 

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -1381,8 +1381,8 @@ unsafeFromForeignPtr fp i n = unsafeFromForeignPtr0 fp' n
 
 {-# RULES
 "unsafeFromForeignPtr fp 0 n -> unsafeFromForeignPtr0 fp n " forall fp n.
-  unsafeFromForeignPtr fp 0 n = unsafeFromForeignPtr0 fp n
-  #-}
+  unsafeFromForeignPtr fp 0 n = unsafeFromForeignPtr0 fp n   #-}
+
 
 -- | /O(1)/ Create a vector from a 'ForeignPtr' and a length.
 --

--- a/Data/Vector/Storable/Mutable.hs
+++ b/Data/Vector/Storable/Mutable.hs
@@ -447,8 +447,8 @@ unsafeFromForeignPtr fp i n = unsafeFromForeignPtr0 fp' n
 
 {-# RULES
 "unsafeFromForeignPtr fp 0 n -> unsafeFromForeignPtr0 fp n " forall fp n.
-  unsafeFromForeignPtr fp 0 n = unsafeFromForeignPtr0 fp n
-  #-}
+  unsafeFromForeignPtr fp 0 n = unsafeFromForeignPtr0 fp n   #-}
+
 
 -- | /O(1)/ Create a mutable vector from a 'ForeignPtr' and a length.
 --

--- a/internal/unbox-tuple-instances
+++ b/internal/unbox-tuple-instances
@@ -122,8 +122,8 @@ zip as bs = V_2 len (unsafeSlice 0 len as) (unsafeSlice 0 len bs)
   where len = length as `delayed_min` length bs
 {-# RULES "stream/zip [Vector.Unboxed]" forall as bs .
   G.stream (zip as bs) = Bundle.zipWith (,) (G.stream as)
-                                            (G.stream bs)
-  #-}
+                                            (G.stream bs)   #-}
+
 -- | /O(1)/ Unzip 2 vectors
 unzip :: (Unbox a, Unbox b) => Vector (a, b) -> (Vector a,
                                                  Vector b)
@@ -290,8 +290,8 @@ zip3 as bs cs = V_3 len (unsafeSlice 0 len as)
 {-# RULES "stream/zip3 [Vector.Unboxed]" forall as bs cs .
   G.stream (zip3 as bs cs) = Bundle.zipWith3 (, ,) (G.stream as)
                                                    (G.stream bs)
-                                                   (G.stream cs)
-  #-}
+                                                   (G.stream cs)   #-}
+
 -- | /O(1)/ Unzip 3 vectors
 unzip3 :: (Unbox a,
            Unbox b,
@@ -502,8 +502,8 @@ zip4 as bs cs ds = V_4 len (unsafeSlice 0 len as)
   G.stream (zip4 as bs cs ds) = Bundle.zipWith4 (, , ,) (G.stream as)
                                                         (G.stream bs)
                                                         (G.stream cs)
-                                                        (G.stream ds)
-  #-}
+                                                        (G.stream ds)   #-}
+
 -- | /O(1)/ Unzip 4 vectors
 unzip4 :: (Unbox a,
            Unbox b,
@@ -771,8 +771,8 @@ zip5 as bs cs ds es = V_5 len (unsafeSlice 0 len as)
                                                  (G.stream bs)
                                                  (G.stream cs)
                                                  (G.stream ds)
-                                                 (G.stream es)
-  #-}
+                                                 (G.stream es)   #-}
+
 -- | /O(1)/ Unzip 5 vectors
 unzip5 :: (Unbox a,
            Unbox b,
@@ -1080,8 +1080,8 @@ zip6 as bs cs ds es fs = V_6 len (unsafeSlice 0 len as)
                                                    (G.stream cs)
                                                    (G.stream ds)
                                                    (G.stream es)
-                                                   (G.stream fs)
-  #-}
+                                                   (G.stream fs)   #-}
+
 -- | /O(1)/ Unzip 6 vectors
 unzip6 :: (Unbox a,
            Unbox b,


### PR DESCRIPTION
May be related to [#22](https://github.com/haskell/vector/pull/22)

This problem exists on at least 0.10.9.1, 0.10.9.0, 0.10, 0.9

The ending `#-}` of a RULES block would cause an error if it was on a new line
by itself. In these cases I moved it up to the next non empty line.

Combining #ifdef in a rules block caused additional problems.
An error was caused if the RUlES block ended with

```
#endif #-}
```

In these cases I copied `#-}` into each branch of the #ifdef.

os: mac osx 10.9.2

The problem was present with the latest command line tools from Apple:
    Command line developer tools for OS X Mavericks 5.1.0.0

and an unknown version that I had before updating to the most recent.

$ gcc --version
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
Target: x86_64-apple-darwin13.1.0
Thread model: posix

$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.6.3

$ cabal --version
cabal-install version 1.16.0.2
using version 1.16.0 of the Cabal library

or with

$cabal --version
cabal-install version 1.18.0.3
using version 1.18.1.2 of the Cabal library 
