### PR TITLE
Make boxed Vector parameter representational

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -6,6 +6,9 @@
            , Rank2Types
            , BangPatterns
   #-}
+#if __GLASGOW_HASKELL__ >= 707
+{-# LANGUAGE RoleAnnotations #-}
+#endif
 
 -- |
 -- Module      : Data.Vector
@@ -212,6 +215,10 @@ import Data.Monoid   ( Monoid(..) )
 import qualified GHC.Exts as Exts (IsList(..))
 #endif
 
+
+#if __GLASGOW_HASKELL__ >= 707
+type role Vector representational
+#endif
 
 -- | Boxed vectors, supporting efficient slicing.
 data Vector a = Vector {-# UNPACK #-} !Int

--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP, DeriveDataTypeable, MultiParamTypeClasses, FlexibleInstances, BangPatterns, TypeFamilies #-}
+#if __GLASGOW_HASKELL__ >= 707
+{-# LANGUAGE RoleAnnotations #-}
+#endif
 
 -- |
 -- Module      : Data.Vector.Mutable
@@ -61,6 +64,10 @@ import Prelude hiding ( length, null, replicate, reverse, read,
 import Data.Typeable ( Typeable )
 
 #include "vector.h"
+
+#if __GLASGOW_HASKELL__ >= 707
+type role MVector nominal representational
+#endif
 
 -- | Mutable boxed vectors keyed on the monad they live in ('IO' or @'ST' s@).
 data MVector s a = MVector {-# UNPACK #-} !Int


### PR DESCRIPTION
This commit allows `Data.Vector.Vector`s to be `coerce`d.