### PR TITLE
add more build tool artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .cabal-sandbox
 cabal.sandbox.config
 dist
+dist-newstyle
+stack.yaml
+.stack-work


### PR DESCRIPTION
Currently, users face minor inconveniences when using `cabal new-build` or `stack` to build `vector`. This resolves them.