### PR TITLE
Add argument haddock for `move`

### DIFF
--- a/Data/Vector/Generic/Mutable.hs
+++ b/Data/Vector/Generic/Mutable.hs
@@ -788,7 +788,9 @@ copy dst src = BOUNDS_CHECK(check) "copy" "overlapping vectors"
 -- copied to a temporary vector and then the temporary vector was copied
 -- to the target vector.
 move :: (PrimMonad m, MVector v a)
-                => v (PrimState m) a -> v (PrimState m) a -> m ()
+     => v (PrimState m) a   -- ^ target
+     -> v (PrimState m) a   -- ^ source
+     -> m ()
 {-# INLINE move #-}
 move dst src = BOUNDS_CHECK(check) "move" "length mismatch"
                                           (length dst == length src)

--- a/Data/Vector/Unboxed/Mutable.hs
+++ b/Data/Vector/Unboxed/Mutable.hs
@@ -279,7 +279,9 @@ unsafeCopy = G.unsafeCopy
 -- copied to a temporary vector and then the temporary vector was copied
 -- to the target vector.
 move :: (PrimMonad m, Unbox a)
-                 => MVector (PrimState m) a -> MVector (PrimState m) a -> m ()
+     => MVector (PrimState m) a   -- ^ target
+     -> MVector (PrimState m) a   -- ^ source
+     -> m ()
 {-# INLINE move #-}
 move = G.move
 


### PR DESCRIPTION
The docs are missing the `source` and `target` haddock in the `move` function.  Added them because the order is rather counter intuitive for me

### 24 Pull Requests (https://24pullrequests.com) ###
![https://24pullrequests.com](https://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png
)