### PR TITLE
Improve "uninitialised element" error message

### DIFF
--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -193,7 +193,7 @@ loopM !n k = let
   in go 0
 
 uninitialised :: a
-uninitialised = error "Data.Vector.Mutable: uninitialised element"
+uninitialised = error "Data.Vector.Mutable: uninitialised element. If you are trying to compact a vector, use the 'force' function to remove uninitialised elements from the underlying array."
 
 -- Length information
 -- ------------------


### PR DESCRIPTION

Compaction ([http://hackage.haskell.org/package/ghc-compact-0.1.0.0/docs/GHC-Compact.html#v:compact](http://hackage.haskell.org/package/ghc-compact-0.1.0.0/docs/GHC-Compact.html#v:compact)) of an immutable vector may crash with the confusing "uninitialised element" error message [https://github.com/haskell/vector/issues/220](https://github.com/haskell/vector/issues/220):

```haskell
module Main where

import qualified Data.Vector as V
import GHC.Compact

main :: IO ()
main = do
  c <- compact $ V.fromList [1, 2, 3]
  pure ()
```

```
*** Exception: Data.Vector.Mutable: uninitialised element
```

As far as I understand, there is no simple way to fix this. However, there is an easy workaround: use the `force` function.

This code doesn't crash:

```haskell
c <- compact $ V.force $ V.fromList [1, 2, 3]
```


The PR adds a suggestion to use the `force` function in the error message.