### PR TITLE
raise bounds for ghc-prim and primitive

### DIFF
--- a/vector.cabal
+++ b/vector.cabal
@@ -138,8 +138,8 @@ Library
         vector.h
 
   Build-Depends: base >= 4.3 && < 4.9
-               , primitive >= 0.5.0.1 && < 0.6
-               , ghc-prim >= 0.2 && < 0.4
+               , primitive >= 0.5.0.1 && < 0.7
+               , ghc-prim >= 0.2 && < 0.5
                , deepseq >= 1.1 && < 1.5
 
   Ghc-Options: -O2 -Wall -fno-warn-orphans


### PR DESCRIPTION
The ghc-prim that comes with ghc-7.10.1 is 0.4.0.0. With that, in turn, only primitive-0.6 will do. Everything seems to build fine with the mechanical change, but perhaps Travis will know better.