### PR TITLE
added MonadZip Vector instance and base version guard

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -168,6 +168,7 @@ import Control.DeepSeq ( NFData, rnf )
 import Control.Monad ( MonadPlus(..), liftM, ap )
 import Control.Monad.ST ( ST )
 import Control.Monad.Primitive
+import Control.Monad.Zip
 
 import Prelude hiding ( length, null,
                         replicate, (++), concat,
@@ -311,6 +312,20 @@ instance MonadPlus Vector where
 
   {-# INLINE mplus #-}
   mplus = (++)
+
+-- MonadZip was added in base-4.4.0
+#if MIN_VERSION_base(4,4,0)
+instance MonadZip Vector where
+  {-# INLINE mzip #-}
+  mzip = zip
+
+  {-# INLINE mzipWith #-}
+  mzipWith = zipWith
+
+  {-# INLINE munzip #-}
+  munzip = unzip
+#endif
+
 
 instance Applicative.Applicative Vector where
   {-# INLINE pure #-}

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -168,7 +168,11 @@ import Control.DeepSeq ( NFData, rnf )
 import Control.Monad ( MonadPlus(..), liftM, ap )
 import Control.Monad.ST ( ST )
 import Control.Monad.Primitive
+
+
+#if MIN_VERSION_base(4,4,0)
 import Control.Monad.Zip
+#endif
 
 import Prelude hiding ( length, null,
                         replicate, (++), concat,

--- a/tests/Tests/Vector.hs
+++ b/tests/Tests/Vector.hs
@@ -424,12 +424,17 @@ testPolymorphicFunctions _ = $(testProperties [
         constructrN xs n f = constructrN (f xs : xs) (n-1) f
 
 testTuplyFunctions:: forall a v. (COMMON_CONTEXT(a, v), VECTOR_CONTEXT((a, a), v), VECTOR_CONTEXT((a, a, a), v)) => v a -> [Test]
-testTuplyFunctions _ = $(testProperties ['prop_zip, 'prop_zip3, 'prop_unzip, 'prop_unzip3])
+testTuplyFunctions _ = $(testProperties [ 'prop_zip, 'prop_zip3, 'prop_mzip
+                                        , 'prop_unzip, 'prop_unzip3, 'prop_munzip])
   where
     prop_zip    :: P (v a -> v a -> v (a, a))           = V.zip `eq` zip
     prop_zip3   :: P (v a -> v a -> v a -> v (a, a, a)) = V.zip3 `eq` zip3
+    prop_mzip   :: P (Data.Vector.Vector a -> Data.Vector.Vector a -> Data.Vector.Vector (a, a))
+        = V.zip `eq` zip
     prop_unzip  :: P (v (a, a) -> (v a, v a))           = V.unzip `eq` unzip
     prop_unzip3 :: P (v (a, a, a) -> (v a, v a, v a))   = V.unzip3 `eq` unzip3
+    prop_munzip :: P (Data.Vector.Vector (a, a) -> (Data.Vector.Vector a, Data.Vector.Vector a))
+        = V.unzip `eq` unzip
 
 testOrdFunctions :: forall a v. (COMMON_CONTEXT(a, v), Ord a, Ord (v a)) => v a -> [Test]
 testOrdFunctions _ = $(testProperties

--- a/tests/Tests/Vector.hs
+++ b/tests/Tests/Vector.hs
@@ -424,17 +424,23 @@ testPolymorphicFunctions _ = $(testProperties [
         constructrN xs n f = constructrN (f xs : xs) (n-1) f
 
 testTuplyFunctions:: forall a v. (COMMON_CONTEXT(a, v), VECTOR_CONTEXT((a, a), v), VECTOR_CONTEXT((a, a, a), v)) => v a -> [Test]
-testTuplyFunctions _ = $(testProperties [ 'prop_zip, 'prop_zip3, 'prop_mzip
-                                        , 'prop_unzip, 'prop_unzip3, 'prop_munzip])
+testTuplyFunctions _ = $(testProperties [ 'prop_zip, 'prop_zip3
+                                        , 'prop_unzip, 'prop_unzip3
+#if MIN_VERSION_base(4,4,0)
+                                        , 'prop_mzip, 'prop_munzip
+#endif
+                                        ])
   where
     prop_zip    :: P (v a -> v a -> v (a, a))           = V.zip `eq` zip
     prop_zip3   :: P (v a -> v a -> v a -> v (a, a, a)) = V.zip3 `eq` zip3
-    prop_mzip   :: P (Data.Vector.Vector a -> Data.Vector.Vector a -> Data.Vector.Vector (a, a))
-        = V.zip `eq` zip
     prop_unzip  :: P (v (a, a) -> (v a, v a))           = V.unzip `eq` unzip
     prop_unzip3 :: P (v (a, a, a) -> (v a, v a, v a))   = V.unzip3 `eq` unzip3
+#if MIN_VERSION_base(4,4,0)
+    prop_mzip   :: P (Data.Vector.Vector a -> Data.Vector.Vector a -> Data.Vector.Vector (a, a))
+        = mzip `eq` zip
     prop_munzip :: P (Data.Vector.Vector (a, a) -> (Data.Vector.Vector a, Data.Vector.Vector a))
-        = V.unzip `eq` unzip
+        = munzip `eq` unzip
+#endif
 
 testOrdFunctions :: forall a v. (COMMON_CONTEXT(a, v), Ord a, Ord (v a)) => v a -> [Test]
 testOrdFunctions _ = $(testProperties

--- a/tests/Tests/Vector.hs
+++ b/tests/Tests/Vector.hs
@@ -24,6 +24,10 @@ import System.Random       (Random)
 import Data.Functor.Identity
 import Control.Monad.Trans.Writer
 
+#if MIN_VERSION_base(4,4,0)
+import Control.Monad.Zip
+#endif
+
 #define COMMON_CONTEXT(a, v) \
  VANILLA_CONTEXT(a, v), VECTOR_CONTEXT(a, v)
 


### PR DESCRIPTION
Adding `MonadZip` instances for `Vector` types allows to use `-XMonadComprehensions` and `-XParallelComprehensions` together:

    >>> :set -XMonadComprehensions
    >>> :set -XParallelListComp
    >>> import qualified Data.Vector as V
    >>> let as = V.fromList [0..10]
    >>> let bs = V.fromList [0..10]
    >>> [ a + b | a <- as | b <- bs ]
    fromList [0,2,4,6,8,10,12,14,16,18,20]

[previous pull request](https://github.com/haskell/vector/pull/78#issuecomment-234935758)