### PR TITLE
Adapt to MonadFail-related changes in base-4.13

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -175,9 +175,10 @@ import Control.DeepSeq ( NFData(rnf)
 #endif
                        )
 
-import Control.Monad ( MonadPlus(..), liftM, ap )
-import Control.Monad.ST ( ST )
-import Control.Monad.Primitive
+import           Control.Monad ( MonadPlus(..), liftM, ap )
+import qualified Control.Monad.Fail as Fail
+import           Control.Monad.ST ( ST )
+import           Control.Monad.Primitive
 
 
 import Control.Monad.Zip
@@ -353,6 +354,12 @@ instance Monad Vector where
   {-# INLINE (>>=) #-}
   (>>=) = flip concatMap
 
+#if !(MIN_VERSION_base(4,13,0))
+  {-# INLINE fail #-}
+  fail = Fail.fail
+#endif
+
+instance Fail.MonadFail Vector where
   {-# INLINE fail #-}
   fail _ = empty
 

--- a/vector.cabal
+++ b/vector.cabal
@@ -152,7 +152,8 @@ Library
                , ghc-prim >= 0.2 && < 0.6
                , deepseq >= 1.1 && < 1.5
   if !impl(ghc > 8.0)
-    Build-Depends: semigroups >= 0.18 && < 0.19
+    Build-Depends: fail == 4.9.*
+                 , semigroups >= 0.18 && < 0.19
 
   Ghc-Options: -O2 -Wall
 


### PR DESCRIPTION
`base-4.13` will finally complete the `MonadFail` proposal by removing the `fail` method from `Monad`. This adapts `vector` to that change by guarding the existing `fail` implementation in `vector` (for `Data.Vector.Vector`) behind CPP, and defining a `MonadFail` instance for `Vector` going forward.