### PR TITLE
Optimize generic version of basicSet.

### DIFF
--- a/benchmarks/Algo/MutableSet.hs
+++ b/benchmarks/Algo/MutableSet.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Algo.MutableSet
+where
+
+import Prelude hiding(length, read)
+
+import Data.Vector.Mutable
+
+mutableSet :: IOVector Int -> IO Int
+{-# NOINLINE mutableSet #-}
+mutableSet v = do
+  let repetitions = 100 -- we repeat to reduce the standard deviation in measurements.
+      l = length v
+
+      -- This function is tail recursive.
+      f :: Int -> Int -> IO Int
+      f i !curSum =
+       if i == 0
+         then
+           return curSum
+         else do
+           -- 'set' is what we want to benchmark.
+           set v i
+           -- In order to make it difficult for ghc to optimize the 'set' call
+           -- away, we read the value of one element and add it to a running sum
+           -- which is returned by the function.
+           val <- read v (l-1)
+           f (i-1) (curSum+val)
+  f repetitions 0

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -4,6 +4,7 @@ import Criterion.Main
 import Criterion.Main.Options
 import Options.Applicative
 
+import Algo.MutableSet(mutableSet)
 import Algo.ListRank  (listRank)
 import Algo.Rootfix   (rootfix)
 import Algo.Leaffix   (leaffix)
@@ -18,6 +19,7 @@ import TestData.Graph     ( randomGraph )
 import TestData.Random    ( randomVector )
 
 import Data.Vector.Unboxed ( Vector )
+import qualified Data.Vector.Mutable as M( IOVector, new )
 
 import System.Environment
 import Data.Word
@@ -62,6 +64,7 @@ main = do
   lparens `seq` rparens `seq`
     nodes `seq` edges1 `seq` edges2 `seq` return ()
 
+  vi <- M.new useSize                :: IO (M.IOVector Int)
   as <- randomVector useSeed useSize :: IO (Vector Double)
   bs <- randomVector useSeed useSize :: IO (Vector Double)
   cs <- randomVector useSeed useSize :: IO (Vector Double)
@@ -69,7 +72,6 @@ main = do
   sp <- randomVector useSeed (floor $ sqrt $ fromIntegral useSize)
                           :: IO (Vector Double)
   as `seq` bs `seq` cs `seq` ds `seq` sp `seq` return ()
-  putStrLn "foo"
   runMode (otherArgs args)
                 [ bench "listRank"  $ whnf listRank useSize
                 , bench "rootfix"   $ whnf rootfix (lparens, rparens)
@@ -79,4 +81,5 @@ main = do
                 , bench "quickhull" $ whnf quickhull (as,bs)
                 , bench "spectral"  $ whnf spectral sp
                 , bench "tridiag"   $ whnf tridiag (as,bs,cs,ds)
+                , bench "mutableSet"$ nfIO $ mutableSet vi
                 ]

--- a/benchmarks/vector-benchmarks.cabal
+++ b/benchmarks/vector-benchmarks.cabal
@@ -22,6 +22,7 @@ Executable algorithms
   Ghc-Options: -O2
 
   Other-Modules:
+        Algo.MutableSet
         Algo.ListRank
         Algo.Rootfix
         Algo.Leaffix
@@ -34,4 +35,3 @@ Executable algorithms
         TestData.ParenTree
         TestData.Graph
         TestData.Random
-

--- a/vector.cabal
+++ b/vector.cabal
@@ -202,7 +202,7 @@ test-suite vector-tests-O0
                  primitive, random,
                  QuickCheck >= 2.9 && < 2.14 , HUnit, tasty,
                  tasty-hunit, tasty-quickcheck,
-                 transformers >= 0.2.0.0,semigroups
+                 transformers >= 0.2.0.0, semigroups
 
   default-extensions: CPP,
               ScopedTypeVariables,
@@ -245,7 +245,7 @@ test-suite vector-tests-O2
                  primitive, random,
                  QuickCheck >= 2.9 && < 2.14 , HUnit,  tasty,
                  tasty-hunit, tasty-quickcheck,
-                 transformers >= 0.2.0.0,semigroups
+                 transformers >= 0.2.0.0, semigroups
 
   default-extensions: CPP,
               ScopedTypeVariables,
@@ -263,4 +263,3 @@ test-suite vector-tests-O2
     Ghc-Options: -fno-warn-orphans -fno-warn-missing-signatures
     if impl(ghc >= 8.0) && impl(ghc < 8.1)
       Ghc-Options: -Wno-redundant-constraints
-


### PR DESCRIPTION
Closes #195: instead of doing N reads on the vector, where N is the length of the vector, we do 0 read. The order of writes is unchanged.

I looked at other places, I saw no other potential optimizations of that sort.

I also updated the commented implementation in Mutable.hs to keep the two in sync.

_EDIT: It seems to me that the CI errors are not related to these changes_

EDIT2 : Added a benchmark function : performance is 5% to 15% better with the new version

EDIT3 : updated some bounds in order to compile with stack lts-10.2