### PR TITLE
add Generics instance to Data.Vector

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -197,6 +197,7 @@ import Data.Monoid   ( Monoid(..) )
 
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as Exts (IsList(..))
+import GHC.Generics
 #endif
 
 
@@ -351,6 +352,30 @@ instance Traversable.Traversable Vector where
 
   {-# INLINE sequence #-}
   sequence = sequence
+
+type Rep1Vector = D1 D1Vector (C1 C1Vector (S1 NoSelector (Rec1 [])))
+
+instance Generic1 Vector where
+  type Rep1 Vector = Rep1Vector
+  from1 v = M1 (M1 (M1 (Rec1 $ toList v)))
+  to1 (M1 (M1 (M1 (Rec1 l)))) = fromList l
+
+data D1Vector
+data C1Vector
+
+instance Datatype D1Vector where
+  datatypeName _ = "Vector"
+  moduleName   _ = "Data.Vector"
+
+instance Constructor C1Vector  where
+  conName _ = "Vector.fromList"
+
+type Rep0Vector a = D1 D1Vector (C1 C1Vector (S1 NoSelector (Rec0 [a])))
+
+instance Generic (Vector a) where
+  type Rep (Vector a) = Rep0Vector a
+  from v = M1 (M1 (M1 (K1 $ toList v)))
+  to (M1 (M1 (M1 (K1 l)))) = fromList l
 
 -- Length information
 -- ------------------


### PR DESCRIPTION
we want Generics for everything (otherwise we can't derive Generics for any data types which contain these without creating orphan instances)

the end-goal is to have all of these: https://gist.github.com/kuk0/92fff1c91c526ffb0a9e
and be able to derive instances for e.g. TextShow or Text.PrettyPrint.Generic.Pretty
