### PR TITLE
Add 'createT', allowing monadic initialisation of any Traversable con…

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -56,7 +56,7 @@ module Data.Vector (
   empty, singleton, replicate, generate, iterateN,
 
   -- ** Monadic initialisation
-  replicateM, generateM, create,
+  replicateM, generateM, create, createT,
 
   -- ** Unfolding
   unfoldr, unfoldrN,
@@ -686,6 +686,11 @@ create :: (forall s. ST s (MVector s a)) -> Vector a
 {-# INLINE create #-}
 -- NOTE: eta-expanded due to http://hackage.haskell.org/trac/ghc/ticket/4120
 create p = G.create p
+
+-- | Execute the monadic action and freeze the resulting vectors.
+createT :: Traversable f => (forall s. ST s (f (MVector s a))) -> f (Vector a)
+{-# INLINE createT #-}
+createT p = G.createT p
 
 
 
@@ -1572,4 +1577,3 @@ unsafeCopy = G.unsafeCopy
 copy :: PrimMonad m => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
 copy = G.copy
-

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -39,7 +39,7 @@ module Data.Vector.Generic (
   empty, singleton, replicate, generate, iterateN,
 
   -- ** Monadic initialisation
-  replicateM, generateM, create,
+  replicateM, generateM, create, createT,
 
   -- ** Unfolding
   unfoldr, unfoldrN,
@@ -708,6 +708,11 @@ generateM n f = unstreamM (MBundle.generateM n f)
 create :: Vector v a => (forall s. ST s (Mutable v s a)) -> v a
 {-# INLINE create #-}
 create p = new (New.create p)
+
+-- | Execute the monadic action and freeze the resulting vectors.
+createT :: (Traversable f, Vector v a) => (forall s. ST s (f (Mutable v s a))) -> f (v a)
+{-# INLINE createT #-}
+createT p = runST (p >>= traverse unsafeFreeze)
 
 -- Restricting memory usage
 -- ------------------------
@@ -2084,4 +2089,3 @@ dataCast :: (Vector v a, Data a, Typeable1 v, Typeable1 t)
          => (forall d. Data  d => c (t d)) -> Maybe  (c (v a))
 {-# INLINE dataCast #-}
 dataCast f = gcast1 f
-

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -42,7 +42,7 @@ module Data.Vector.Primitive (
   empty, singleton, replicate, generate, iterateN,
 
   -- ** Monadic initialisation
-  replicateM, generateM, create,
+  replicateM, generateM, create, createT,
 
   -- ** Unfolding
   unfoldr, unfoldrN,
@@ -605,6 +605,11 @@ create :: Prim a => (forall s. ST s (MVector s a)) -> Vector a
 {-# INLINE create #-}
 -- NOTE: eta-expanded due to http://hackage.haskell.org/trac/ghc/ticket/4120
 create p = G.create p
+
+-- | Execute the monadic action and freeze the resulting vectors.
+createT :: (Traversable f, Prim a) => (forall s. ST s (f (MVector s a))) -> f (Vector a)
+{-# INLINE createT #-}
+createT p = G.createT p
 
 -- Restricting memory usage
 -- ------------------------
@@ -1336,5 +1341,3 @@ unsafeCopy = G.unsafeCopy
 copy :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
 copy = G.copy
-
-

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -39,7 +39,7 @@ module Data.Vector.Storable (
   empty, singleton, replicate, generate, iterateN,
 
   -- ** Monadic initialisation
-  replicateM, generateM, create,
+  replicateM, generateM, create, createT,
 
   -- ** Unfolding
   unfoldr, unfoldrN,
@@ -615,6 +615,11 @@ create :: Storable a => (forall s. ST s (MVector s a)) -> Vector a
 {-# INLINE create #-}
 -- NOTE: eta-expanded due to http://hackage.haskell.org/trac/ghc/ticket/4120
 create p = G.create p
+
+-- | Execute the monadic action and freeze the resulting vectors.
+createT :: (Traversable f, Storable a) => (forall s. ST s (f (MVector s a))) -> f (Vector a)
+{-# INLINE createT #-}
+createT p = G.createT p
 
 -- Restricting memory usage
 -- ------------------------
@@ -1432,5 +1437,3 @@ unsafeToForeignPtr0 (Vector n fp) = (fp, n)
 unsafeWith :: Storable a => Vector a -> (Ptr a -> IO b) -> IO b
 {-# INLINE unsafeWith #-}
 unsafeWith (Vector _ fp) = withForeignPtr fp
-
-

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -62,7 +62,7 @@ module Data.Vector.Unboxed (
   empty, singleton, replicate, generate, iterateN,
 
   -- ** Monadic initialisation
-  replicateM, generateM, create,
+  replicateM, generateM, create, createT,
 
   -- ** Unfolding
   unfoldr, unfoldrN,
@@ -584,6 +584,11 @@ create :: Unbox a => (forall s. ST s (MVector s a)) -> Vector a
 {-# INLINE create #-}
 -- NOTE: eta-expanded due to http://hackage.haskell.org/trac/ghc/ticket/4120
 create p = G.create p
+
+-- | Execute the monadic action and freeze the resulting vectors.
+createT :: (Traversable f, Unbox a) => (forall s. ST s (f (MVector s a))) -> f (Vector a)
+{-# INLINE createT #-}
+createT p = G.createT p
 
 -- Restricting memory usage
 -- ------------------------
@@ -1431,4 +1436,3 @@ copy = G.copy
 
 #define DEFINE_IMMUTABLE
 #include "unbox-tuple-instances"
-

--- a/tests/Tests/Vector.hs
+++ b/tests/Tests/Vector.hs
@@ -105,6 +105,7 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_generate, 'prop_iterateN,
 
         -- Monadic initialisation (FIXME)
+        'prop_createT,
         {- 'prop_replicateM, 'prop_generateM, 'prop_create, -}
 
         -- Unfolding (FIXME)
@@ -216,6 +217,9 @@ testPolymorphicFunctions _ = $(testProperties [
               = (\n _ -> n < 1000) ===> V.generate `eq` Util.generate
     prop_iterateN  :: P (Int -> (a -> a) -> a -> v a)
               = (\n _ _ -> n < 1000) ===> V.iterateN `eq` (\n f -> take n . iterate f)
+
+    prop_createT :: P ((a, v a) -> (a, v a))
+    prop_createT = (\v -> V.createT (traverse V.thaw v)) `eq` id
 
     prop_head      :: P (v a -> a) = not . V.null ===> V.head `eq` head
     prop_last      :: P (v a -> a) = not . V.null ===> V.last `eq` last
@@ -649,4 +653,3 @@ tests = [
          testGroup "Data.Vector.Unboxed.Vector (Int,Bool,Int)" (testTupleUnboxedVector (undefined :: Data.Vector.Unboxed.Vector (Int,Bool,Int)))
 
     ]
-


### PR DESCRIPTION
…tainer of vectors.

The current definition of `create`

    create :: Vector v a => (forall s. ST s (Mutable v s a)) -> v a 

is a little bit restrictive, as it does not allow us to return any other additional information calculated during the construction of the vector, such as vector indices. We can instead use a combinator like `create' :: Vector v a => (forall s. ST s (b, Mutable v s a)) -> (b, v a)` to return extra data alongside the vector, but I attempted to generalise this even further.

My formula right now is:

    createT :: (Traversable f, Vector v a) => (forall s. ST s (f (Mutable v s a))) -> f (v a)
    createT p = runST (p >>= traverse unsafeFreeze)

I believe this should be safe, as `runST (p >>= traverse freeze)` is safe and parametricity guarantees that the traversal cannot run any other ST actions (that would, say, write to the mutable vector) after the freeze.

The Traversable context allows for things such as returning auxiliary data (`instance Traversable ((,) b)`), returning multiple vectors (Traversable instances for lists, vectors, etc), even Trees of vectors, and a few other less useful seeming instances like Maybe.

I'm not sure of a few things: is it possible to integrate this with the stream fusion framework in any way (eg. with New)? Also, I added a very limited test, `prop_createT`, but I'm not clear on how meaningful that one actually is.

It would be great to have a pair of eyes run over this, or thought as to whether or not this would be useful and/or worth including in the library :)