### PR TITLE
Use GHC.Types.SPEC instead of GHC.Exts.SpecConstrAnnotation

### DIFF
--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -92,16 +92,20 @@ import Prelude hiding ( length, null,
 import Data.Int  ( Int8, Int16, Int32, Int64 )
 import Data.Word ( Word8, Word16, Word32, Word, Word64 )
 
-#if __GLASGOW_HASKELL__ >= 700
+#if __GLASGOW_HASKELL__ >= 708
+import GHC.Types ( SPEC(..) )
+#elif __GLASGOW_HASKELL__ >= 700
 import GHC.Exts ( SpecConstrAnnotation(..) )
 #endif
 
 #include "vector.h"
 #include "MachDeps.h"
 
+#if __GLASGOW_HASKELL__ < 708
 data SPEC = SPEC | SPEC2
 #if __GLASGOW_HASKELL__ >= 700
 {-# ANN type SPEC ForceSpecConstr #-}
+#endif
 #endif
 
 emptyStream :: String


### PR DESCRIPTION
This means GHCi isn't needed anymore to build vector. This has a couple
of advantages:
  * `vector` can now be built with a stage1 compiler (e.g. iOS
    cross-compiler) [1]
  * `vector` and its dependencies can now be build on a noexec mounted
    disk, preventing bug reports such as [2]

GHC.Types.SPEC was added to ghc-prim 0.3.1.0 / GHC 7.8.1 [3].

[1] http://git.haskell.org/ghc.git/commitdiff/cee3adbcc180bdf1be8b24aeaafa2ca4a737cbbf
[2] https://ghc.haskell.org/trac/ghc/ticket/10131
[3] https://downloads.haskell.org/~ghc/7.8.1/docs/html/users_guide/release-7-8-1.html