### PR TITLE
added monadzip instance for Data.Vector

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -308,6 +308,8 @@ instance MonadPlus Vector where
   {-# INLINE mplus #-}
   mplus = (++)
 
+-- MonadZip was added in base-4.4.0
+#if MIN_VERSION_base(4,4,0)
 instance MonadZip Vector where
   {-# INLINE mzip #-}
   mzip = zip
@@ -317,6 +319,7 @@ instance MonadZip Vector where
 
   {-# INLINE munzip #-}
   munzip = unzip
+#endif
 
 instance Applicative.Applicative Vector where
   {-# INLINE pure #-}

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -166,6 +166,7 @@ import Control.DeepSeq ( NFData, rnf )
 import Control.Monad ( MonadPlus(..), liftM, ap )
 import Control.Monad.ST ( ST )
 import Control.Monad.Primitive
+import Control.Monad.Zip
 
 import Prelude hiding ( length, null,
                         replicate, (++), concat,
@@ -306,6 +307,16 @@ instance MonadPlus Vector where
 
   {-# INLINE mplus #-}
   mplus = (++)
+
+instance MonadZip Vector where
+  {-# INLINE mzip #-}
+  mzip = zip
+
+  {-# INLINE mzipWith #-}
+  mzipWith = zipWith
+
+  {-# INLINE munzip #-}
+  munzip = unzip
 
 instance Applicative.Applicative Vector where
   {-# INLINE pure #-}


### PR DESCRIPTION
Adding `MonadZip` instances for `Vector` types allows to use `-XMonadComprehensions` and `-XParallelComprehensions` together:

    >>> :set -XMonadComprehensions
    >>> :set -XParallelListComp
    >>> import qualified Data.Vector as V
    >>> let as = V.fromList [0..10]
    >>> let bs = V.fromList [0..10]
    >>> [ a + b | a <- as | b <- bs ]
    fromList [0,2,4,6,8,10,12,14,16,18,20]

I would like to add the instance for all other types (especially the unboxed type) but I see that there are no instances of `Monad` nor `MonadPlus` there which is probably for a reason?