### PR TITLE
fix typo in construct[r]N examples

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -687,7 +687,7 @@ unfoldrNM = G.unfoldrNM
 -- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
--- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in f <a,b,c>
+-- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
 --
 constructN :: Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
@@ -697,7 +697,7 @@ constructN = G.constructN
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
--- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in f <c,b,a>
+-- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in <c,b,a>
 --
 constructrN :: Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructrN #-}

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -573,7 +573,7 @@ unfoldrNM n f = unstreamM . MBundle.unfoldrNM n f
 -- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
--- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in f <a,b,c>
+-- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
 --
 constructN :: forall v a. Vector v a => Int -> (v a -> a) -> v a
 {-# INLINE constructN #-}
@@ -602,7 +602,7 @@ constructN !n f = runST (
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
--- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in f <c,b,a>
+-- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in <c,b,a>
 --
 constructrN :: forall v a. Vector v a => Int -> (v a -> a) -> v a
 {-# INLINE constructrN #-}

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -536,7 +536,7 @@ unfoldrNM = G.unfoldrNM
 -- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
--- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in f <a,b,c>
+-- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
 --
 constructN :: Prim a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
@@ -546,7 +546,7 @@ constructN = G.constructN
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
--- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in f <c,b,a>
+-- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in <c,b,a>
 --
 constructrN :: Prim a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructrN #-}

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -546,7 +546,7 @@ unfoldrNM = G.unfoldrNM
 -- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
--- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in f <a,b,c>
+-- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
 --
 constructN :: Storable a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
@@ -556,7 +556,7 @@ constructN = G.constructN
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
--- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in f <c,b,a>
+-- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in <c,b,a>
 --
 constructrN :: Storable a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructrN #-}

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -515,7 +515,7 @@ unfoldrNM = G.unfoldrNM
 -- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
--- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in f <a,b,c>
+-- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
 --
 constructN :: Unbox a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
@@ -525,7 +525,7 @@ constructN = G.constructN
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
--- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in f <c,b,a>
+-- > constructrN 3 f = let a = f <> ; b = f<a> ; c = f <b,a> in <c,b,a>
 --
 constructrN :: Unbox a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructrN #-}


### PR DESCRIPTION
(there are extra `f` call in the results)