### PR TITLE
Correct semigroups conditional version bounds

### DIFF
--- a/vector.cabal
+++ b/vector.cabal
@@ -155,7 +155,7 @@ Library
                , primitive >= 0.5.0.1 && < 0.7
                , ghc-prim >= 0.2 && < 0.6
                , deepseq >= 1.1 && < 1.5
-  if !impl(ghc > 8.0)
+  if impl(ghc < 8.0)
     Build-Depends: semigroups >= 0.18 && < 0.19
 
   Ghc-Options: -O2 -Wall


### PR DESCRIPTION
`Data.Semigroup` was introduced in `base-4.9` (GHC 8.0), but `impl` flag was causing `vector` to depend on the `semigroups` library even when GHC 8.0 was being used. This fixes it so that `vector` doesn't depend on `semigroups` for GHC 8.0.