### PR TITLE
Make the use of MultiParamTypeClasses in Data.Vector.Generic.New explicit

### DIFF
--- a/Data/Vector/Generic/New.hs
+++ b/Data/Vector/Generic/New.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, Rank2Types, FlexibleContexts #-}
+{-# LANGUAGE CPP, Rank2Types, FlexibleContexts, MultiParamTypeClasses #-}
 
 -- |
 -- Module      : Data.Vector.Generic.New


### PR DESCRIPTION
I noticed that Data.Vector.Generic.New uses MultiParamTypeClasses but does not say so when trying to parse it with haskell-src-exts. I do not know why GHC does not choke on this though.
