### PR TITLE
Add mapMaybeM and imapMaybeM

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -114,8 +114,8 @@ module Data.Vector (
 
   -- ** Filtering
   filter, ifilter, uniq,
-  mapMaybe, imapMaybe,
-  filterM,
+  mapMaybe, imapMaybe, imapMaybeM,
+  filterM, mapMaybeM,
   takeWhile, dropWhile,
 
   -- ** Partitioning
@@ -1213,6 +1213,14 @@ imapMaybe = G.imapMaybe
 filterM :: Monad m => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
+
+mapMaybeM :: Monad m => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
+{-# INLINE mapMaybeM #-}
+mapMaybeM = G.mapMaybeM
+
+imapMaybeM :: Monad m => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
+{-# INLINE imapMaybeM #-}
+imapMaybeM = G.imapMaybeM
 
 -- | /O(n)/ Yield the longest prefix of elements satisfying the predicate
 -- without copying.

--- a/Data/Vector/Fusion/Bundle.hs
+++ b/Data/Vector/Fusion/Bundle.hs
@@ -71,7 +71,7 @@ module Data.Vector.Fusion.Bundle (
   fromVector, reVector, fromVectors, concatVectors,
 
   -- * Monadic combinators
-  mapM, mapM_, zipWithM, zipWithM_, filterM, foldM, fold1M, foldM', fold1M',
+  mapM, mapM_, zipWithM, zipWithM_, filterM, mapMaybeM, foldM, fold1M, foldM', fold1M',
 
   eq, cmp, eqBy, cmpBy
 ) where
@@ -551,6 +551,10 @@ zipWithM_ f as bs = M.zipWithM_ f (lift as) (lift bs)
 filterM :: Monad m => (a -> m Bool) -> Bundle v a -> M.Bundle m v a
 {-# INLINE filterM #-}
 filterM f = M.filterM f . lift
+
+mapMaybeM :: Monad m => (a -> m (Maybe b)) -> Bundle v a -> M.Bundle m v b
+{-# INLINE mapMaybeM #-}
+mapMaybeM f = M.mapMaybeM f . lift
 
 -- | Monadic fold
 foldM :: Monad m => (a -> b -> m a) -> a -> Bundle v b -> m a

--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -43,7 +43,7 @@ module Data.Vector.Fusion.Bundle.Monadic (
   eqBy, cmpBy,
 
   -- * Filtering
-  filter, filterM, takeWhile, takeWhileM, dropWhile, dropWhileM,
+  filter, filterM, mapMaybeM, takeWhile, takeWhileM, dropWhile, dropWhileM,
 
   -- * Searching
   elem, notElem, find, findM, findIndex, findIndexM,
@@ -445,6 +445,10 @@ filter f = filterM (return . f)
 filterM :: Monad m => (a -> m Bool) -> Bundle m v a -> Bundle m v a
 {-# INLINE_FUSED filterM #-}
 filterM f Bundle{sElems = s, sSize = n} = fromStream (S.filterM f s) (toMax n)
+
+mapMaybeM :: Monad m => (a -> m (Maybe b)) -> Bundle m v a -> Bundle m v b
+{-# INLINE_FUSED mapMaybeM #-}
+mapMaybeM f Bundle{sElems = s, sSize = n} = fromStream (S.mapMaybeM f s) (toMax n)
 
 -- | Longest prefix of elements that satisfy the predicate
 takeWhile :: Monad m => (a -> Bool) -> Bundle m v a -> Bundle m v a

--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -40,7 +40,7 @@ module Data.Vector.Fusion.Stream.Monadic (
   eqBy, cmpBy,
 
   -- * Filtering
-  filter, filterM, uniq, mapMaybe, takeWhile, takeWhileM, dropWhile, dropWhileM,
+  filter, filterM, uniq, mapMaybe, mapMaybeM, takeWhile, takeWhileM, dropWhile, dropWhileM,
 
   -- * Searching
   elem, notElem, find, findM, findIndex, findIndexM,
@@ -716,6 +716,22 @@ filterM f (Stream step t) = Stream step' t
                                   b <- f x
                                   return $ if b then Yield x s'
                                                 else Skip    s'
+                  Skip    s' -> return $ Skip s'
+                  Done       -> return $ Done
+
+mapMaybeM :: Monad m => (a -> m (Maybe b)) -> Stream m a -> Stream m b
+{-# INLINE_FUSED mapMaybeM #-}
+mapMaybeM f (Stream step t) = Stream step' t
+  where
+    {-# INLINE_INNER step' #-}
+    step' s = do
+                r <- step s
+                case r of
+                  Yield x s' -> do
+                                  fx <- f x
+                                  return $ case fx of
+                                    Nothing -> Skip s'
+                                    Just b  -> Yield b s'
                   Skip    s' -> return $ Skip s'
                   Done       -> return $ Done
 

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -98,7 +98,7 @@ module Data.Vector.Generic (
   -- ** Filtering
   filter, ifilter, uniq,
   mapMaybe, imapMaybe,
-  filterM,
+  filterM, mapMaybeM, imapMaybeM,
   takeWhile, dropWhile,
 
   -- ** Partitioning
@@ -1333,6 +1333,14 @@ imapMaybe f = unstream
 filterM :: (Monad m, Vector v a) => (a -> m Bool) -> v a -> m (v a)
 {-# INLINE filterM #-}
 filterM f = unstreamM . Bundle.filterM f . stream
+
+mapMaybeM :: (Monad m, Vector v a, Vector v b) => (a -> m (Maybe b)) -> v a -> m (v b)
+{-# INLINE mapMaybeM #-}
+mapMaybeM f = unstreamM . Bundle.mapMaybeM f . stream
+
+imapMaybeM :: (Monad m, Vector v a, Vector v b)
+      => (Int -> a -> m (Maybe b)) -> v a -> m (v b)
+imapMaybeM f = unstreamM . Bundle.mapMaybeM (\(i, a) -> f i a) . Bundle.indexed . stream
 
 -- | /O(n)/ Yield the longest prefix of elements satisfying the predicate
 -- without copying.

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -98,6 +98,7 @@ module Data.Vector.Primitive (
   -- ** Filtering
   filter, ifilter, uniq,
   mapMaybe, imapMaybe,
+  mapMaybeM, imapMaybeM,
   filterM,
   takeWhile, dropWhile,
 
@@ -946,10 +947,22 @@ mapMaybe :: (Prim a, Prim b) => (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
+mapMaybeM
+  :: (Monad m, Prim a, Prim b)
+  => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
+{-# INLINE mapMaybeM #-}
+mapMaybeM = G.mapMaybeM
+
 -- | /O(n)/ Drop elements when predicate, applied to index and value, returns Nothing
 imapMaybe :: (Prim a, Prim b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
+
+imapMaybeM
+  :: (Monad m, Prim a, Prim b)
+  => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
+{-# INLINE imapMaybeM #-}
+imapMaybeM = G.imapMaybeM
 
 -- | /O(n)/ Drop elements that do not satisfy the monadic predicate
 filterM :: (Monad m, Prim a) => (a -> m Bool) -> Vector a -> m (Vector a)

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -95,6 +95,7 @@ module Data.Vector.Storable (
   -- ** Filtering
   filter, ifilter, uniq,
   mapMaybe, imapMaybe,
+  mapMaybeM, imapMaybeM,
   filterM,
   takeWhile, dropWhile,
 
@@ -961,6 +962,18 @@ mapMaybe = G.mapMaybe
 imapMaybe :: (Storable a, Storable b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
+
+mapMaybeM
+  :: (Monad m, Storable a, Storable b)
+  => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
+{-# INLINE mapMaybeM #-}
+mapMaybeM = G.mapMaybeM
+
+imapMaybeM
+  :: (Monad m, Storable a, Storable b)
+  => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
+{-# INLINE imapMaybeM #-}
+imapMaybeM = G.imapMaybeM
 
 -- | /O(n)/ Drop elements that do not satisfy the monadic predicate
 filterM :: (Monad m, Storable a) => (a -> m Bool) -> Vector a -> m (Vector a)

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -121,6 +121,7 @@ module Data.Vector.Unboxed (
   -- ** Filtering
   filter, ifilter, uniq,
   mapMaybe, imapMaybe,
+  mapMaybeM, imapMaybeM,
   filterM,
   takeWhile, dropWhile,
 
@@ -999,6 +1000,14 @@ mapMaybe = G.mapMaybe
 imapMaybe :: (Unbox a, Unbox b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
+
+mapMaybeM :: (Monad m, Unbox a, Unbox b) => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
+{-# INLINE mapMaybeM #-}
+mapMaybeM = G.mapMaybeM
+
+imapMaybeM :: (Monad m, Unbox a, Unbox b) => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
+{-# INLINE imapMaybeM #-}
+imapMaybeM = G.imapMaybeM
 
 -- | /O(n)/ Drop elements that do not satisfy the monadic predicate
 filterM :: (Monad m, Unbox a) => (a -> m Bool) -> Vector a -> m (Vector a)


### PR DESCRIPTION
Add

```haskell
mapMaybeM :: Monad m => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
imapMaybeM :: Monad m => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
```

`mapMaybeM` is similar to `wither`, but the stream fusion framework
seems to require that we use a `Monad` constraint rather than an
`Applicative` one to get good performance. `imapMaybeM` is the
indexed variant.

Resolves #183