### PR TITLE
Remove map from Prelude hiding list for Mutable.hs

### DIFF
--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -54,7 +54,7 @@ import qualified Data.Vector.Generic.Mutable as G
 import           Data.Primitive.Array
 import           Control.Monad.Primitive
 
-import Prelude hiding ( length, null, replicate, reverse, map, read,
+import Prelude hiding ( length, null, replicate, reverse, read,
                         take, drop, splitAt, init, tail )
 
 import Data.Typeable ( Typeable )


### PR DESCRIPTION
The Mutable module neither defines nor uses anything named map,
and mutable vectors can't exactly be mapped anyway, so there's no
obvious reason to hide Prelude.map.