### PR TITLE
Use new `cabal-install-head` in Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
  - GHCVER=7.4.2 CABALVER=1.16
  - GHCVER=7.6.3 CABALVER=1.16
  - GHCVER=7.8.2 CABALVER=1.18
- - GHCVER=head  CABALVER=1.20
+ - GHCVER=head  CABALVER=head
 
 matrix:
   allow_failures:
-   - env: GHCVER=head  CABALVER=1.20
+   - env: GHCVER=head  CABALVER=head
 
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc


### PR DESCRIPTION
(note, this will fail until a new version of `test-framework` is uploaded to hackage)