### PR TITLE
Compare vector sizes in eq[By]

### DIFF
--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -426,7 +426,15 @@ zip6 = zipWith6 (,,,,,)
 -- | Check if two 'Bundle's are equal
 eqBy :: (Monad m) => (a -> b -> Bool) -> Bundle m v a -> Bundle m v b -> m Bool
 {-# INLINE_FUSED eqBy #-}
-eqBy eq x y = S.eqBy eq (sElems x) (sElems y)
+eqBy eq x y
+  | sizesAreDifferent (sSize x) (sSize y) = pure False
+  | otherwise                             = S.eqBy eq (sElems x) (sElems y)
+  where
+    sizesAreDifferent :: Size -> Size -> Bool
+    sizesAreDifferent (Exact a) (Exact b) = a /= b
+    sizesAreDifferent (Exact a) (Max b)   = a > b
+    sizesAreDifferent (Max a)   (Exact b) = a < b
+    sizesAreDifferent _         _         = False
 
 -- | Lexicographically compare two 'Bundle's
 cmpBy :: (Monad m) => (a -> b -> Ordering) -> Bundle m v a -> Bundle m v b -> m Ordering

--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -427,7 +427,7 @@ zip6 = zipWith6 (,,,,,)
 eqBy :: (Monad m) => (a -> b -> Bool) -> Bundle m v a -> Bundle m v b -> m Bool
 {-# INLINE_FUSED eqBy #-}
 eqBy eq x y
-  | sizesAreDifferent (sSize x) (sSize y) = pure False
+  | sizesAreDifferent (sSize x) (sSize y) = return False
   | otherwise                             = S.eqBy eq (sElems x) (sElems y)
   where
     sizesAreDifferent :: Size -> Size -> Bool


### PR DESCRIPTION
Fixes #260.

Core for eqBy on two Data.Vectors:

    case /=# dt1_dmDH dt4_dmDK of {
      __DEFAULT ->
        join {
          exit_X7O [Dmd=<L,C(U)>] :: Int# -> Bool
          [LclId[JoinId(1)], Arity=1, Str=<L,U>]
          exit_X7O (ww_syBO [OS=OneShot] :: Int#)
            = case >=# ww_syBO dt4_dmDK of {
                __DEFAULT -> False;
                1# -> True
              } } in
        joinrec {
          $s$weq_loop0_sDz0 [Occ=LoopBreaker] :: Int# -> Int# -> Bool
          [LclId[JoinId(2)], Arity=2, Str=<L,U><L,U>, Unf=OtherCon []]
          $s$weq_loop0_sDz0 (sc_sDyZ :: Int#) (sc1_sDyY :: Int#)
            = case >=# sc1_sDyY dt1_dmDH of {
                __DEFAULT ->
                  case indexArray# @ a_aiST dt2_dmDI (+# dt_dmDG sc1_sDyY) of
                  { (# ipv_apdc #) ->
                  case >=# sc_sDyZ dt4_dmDK of {
                    __DEFAULT ->
                      case indexArray# @ b_aiSU dt5_dmDL (+# dt3_dmDJ sc_sDyZ) of
                      { (# ipv1_Xppx #) ->
                      case ds_dm0i ipv_apdc ipv1_Xppx of {
                        False -> False;
                        True -> jump $s$weq_loop0_sDz0 (+# sc_sDyZ 1#) (+# sc1_sDyY 1#)
                      }
                      };
                    1# -> False
                  }
                  };
                1# -> jump exit_X7O sc_sDyZ
              }; } in
        jump $s$weq_loop0_sDz0 0# 0#;
      1# -> False
    };