### PR TITLE
Fix maximumBy comparison

### DIFF
--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1602,8 +1602,8 @@ maximumBy cmpr = Bundle.foldl1' maxBy . stream
   where
     {-# INLINE maxBy #-}
     maxBy x y = case cmpr x y of
-                  LT -> y
-                  _  -> x
+                  GT -> x
+                  _  -> y
 
 -- | /O(n)/ Yield the minimum element of the vector. The vector may not be
 -- empty.

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1636,8 +1636,8 @@ maxIndexBy cmpr = fst . Bundle.foldl1' imax . Bundle.indexed . stream
   where
     imax (i,x) (j,y) = i `seq` j `seq`
                        case cmpr x y of
-                         LT -> (j,y)
-                         _  -> (i,x)
+                         GT -> (i,x)
+                         _  -> (j,y)
 
 -- | /O(n)/ Yield the index of the minimum element of the vector. The vector
 -- may not be empty.

--- a/tests/Tests/Vector.hs
+++ b/tests/Tests/Vector.hs
@@ -500,13 +500,23 @@ testOrdFunctions :: forall a v. (CommonContext a v, Ord a, Ord (v a)) => v a -> 
 testOrdFunctions _ = $(testProperties
   ['prop_compare,
    'prop_maximum, 'prop_minimum,
-   'prop_minIndex, 'prop_maxIndex ])
+   'prop_minIndex, 'prop_maxIndex,
+   'prop_maximumBy, 'prop_minimumBy,
+   'prop_maxIndexBy, 'prop_minIndexBy])
   where
     prop_compare :: P (v a -> v a -> Ordering) = compare `eq` compare
     prop_maximum :: P (v a -> a) = not . V.null ===> V.maximum `eq` maximum
     prop_minimum :: P (v a -> a) = not . V.null ===> V.minimum `eq` minimum
     prop_minIndex :: P (v a -> Int) = not . V.null ===> V.minIndex `eq` minIndex
     prop_maxIndex :: P (v a -> Int) = not . V.null ===> V.maxIndex `eq` maxIndex
+    prop_maximumBy :: P (v a -> a) =
+      not . V.null ===> V.maximumBy compare `eq` maximum
+    prop_minimumBy :: P (v a -> a) =
+      not . V.null ===> V.minimumBy compare `eq` minimum
+    prop_maxIndexBy :: P (v a -> Int) =
+      not . V.null ===> V.maxIndexBy compare `eq` maxIndex
+    prop_minIndexBy :: P (v a -> Int) =
+      not . V.null ===> V.minIndexBy compare `eq` minIndex
 
 testEnumFunctions :: forall a v. (CommonContext a v, Enum a, Ord a, Num a, Random a) => v a -> [Test]
 testEnumFunctions _ = $(testProperties

--- a/tests/Utilities.hs
+++ b/tests/Utilities.hs
@@ -336,7 +336,7 @@ minIndex = fst . foldr1 imin . zip [0..]
 maxIndex :: Ord a => [a] -> Int
 maxIndex = fst . foldr1 imax . zip [0..]
   where
-    imax (i,x) (j,y) | x >= y    = (i,x)
+    imax (i,x) (j,y) | x >  y    = (i,x)
                      | otherwise = (j,y)
 
 iterateNM :: Monad m => Int -> (a -> m a) -> a -> m [a]


### PR DESCRIPTION
`maximumBy` for vectors does not behave like the list version:

``` haskell
> maximumBy (comparing snd) $ zip [0..10 :: Int] (repeat 'a')
(10,'a')
> V.maximumBy (comparing snd) . V.fromList $ zip [0..10 :: Int] (repeat 'a')
(0,'a')
```

This pull request fixes this issue by checking for `GT` rather than `LT` which changes the behavior in the `EQ` case.