### PR TITLE
Use SSE2 for floating-point operations on i386

### DIFF
--- a/vector.cabal
+++ b/vector.cabal
@@ -153,6 +153,9 @@ Library
 
   Ghc-Options: -O2 -Wall
 
+  if arch(i386)
+    Ghc-Options: -msse2
+
   if !flag(Wall)
     Ghc-Options: -fno-warn-orphans
 
@@ -206,6 +209,9 @@ test-suite vector-tests-O0
   Ghc-Options: -O0
   Ghc-Options: -Wall
 
+  if arch(i386)
+    Ghc-Options: -msse2
+
   if !flag(Wall)
     Ghc-Options: -fno-warn-orphans -fno-warn-missing-signatures
     if impl(ghc >= 8.0) && impl( ghc < 8.1)
@@ -242,6 +248,9 @@ test-suite vector-tests-O2
               TemplateHaskell
 
   Ghc-Options: -O2 -Wall
+
+  if arch(i386)
+    Ghc-Options: -msse2
 
   if !flag(Wall)
     Ghc-Options: -fno-warn-orphans -fno-warn-missing-signatures


### PR DESCRIPTION
Closes #186: Tests fail on i386 architecture