### PR TITLE
Bump upper bounds in vector-benchmarks.cabal

### DIFF
--- a/benchmarks/vector-benchmarks.cabal
+++ b/benchmarks/vector-benchmarks.cabal
@@ -12,13 +12,13 @@ Executable algorithms
   Main-Is: Main.hs
 
   Build-Depends: base >= 2 && < 5, array,
-                 criterion >= 0.5 && < 0.7,
-                 mwc-random >= 0.5 && < 0.13,
-                 vector == 0.10.9
+                 criterion >= 0.5 && < 1.1,
+                 mwc-random >= 0.5 && < 0.14,
+                 vector
 
   if impl(ghc<6.13)
     Ghc-Options: -finline-if-enough-args -fno-method-sharing
-  
+
   Ghc-Options: -O2
 
   Other-Modules:
@@ -34,4 +34,3 @@ Executable algorithms
         TestData.ParenTree
         TestData.Graph
         TestData.Random
-


### PR DESCRIPTION
Also:

+ remove fixed version constraint for vector

+ normalized whitespace