### PR TITLE
Include modules that test-suites depend on in other-modules

### DIFF
--- a/vector.cabal
+++ b/vector.cabal
@@ -50,11 +50,6 @@ Extra-Source-Files:
       tests/LICENSE
       tests/Setup.hs
       tests/Main.hs
-      tests/Boilerplater.hs
-      tests/Utilities.hs
-      tests/Tests/Move.hs
-      tests/Tests/Bundle.hs
-      tests/Tests/Vector.hs
       benchmarks/vector-benchmarks.cabal
       benchmarks/LICENSE
       benchmarks/Setup.hs
@@ -183,6 +178,14 @@ test-suite vector-tests-O0
   Default-Language: Haskell2010
   type: exitcode-stdio-1.0
   Main-Is:  Main.hs
+
+  other-modules: Boilerplater
+                 Tests.Bundle
+                 Tests.Move
+                 Tests.Vector
+                 Tests.Vector.UnitTests
+                 Utilities
+
   hs-source-dirs: tests
   Build-Depends: base >= 4.5 && < 5, template-haskell, vector,
                  random,
@@ -213,6 +216,14 @@ test-suite vector-tests-O2
   Default-Language: Haskell2010
   type: exitcode-stdio-1.0
   Main-Is:  Main.hs
+
+  other-modules: Boilerplater
+                 Tests.Bundle
+                 Tests.Move
+                 Tests.Vector
+                 Tests.Vector.UnitTests
+                 Utilities
+
   hs-source-dirs: tests
   Build-Depends: base >= 4.5 && < 5, template-haskell, vector,
                  random,


### PR DESCRIPTION
As noted in https://github.com/haskell/vector/issues/138#issuecomment-279217723, `vector`'s test suites do not compile when obtained from Hackage. That is because a module that the test suites depend on (`Tests.Vector.UnitTests`) is not included with the tarball that gets uploaded to Hackage, so when one attempts to compile the test suites from Hackage, you get a "Failed to load interface" error.

This fixes the issue by adding `Tests.Vector.UnitTests` (and other dependent modules) to an `other-modules` stanza in the test suites, which makes `Cabal` include them in a release tarball. As a result, there's no need to list them explicitly in `extra-source-files` anymore.

Since this issue is keeping `vector` [partially blocked from Stackage](https://github.com/fpco/stackage/blob/ebcc6780ddde70a860ecb5667a5a5f690def3d8a/build-constraints.yaml#L2997), it'd probably be a good idea to make a minor release with this change.

Fixes #138.