### PR TITLE
Bumped upper version bound for base

### DIFF
--- a/vector.cabal
+++ b/vector.cabal
@@ -144,7 +144,7 @@ Library
   Install-Includes:
         vector.h
 
-  Build-Depends: base >= 4.5 && < 4.11
+  Build-Depends: base >= 4.5 && < 4.12
                , primitive >= 0.5.0.1 && < 0.7
                , ghc-prim >= 0.2 && < 0.6
                , deepseq >= 1.1 && < 1.5


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). This PR fix compilation with this version of GHC.

Blocking https://github.com/agda/agda/issues/2878.
  