### PR TITLE
 Make Storable vectors nominally roled, and add unsafeCoerceVector functions

### DIFF
--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -132,7 +132,10 @@ module Data.Vector.Storable (
   toList, fromList, fromListN,
 
   -- ** Other vector types
-  G.convert, unsafeCast, unsafeCoerceVector,
+  G.convert, unsafeCast,
+#if __GLASGOW_HASKELL__ >= 708
+  unsafeCoerceVector,
+#endif
 
   -- ** Mutable vectors
   freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy,

--- a/Data/Vector/Storable/Mutable.hs
+++ b/Data/Vector/Storable/Mutable.hs
@@ -53,7 +53,10 @@ module Data.Vector.Storable.Mutable(
   set, copy, move, unsafeCopy, unsafeMove,
 
   -- * Unsafe conversions
-  unsafeCast, unsafeCoerceMVector,
+  unsafeCast,
+#if __GLASGOW_HASKELL__ >= 708
+  unsafeCoerceMVector,
+#endif
 
   -- * Raw pointers
   unsafeFromForeignPtr, unsafeFromForeignPtr0,

--- a/changelog
+++ b/changelog
@@ -6,6 +6,31 @@ Changes in version next
    it would choose the first element). Similarly, `maxIndexBy` will also
    now pick the last element if several elements could be considered the
    maximum.
+ * The role signatures on several `Vector` types were too permissive, so they
+   have been tightened up:
+   * The role signature for `Data.Vector.Mutable.MVector` is now
+     `type role MVector nominal representational` (previously, both arguments
+     were `phantom`).
+   * The role signature for `Data.Vector.Primitive.Vector` is now
+     `type role Vector representational` (previously, it was `phantom`).
+   * The role signature for `Data.Vector.Storable.Vector` is now
+     `type role Vector nominal` (previous, it was `phantom`), and the signature
+     for `Data.Vector.Storable.Mutable.MVector` is now
+     `type role MVector nominal nominal` (previous, both arguments were
+     `phantom`).
+
+     We pick `nominal` for the role of the last argument instead of
+     `representational` since the internal structure of a `Storable` vector
+     is determined by the `Storable` instance of the element type, and it is
+     not guaranteed that the `Storable` instances between two
+     representationally equal types will preserve this internal structure.
+     One consequence of this choice is that it is no longer possible to
+     `coerce` between `Storable.Vector a` and `Storable.Vector b` if `a` and
+     `b` are nominally distinct but representationally equal types. We now
+     provide `unsafeCoerce{M}Vector` functions in
+     `Data.Vector.Storable{.Mutable}` to allow this (the onus is on the user
+     to ensure that no `Storable` invariants are broken when using these
+     functions).
  * The `Mutable` type family is now injective on GHC 8.0 or later.
  * Using empty `Storable` vectors no longer results in division-by-zero
    errors.


### PR DESCRIPTION
In #224, we came to the conclusion that `Storable` vectors should be nominally roled in their type arguments. This PR implements that. I've also added `unsafeCoerce{M}Vector` functions which allow one to `coerce` between two `Storable` vectors in the event where you (the programmer) can ensure that the two `Storable` instances you're coercing between have identical memory representations.

There's still an open question about what to name these `unsafeCoerce{M}Vector` functions—suggestions welcome.