### PR TITLE
Modernize GenUnboxTuple

### DIFF
--- a/internal/GenUnboxTuple.hs
+++ b/internal/GenUnboxTuple.hs
@@ -177,6 +177,9 @@ generate n =
                                  <+> parens (var 'm' <> char '+' <> var 'n')
                                  <+> sep (map (<> char '\'') varss))
 
+    gen_initialize rec
+      = (pat "MV", mk_do [qM rec <+> vs | vs <- varss] empty)
+
     gen_unsafeFreeze rec
       = (pat "MV",
          mk_do [vs <> char '\'' <+> text "<-" <+> qG rec <+> vs | vs <- varss]
@@ -224,7 +227,8 @@ generate n =
                       ,("basicSet",               gen_set)
                       ,("basicUnsafeCopy",        gen_unsafeCopy "MV" qM)
                       ,("basicUnsafeMove",        gen_unsafeMove)
-                      ,("basicUnsafeGrow",        gen_unsafeGrow)]
+                      ,("basicUnsafeGrow",        gen_unsafeGrow)
+                      ,("basicInitialize",        gen_initialize)]
 
     methods_Vector  = [("basicUnsafeFreeze",      gen_unsafeFreeze)
                       ,("basicUnsafeThaw",        gen_unsafeThaw)

--- a/internal/GenUnboxTuple.hs
+++ b/internal/GenUnboxTuple.hs
@@ -33,12 +33,12 @@ generate n =
        ]
 
   where
-    vars  = map char $ take n ['a'..]
+    vars  = map (\c -> text ['_',c]) $ take n ['a'..]
     varss = map (<> char 's') vars
     tuple xs = parens $ hsep $ punctuate comma xs
     vtuple xs = parens $ sep $ punctuate comma xs
     con s = text s <> char '_' <> int n
-    var c = text (c : "_")
+    var c = text ('_' : c : "_")
 
     data_instance ty c
       = hang (hsep [text "data instance", text ty, tuple vars])


### PR DESCRIPTION
internal/unbox-tuple-instances is auto-generated by the code in internal/GenUnboxTuple.hs. However, not knowing that, I hand edited the generated code a while back to fix warnings and deal with an added mutable vector method. These commits make the generator produce equivalent code.

Fixes #120.