### PR TITLE
Export Primitive Vector's constructor

### DIFF
--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -17,7 +17,7 @@
 
 module Data.Vector.Primitive (
   -- * Primitive vectors
-  Vector, MVector(..), Prim,
+  Vector(..), MVector(..), Prim,
 
   -- * Accessors
 
@@ -173,7 +173,7 @@ import qualified GHC.Exts as Exts
 -- | Unboxed vectors of primitive types
 data Vector a = Vector {-# UNPACK #-} !Int
                        {-# UNPACK #-} !Int
-                       {-# UNPACK #-} !ByteArray
+                       {-# UNPACK #-} !ByteArray -- ^ offset, length, underlying byte array
   deriving ( Typeable )
 
 instance NFData (Vector a)

--- a/Data/Vector/Primitive/Mutable.hs
+++ b/Data/Vector/Primitive/Mutable.hs
@@ -69,7 +69,7 @@ import Data.Typeable ( Typeable )
 -- | Mutable vectors of primitive types.
 data MVector s a = MVector {-# UNPACK #-} !Int
                            {-# UNPACK #-} !Int
-                           {-# UNPACK #-} !(MutableByteArray s)
+                           {-# UNPACK #-} !(MutableByteArray s) -- ^ offset, length, underlying mutable byte array
         deriving ( Typeable )
 
 type IOVector = MVector RealWorld


### PR DESCRIPTION
This is useful to access the underlying ByteArray, eg. to pass it to FFI functions.
