### PR TITLE
Fix dropWhile performance

### DIFF
--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1348,7 +1348,10 @@ takeWhile f = unstream . Bundle.takeWhile f . stream
 -- without copying.
 dropWhile :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE dropWhile #-}
-dropWhile f = unstream . Bundle.dropWhile f . stream
+-- We don't want to use the streaming method because it results in a copy
+dropWhile f v = case findIndex f v of
+  Nothing -> empty
+  Just n  -> drop n v
 
 -- Parititioning
 -- -------------

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1349,7 +1349,7 @@ takeWhile f = unstream . Bundle.takeWhile f . stream
 dropWhile :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE dropWhile #-}
 -- We don't want to use the streaming method because it results in a copy
-dropWhile f v = case findIndex f v of
+dropWhile f v = case findIndex (not . f) v of
   Nothing -> empty
   Just n  -> drop n v
 


### PR DESCRIPTION
The `unstream` version results in a copy of the remainder of the vector
which is rarely what you want to do. This commit uses `drop` directly
after `findIndex` which results in a big speed gain if the remaining
part of the vector is large.

Cf. https://github.com/haskell/vector/issues/108
and https://github.com/haskell/vector/issues/141