### PR TITLE
Update vector-benchmarks.

### DIFF
--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -17,17 +17,31 @@ import TestData.Random    ( randomVector )
 
 import Data.Vector.Unboxed ( Vector )
 
+import System.Environment
+import Data.Word
+
 size :: Int
 size = 100000
 
-main = lparens `seq` rparens `seq`
+seed :: Word32
+seed = 42
+
+main = do
+  args <- getArgs
+  case args of
+    ("--seed":s:args') -> do
+      withArgs args' (main' (read s))
+    _ -> main' seed
+
+main' seed =
+       lparens `seq` rparens `seq`
        nodes `seq` edges1 `seq` edges2 `seq`
        do
-         as <- randomVector size :: IO (Vector Double)
-         bs <- randomVector size :: IO (Vector Double)
-         cs <- randomVector size :: IO (Vector Double)
-         ds <- randomVector size :: IO (Vector Double)
-         sp <- randomVector (floor $ sqrt $ fromIntegral size)
+         as <- randomVector seed size :: IO (Vector Double)
+         bs <- randomVector seed size :: IO (Vector Double)
+         cs <- randomVector seed size :: IO (Vector Double)
+         ds <- randomVector seed size :: IO (Vector Double)
+         sp <- randomVector seed (floor $ sqrt $ fromIntegral size)
                                  :: IO (Vector Double)
          as `seq` bs `seq` cs `seq` ds `seq` sp `seq`
            defaultMain [ bench "listRank"  $ whnf listRank size
@@ -41,6 +55,6 @@ main = lparens `seq` rparens `seq`
                        ]
   where
     (lparens, rparens) = parenTree size
-    (nodes, edges1, edges2) = randomGraph size
-    
+    (nodes, edges1, edges2) = randomGraph seed size
+
 

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -21,7 +21,7 @@ import System.Environment
 import Data.Word
 
 size :: Int
-size = 100000
+size = 2000000
 
 seed :: Word32
 seed = 42

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,9 @@
+# Dependence on random numbers.
+
+These benchmarks depend on random numbers which are by default generated using a static seed.
+
+To avoid misleading results:
+* Run the benchmarks using the static seed for a first approximation.
+* Verify the results by running the benchmark with different seeds.
+
+Seeds can be given by using `./algorithms --seed 42`

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -6,5 +6,4 @@ To avoid misleading results:
 * Run the benchmarks using the static seed for a first approximation.
 * Verify the results by running the benchmark with different seeds.
 
-Seeds can be given by using `./algorithms --seed 42`
-Any seed given MUST be the first argument to the executable or it will be ignored.
+Seeds can be given by using `--seed 42`

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,3 +7,4 @@ To avoid misleading results:
 * Verify the results by running the benchmark with different seeds.
 
 Seeds can be given by using `./algorithms --seed 42`
+Any seed given MUST be the first argument to the executable or it will be ignored.

--- a/benchmarks/TestData/Graph.hs
+++ b/benchmarks/TestData/Graph.hs
@@ -7,11 +7,13 @@ import qualified Data.Vector.Unboxed as V
 
 import Control.Monad.ST ( ST, runST )
 
-randomGraph :: Int -> (Int, V.Vector Int, V.Vector Int)
-randomGraph e
+import Data.Word
+
+randomGraph :: Word32 -> Int -> (Int, V.Vector Int, V.Vector Int)
+randomGraph seed e
   = runST (
     do
-      g <- create
+      g <- initialize (V.singleton seed)
       arr <- STA.newArray (0,n-1) [] :: ST s (STA.STArray s Int [Int])
       addRandomEdges n g arr e
       xs <- STA.getAssocs arr

--- a/benchmarks/TestData/Random.hs
+++ b/benchmarks/TestData/Random.hs
@@ -4,10 +4,11 @@ import qualified Data.Vector.Unboxed as V
 
 import System.Random.MWC
 import Control.Monad.ST ( runST )
+import Data.Word
 
-randomVector :: (Variate a, V.Unbox a) => Int -> IO (V.Vector a)
-randomVector n = withSystemRandom $ \g ->
-  do
+randomVector :: (Variate a, V.Unbox a) => Word32 -> Int -> IO (V.Vector a)
+randomVector seed n = do
+    g <- initialize (V.singleton seed)
     xs <- sequence $ replicate n $ uniform g
     io (return $ V.fromListN n xs)
   where

--- a/benchmarks/cabal.project
+++ b/benchmarks/cabal.project
@@ -1,0 +1,1 @@
+packages: ../vector.cabal vector-benchmarks.cabal

--- a/benchmarks/vector-benchmarks.cabal
+++ b/benchmarks/vector-benchmarks.cabal
@@ -14,7 +14,7 @@ Executable algorithms
   Build-Depends: base >= 2 && < 5, array,
                  criterion >= 0.5 && < 1.6,
                  mwc-random >= 0.5 && < 0.15,
-                 vector
+                 vector, optparse-applicative
 
   if impl(ghc<6.13)
     Ghc-Options: -finline-if-enough-args -fno-method-sharing

--- a/benchmarks/vector-benchmarks.cabal
+++ b/benchmarks/vector-benchmarks.cabal
@@ -1,5 +1,5 @@
 Name:           vector-benchmarks
-Version:        0.10.9
+Version:        0.10.10
 License:        BSD3
 License-File:   LICENSE
 Author:         Roman Leshchinskiy <rl@cse.unsw.edu.au>
@@ -12,13 +12,13 @@ Executable algorithms
   Main-Is: Main.hs
 
   Build-Depends: base >= 2 && < 5, array,
-                 criterion >= 0.5 && < 0.7,
-                 mwc-random >= 0.5 && < 0.13,
-                 vector == 0.10.9
+                 criterion >= 0.5 && < 1.6,
+                 mwc-random >= 0.5 && < 0.15,
+                 vector
 
   if impl(ghc<6.13)
     Ghc-Options: -finline-if-enough-args -fno-method-sharing
-  
+
   Ghc-Options: -O2
 
   Other-Modules:


### PR DESCRIPTION
* Use a static seed by default.
  This makes consecutive runs comparable.
* Allow passing a different seed.
  This allows avoidance of local optima for the used benchmarks.
* Update bounds on criterion,mcw-random.
* Remove bounds from vector dependency, add cabal.project.
  This way vector-benchmarks should pick up the vector dependency
  from the repo and not an older version from hackage.