### PR TITLE
Add Semigroup instances matching all Monoids.

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -183,9 +183,10 @@ import Prelude hiding ( length, null,
                         enumFromTo, enumFromThenTo,
                         mapM, mapM_, sequence, sequence_ )
 
-import Data.Typeable ( Typeable )
-import Data.Data     ( Data(..) )
-import Text.Read     ( Read(..), readListPrecDefault )
+import Data.Typeable  ( Typeable )
+import Data.Data      ( Data(..) )
+import Text.Read      ( Read(..), readListPrecDefault )
+import Data.Semigroup ( Semigroup(..) )
 
 import qualified Control.Applicative as Applicative
 import qualified Data.Foldable as Foldable
@@ -283,6 +284,13 @@ instance Ord a => Ord (Vector a) where
 
   {-# INLINE (>=) #-}
   xs >= ys = Bundle.cmp (G.stream xs) (G.stream ys) /= LT
+
+instance Semigroup (Vector a) where
+  {-# INLINE (<>) #-}
+  (<>) = (++)
+
+  {-# INLINE sconcat #-}
+  sconcat = G.concatNE
 
 instance Monoid (Vector a) where
   {-# INLINE mempty #-}
@@ -1575,4 +1583,3 @@ unsafeCopy = G.unsafeCopy
 copy :: PrimMonad m => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
 copy = G.copy
-

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -49,7 +49,7 @@ module Data.Vector.Generic (
   enumFromN, enumFromStepN, enumFromTo, enumFromThenTo,
 
   -- ** Concatenation
-  cons, snoc, (++), concat,
+  cons, snoc, (++), concat, concatNE,
 
   -- ** Restricting memory usage
   force,
@@ -194,6 +194,7 @@ import Prelude hiding ( length, null,
                         showsPrec )
 
 import qualified Text.Read as Read
+import qualified Data.List.NonEmpty as NonEmpty
 
 #if __GLASGOW_HASKELL__ >= 707
 import Data.Typeable ( Typeable, gcast1 )
@@ -684,6 +685,10 @@ concat vs = unstream (Bundle.flatten mk step (Exact n) (Bundle.fromList vs))
            in
            k `seq` (v,0,k)
 -}
+
+-- | /O(n)/ Concatenate all vectors in the non-empty list
+concatNE :: Vector v a => NonEmpty.NonEmpty (v a) -> v a
+concatNE = concat . NonEmpty.toList
 
 -- Monadic initialisation
 -- ----------------------
@@ -2084,4 +2089,3 @@ dataCast :: (Vector v a, Data a, Typeable1 v, Typeable1 t)
          => (forall d. Data  d => c (t d)) -> Maybe  (c (v a))
 {-# INLINE dataCast #-}
 dataCast f = gcast1 f
-

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -160,9 +160,10 @@ import Prelude hiding ( length, null,
                         enumFromTo, enumFromThenTo,
                         mapM, mapM_ )
 
-import Data.Typeable ( Typeable )
-import Data.Data     ( Data(..) )
-import Text.Read     ( Read(..), readListPrecDefault )
+import Data.Typeable  ( Typeable )
+import Data.Data      ( Data(..) )
+import Text.Read      ( Read(..), readListPrecDefault )
+import Data.Semigroup ( Semigroup(..) )
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid   ( Monoid(..) )
@@ -249,6 +250,13 @@ instance (Prim a, Ord a) => Ord (Vector a) where
 
   {-# INLINE (>=) #-}
   xs >= ys = Bundle.cmp (G.stream xs) (G.stream ys) /= LT
+
+instance Prim a => Semigroup (Vector a) where
+  {-# INLINE (<>) #-}
+  (<>) = (++)
+
+  {-# INLINE sconcat #-}
+  sconcat = G.concatNE
 
 instance Prim a => Monoid (Vector a) where
   {-# INLINE mempty #-}
@@ -1338,5 +1346,3 @@ unsafeCopy = G.unsafeCopy
 copy :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
 copy = G.copy
-
-

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -165,9 +165,10 @@ import Prelude hiding ( length, null,
                         enumFromTo, enumFromThenTo,
                         mapM, mapM_ )
 
-import Data.Typeable ( Typeable )
-import Data.Data     ( Data(..) )
-import Text.Read     ( Read(..), readListPrecDefault )
+import Data.Typeable  ( Typeable )
+import Data.Data      ( Data(..) )
+import Text.Read      ( Read(..), readListPrecDefault )
+import Data.Semigroup ( Semigroup(..) )
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid   ( Monoid(..) )
@@ -258,6 +259,13 @@ instance (Storable a, Ord a) => Ord (Vector a) where
 
   {-# INLINE (>=) #-}
   xs >= ys = Bundle.cmp (G.stream xs) (G.stream ys) /= LT
+
+instance Storable a => Semigroup (Vector a) where
+  {-# INLINE (<>) #-}
+  (<>) = (++)
+
+  {-# INLINE sconcat #-}
+  sconcat = G.concatNE
 
 instance Storable a => Monoid (Vector a) where
   {-# INLINE mempty #-}
@@ -1434,5 +1442,3 @@ unsafeToForeignPtr0 (Vector n fp) = (fp, n)
 unsafeWith :: Storable a => Vector a -> (Ptr a -> IO b) -> IO b
 {-# INLINE unsafeWith #-}
 unsafeWith (Vector _ fp) = withForeignPtr fp
-
-

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -184,7 +184,8 @@ import Prelude hiding ( length, null,
                         enumFromTo, enumFromThenTo,
                         mapM, mapM_ )
 
-import Text.Read     ( Read(..), readListPrecDefault )
+import Text.Read      ( Read(..), readListPrecDefault )
+import Data.Semigroup ( Semigroup(..) )
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid   ( Monoid(..) )
@@ -221,6 +222,13 @@ instance (Unbox a, Ord a) => Ord (Vector a) where
 
   {-# INLINE (>=) #-}
   xs >= ys = Bundle.cmp (G.stream xs) (G.stream ys) /= LT
+
+instance Unbox a => Semigroup (Vector a) where
+  {-# INLINE (<>) #-}
+  (<>) = (++)
+
+  {-# INLINE sconcat #-}
+  sconcat = G.concatNE
 
 instance Unbox a => Monoid (Vector a) where
   {-# INLINE mempty #-}
@@ -1433,4 +1441,3 @@ copy = G.copy
 
 #define DEFINE_IMMUTABLE
 #include "unbox-tuple-instances"
-

--- a/vector.cabal
+++ b/vector.cabal
@@ -142,6 +142,8 @@ Library
                , primitive >= 0.5.0.1 && < 0.7
                , ghc-prim >= 0.2 && < 0.6
                , deepseq >= 1.1 && < 1.5
+  if !impl(ghc > 8.0)
+    Build-Depends: semigroups >= 0.18 && < 0.19
 
   Ghc-Options: -O2 -Wall -fno-warn-orphans
 


### PR DESCRIPTION
This uses `Data.Semigroup`/`Data.List.NonEmpty` from base-4.9.0.0 for GHC 8 and semigroups-0.18
for older GHCs.

I chose the name `concatNE` in `Data.Vector.Generic` for lack of better naming ideas. I also don't export `concatNE` from the modules defining the Semigroup instances, that doesn't conform to other functions such as `(++)` which are re-exported with more specific type signatures. Should I change any of this?
