### PR TITLE
add  Pure :: (* -> * -> *) -> (* -> *) type family alongside the stan…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 env:
- - GHCVER=7.0.1 CABALVER=1.16
- - GHCVER=7.0.4 CABALVER=1.16
- # we have to use CABALVER=1.16 for GHC<7.6 as well, as there's
- # no package for earlier cabal versions in the PPA
- - GHCVER=7.2.2 CABALVER=1.16
  - GHCVER=7.4.2 CABALVER=1.16
  - GHCVER=7.6.3 CABALVER=1.16
  - GHCVER=7.8.2 CABALVER=1.18

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -234,6 +234,8 @@ instance Data a => Data (Vector a) where
 
 type instance G.Mutable Vector = MVector
 
+type instance G.Pure MVector = Vector
+
 instance G.Vector Vector a where
   {-# INLINE basicUnsafeFreeze #-}
   basicUnsafeFreeze (MVector i n marr)

--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -107,7 +107,7 @@ import Data.Word ( Word8, Word16, Word32, Word, Word64 )
 #include "vector.h"
 #include "MachDeps.h"
 
-data Chunk v a = Chunk Int (forall m. (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m ())
+data Chunk v a = Chunk Int (forall m mv. (PrimMonad m, Vector v a, MUTABLE_PURE(mv,v)) => mv (PrimState m) a -> m ())
 
 -- | Monadic streams
 data Bundle m v a = Bundle { sElems  :: Stream m a

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -705,7 +705,7 @@ generateM n f = unstreamM (MBundle.generateM n f)
 -- @
 -- create (do { v \<- 'M.new' 2; 'M.write' v 0 \'a\'; 'M.write' v 1 \'b\'; return v }) = \<'a','b'\>
 -- @
-create :: (Vector v a, MUTABLE_PURE(mv,v)) => (forall s. ST s (mv s a)) -> v a
+create :: (Vector v a, mv ~ Mutable v ) => (forall s. ST s (mv s a)) -> v a
 {-# INLINE create #-}
 create p = new (New.create p)
 
@@ -941,13 +941,13 @@ unsafeBackpermute v is = seq v
 -- @
 -- modify (\\v -> 'M.write' v 0 \'x\') ('replicate' 3 \'a\') = \<\'x\',\'a\',\'a\'\>
 -- @
-modify :: (Vector v a,MUTABLE_PURE(mv,v)) => (forall s. mv s a -> ST s ()) -> v a -> v a
+modify :: (Vector v a, mv ~ Mutable v ) => (forall s. mv s a -> ST s ()) -> v a -> v a
 {-# INLINE modify #-}
 modify p = new . New.modify p . clone
 
 -- We have to make sure that this is strict in the stream but we can't seq on
 -- it while fusion is happening. Hence this ugliness.
-modifyWithBundle :: (Vector v a, MUTABLE_PURE(mv,v)  )
+modifyWithBundle :: (Vector v a, mv ~ Mutable v )
                  => (forall s. mv s a -> Bundle u b -> ST s ())
                  -> v a -> Bundle u b -> v a
 {-# INLINE modifyWithBundle #-}
@@ -1834,7 +1834,7 @@ unsafeThaw :: (PrimMonad m, Vector v a,MUTABLE_PURE(mv,v)) => v a -> m (mv (Prim
 unsafeThaw = basicUnsafeThaw
 
 -- | /O(n)/ Yield a mutable copy of the immutable vector.
-thaw :: (PrimMonad m, Vector v a, MUTABLE_PURE(mv,v)) => v a -> m (Mutable v (PrimState m) a)
+thaw :: (PrimMonad m, Vector v a, MUTABLE_PURE(mv,v)) => v a -> m (mv (PrimState m) a)
 {-# INLINE_FUSED thaw #-}
 thaw v = do
            mv <- M.unsafeNew (length v)

--- a/Data/Vector/Generic/Base.hs
+++ b/Data/Vector/Generic/Base.hs
@@ -35,7 +35,8 @@ type family Pure (mv :: * -> * -> *) :: * -> *
 -- | Class of immutable vectors. Every immutable vector is associated with its
 -- mutable version through the 'Mutable' type family. Methods of this class
 -- should not be used directly. Instead, "Data.Vector.Generic" and other
--- Data.Vector modules provide safe and fusible wrappers.
+-- Data.Vector modules provide safe and fusible wrappers. Every 'Vector' instance
+-- must provide instances of both 'Mutable' and 'Pure' that jointly obey @v ~ 'Pure' ('Mutable' v)@.
 --
 -- Minimum complete implementation:
 --

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -196,6 +196,8 @@ instance (Data a, Prim a) => Data (Vector a) where
 
 type instance G.Mutable Vector = MVector
 
+type instance G.Pure MVector = Vector
+
 instance Prim a => G.Vector Vector a where
   {-# INLINE basicUnsafeFreeze #-}
   basicUnsafeFreeze (MVector i n marr)

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -203,6 +203,8 @@ instance (Data a, Storable a) => Data (Vector a) where
 
 type instance G.Mutable Vector = MVector
 
+type instance G.Pure MVector = Vector
+
 instance Storable a => G.Vector Vector a where
   {-# INLINE basicUnsafeFreeze #-}
   basicUnsafeFreeze (MVector n fp) = return $ Vector n fp

--- a/Data/Vector/Unboxed/Base.hs
+++ b/Data/Vector/Unboxed/Base.hs
@@ -60,6 +60,8 @@ type STVector s = MVector s
 
 type instance G.Mutable Vector = MVector
 
+type instance G.Pure MVector = Vector
+
 class (G.Vector Vector a, M.MVector MVector a) => Unbox a
 
 instance NFData (Vector a) where rnf !_ = ()

--- a/include/vector.h
+++ b/include/vector.h
@@ -19,3 +19,4 @@ import qualified Data.Vector.Internal.Check as Ck
 #define PHASE_STREAM  Please use "PHASE_FUSED" instead
 #define INLINE_STREAM Please use "INLINE_FUSED" instead
 
+#define MUTABLE_PURE(mv,v) v ~ (Pure mv), mv ~ (Mutable v)

--- a/vector.cabal
+++ b/vector.cabal
@@ -137,8 +137,8 @@ Library
   Install-Includes:
         vector.h
 
-  Build-Depends: base >= 4.3 && < 4.9
-               , primitive >= 0.5.0.1 && < 0.6
+  Build-Depends: base >= 4.3 && < 4.10
+               , primitive >= 0.5.0.1 && < 0.7
                , ghc-prim >= 0.2 && < 0.4
                , deepseq >= 1.1 && < 1.5
 

--- a/vector.cabal
+++ b/vector.cabal
@@ -139,7 +139,7 @@ Library
 
   Build-Depends: base >= 4.3 && < 4.10
                , primitive >= 0.5.0.1 && < 0.7
-               , ghc-prim >= 0.2 && < 0.4
+               , ghc-prim >= 0.2 && < 0.5
                , deepseq >= 1.1 && < 1.5
 
   Ghc-Options: -O2 -Wall -fno-warn-orphans


### PR DESCRIPTION
…dard Mutable type family.

This is to allow better bidirectional inference in code that mixes Mutable and Pure Vectors.

also the first of a few different changes / additions we agreed on doing for vector 0.11

theres a few few style questions that should probably be discussed before this gets merged in, such as my choice in using a CPP approach as shorthand in modules that already were doing CPP hacks.

@dolio  @tibbe  @erikd  et al would love some feedback please :) 
