### PR TITLE
Correct spelling in comments

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -920,7 +920,7 @@ imapM_ :: Monad m => (Int -> a -> m b) -> Vector a -> m ()
 imapM_ = G.imapM_
 
 -- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
--- vector of results. Equvalent to @flip 'mapM'@.
+-- vector of results. Equivalent to @flip 'mapM'@.
 forM :: Monad m => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1038,7 +1038,7 @@ imapM_ :: (Monad m, Vector v a) => (Int -> a -> m b) -> v a -> m ()
 imapM_ f = Bundle.mapM_ (uncurry f) . Bundle.indexed . stream
 
 -- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
--- vector of results. Equvalent to @flip 'mapM'@.
+-- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Vector v a, Vector v b) => v a -> (a -> m b) -> m (v b)
 {-# INLINE forM #-}
 forM as f = mapM f as

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -775,7 +775,7 @@ mapM_ :: (Monad m, Prim a) => (a -> m b) -> Vector a -> m ()
 mapM_ = G.mapM_
 
 -- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
--- vector of results. Equvalent to @flip 'mapM'@.
+-- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Prim a, Prim b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -785,7 +785,7 @@ mapM_ :: (Monad m, Storable a) => (a -> m b) -> Vector a -> m ()
 mapM_ = G.mapM_
 
 -- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
--- vector of results. Equvalent to @flip 'mapM'@.
+-- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Storable a, Storable b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -822,7 +822,7 @@ imapM_ :: (Monad m, Unbox a) => (Int -> a -> m b) -> Vector a -> m ()
 imapM_ = G.imapM_
 
 -- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
--- vector of results. Equvalent to @flip 'mapM'@.
+-- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Unbox a, Unbox b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM


### PR DESCRIPTION
Corrects "Equvalent" to "Equivalent" in a number of places.

