### PR TITLE
Make storable vectors respect alignment of underlying elements

### DIFF
--- a/Data/Vector/Fusion/Bundle.hs
+++ b/Data/Vector/Fusion/Bundle.hs
@@ -111,7 +111,7 @@ type Bundle = M.Bundle Id
 type MBundle = M.Bundle
 
 inplace :: (forall m. Monad m => S.Stream m a -> S.Stream m b)
-	-> (Size -> Size) -> Bundle v a -> Bundle v b
+        -> (Size -> Size) -> Bundle v a -> Bundle v b
 {-# INLINE_FUSED inplace #-}
 inplace f g b = b `seq` M.fromStream (f (M.elements b)) (g (M.size b))
 


### PR DESCRIPTION
Fix for issue #75.

The only nontrivial bit is the use of `touch` in ForeignPtr finalizers for GHCs up to 7.6. It's needed because after transforming mutable byte array into pointer there're no references left from that pointer to original byte array because pointer is just an address.