### PR TITLE
Fix crash in specialized enumFromTo

### DIFF
--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -758,13 +758,15 @@ enumFromTo x y = fromList [x .. y]
 -- FIXME: add "too large" test for Int
 enumFromTo_small :: (Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_small #-}
-enumFromTo_small x y = x `seq` y `seq` fromStream (Stream step x) (Exact n)
+enumFromTo_small x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact n)
   where
     n = delay_inline max (fromIntegral y - fromIntegral x + 1) 0
 
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 {-# RULES
 
@@ -808,7 +810,7 @@ enumFromTo_small x y = x `seq` y `seq` fromStream (Stream step x) (Exact n)
 
 enumFromTo_int :: forall m v. Monad m => Int -> Int -> Bundle m v Int
 {-# INLINE_FUSED enumFromTo_int #-}
-enumFromTo_int x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len x y))
+enumFromTo_int x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (len x y))
   where
     {-# INLINE [0] len #-}
     len :: Int -> Int -> Int
@@ -820,12 +822,14 @@ enumFromTo_int x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len x y)
         n = v-u+1
 
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 enumFromTo_intlike :: (Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_intlike #-}
-enumFromTo_intlike x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len x y))
+enumFromTo_intlike x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (len x y))
   where
     {-# INLINE [0] len #-}
     len u v | u > v     = 0
@@ -836,8 +840,10 @@ enumFromTo_intlike x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len 
         n = v-u+1
 
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 {-# RULES
 
@@ -860,7 +866,7 @@ enumFromTo_intlike x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len 
 
 enumFromTo_big_word :: (Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_big_word #-}
-enumFromTo_big_word x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len x y))
+enumFromTo_big_word x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (len x y))
   where
     {-# INLINE [0] len #-}
     len u v | u > v     = 0
@@ -871,8 +877,10 @@ enumFromTo_big_word x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len
         n = v-u
 
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 {-# RULES
 
@@ -901,7 +909,7 @@ enumFromTo_big_word x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len
 -- FIXME: the "too large" test is totally wrong
 enumFromTo_big_int :: (Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_big_int #-}
-enumFromTo_big_int x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len x y))
+enumFromTo_big_int x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (len x y))
   where
     {-# INLINE [0] len #-}
     len u v | u > v     = 0
@@ -912,8 +920,10 @@ enumFromTo_big_int x y = x `seq` y `seq` fromStream (Stream step x) (Exact (len 
         n = v-u+1
 
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 
 {-# RULES

--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -1325,11 +1325,13 @@ enumFromTo x y = fromList [x .. y]
 -- FIXME: add "too large" test for Int
 enumFromTo_small :: (Integral a, Monad m) => a -> a -> Stream m a
 {-# INLINE_FUSED enumFromTo_small #-}
-enumFromTo_small x y = x `seq` y `seq` Stream step x
+enumFromTo_small x y = x `seq` y `seq` Stream step (Just x)
   where
     {-# INLINE_INNER step #-}
-    step w | w <= y    = return $ Yield w (w+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 {-# RULES
 
@@ -1373,7 +1375,7 @@ enumFromTo_small x y = x `seq` y `seq` Stream step x
 
 enumFromTo_int :: forall m. Monad m => Int -> Int -> Stream m Int
 {-# INLINE_FUSED enumFromTo_int #-}
-enumFromTo_int x y = x `seq` y `seq` Stream step x
+enumFromTo_int x y = x `seq` y `seq` Stream step (Just x)
   where
     -- {-# INLINE [0] len #-}
     -- len :: Int -> Int -> Int
@@ -1385,16 +1387,21 @@ enumFromTo_int x y = x `seq` y `seq` Stream step x
     --     n = v-u+1
 
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
+
 
 enumFromTo_intlike :: (Integral a, Monad m) => a -> a -> Stream m a
 {-# INLINE_FUSED enumFromTo_intlike #-}
-enumFromTo_intlike x y = x `seq` y `seq` Stream step x
+enumFromTo_intlike x y = x `seq` y `seq` Stream step (Just x)
   where
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 {-# RULES
 
@@ -1415,11 +1422,13 @@ enumFromTo_intlike x y = x `seq` y `seq` Stream step x
 
 enumFromTo_big_word :: (Integral a, Monad m) => a -> a -> Stream m a
 {-# INLINE_FUSED enumFromTo_big_word #-}
-enumFromTo_big_word x y = x `seq` y `seq` Stream step x
+enumFromTo_big_word x y = x `seq` y `seq` Stream step (Just x)
   where
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 {-# RULES
 
@@ -1449,11 +1458,13 @@ enumFromTo_big_word x y = x `seq` y `seq` Stream step x
 -- FIXME: the "too large" test is totally wrong
 enumFromTo_big_int :: (Integral a, Monad m) => a -> a -> Stream m a
 {-# INLINE_FUSED enumFromTo_big_int #-}
-enumFromTo_big_int x y = x `seq` y `seq` Stream step x
+enumFromTo_big_int x y = x `seq` y `seq` Stream step (Just x)
   where
     {-# INLINE_INNER step #-}
-    step z | z <= y    = return $ Yield z (z+1)
-           | otherwise = return $ Done
+    step Nothing              = return $ Done
+    step (Just z) | z == y    = return $ Yield z Nothing
+                  | z <  y    = return $ Yield z (Just (z+1))
+                  | otherwise = return $ Done
 
 {-# RULES
 

--- a/tests/Tests/Vector/UnitTests.hs
+++ b/tests/Tests/Vector/UnitTests.hs
@@ -48,24 +48,24 @@ tests =
       ]
   , testGroup "Regression tests"
     [ testGroup "enumFromTo crash #188" $
-      [ regression188 (Proxy :: Proxy Word8)
-      , regression188 (Proxy :: Proxy Word16)
-      , regression188 (Proxy :: Proxy Word32)
-      , regression188 (Proxy :: Proxy Word64)
-      , regression188 (Proxy :: Proxy Word)
-      , regression188 (Proxy :: Proxy Int8)
-      , regression188 (Proxy :: Proxy Int16)
-      , regression188 (Proxy :: Proxy Int32)
-      , regression188 (Proxy :: Proxy Int64)
-      , regression188 (Proxy :: Proxy Int)
-      , regression188 (Proxy :: Proxy Char)
+      [ regression188 ([] :: [Word8])
+      , regression188 ([] :: [Word16])
+      , regression188 ([] :: [Word32])
+      , regression188 ([] :: [Word64])
+      , regression188 ([] :: [Word])
+      , regression188 ([] :: [Int8])
+      , regression188 ([] :: [Int16])
+      , regression188 ([] :: [Int32])
+      , regression188 ([] :: [Int64])
+      , regression188 ([] :: [Int])
+      , regression188 ([] :: [Char])
       ]
     ]
   ]
 
 regression188
-  :: forall a. (Typeable a, Enum a, Bounded a, Eq a, Show a)
-  => Proxy a -> Test
+  :: forall proxy a. (Typeable a, Enum a, Bounded a, Eq a, Show a)
+  => proxy a -> Test
 regression188 _ = testCase (show (typeOf (undefined :: a)))
   $ Vector.fromList [maxBound::a] @=? Vector.enumFromTo maxBound maxBound
 {-# INLINE regression188 #-}

--- a/tests/Tests/Vector/UnitTests.hs
+++ b/tests/Tests/Vector/UnitTests.hs
@@ -5,15 +5,19 @@ module Tests.Vector.UnitTests (tests) where
 
 import Control.Applicative as Applicative
 import Control.Monad.Primitive
+import Data.Int
+import Data.Word
+import Data.Typeable
 import qualified Data.Vector.Generic  as Generic
 import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector          as Vector
 import Foreign.Ptr
 import Foreign.Storable
 import Text.Printf
 
 import Test.Framework
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit (Assertion, assertBool)
+import Test.HUnit (Assertion, assertBool, (@=?))
 
 newtype Aligned a = Aligned { getAligned :: a }
 
@@ -42,7 +46,29 @@ tests =
       , testCase "Aligned Int" $
           checkAddressAlignment alignedIntVec
       ]
+  , testGroup "Regression tests"
+    [ testGroup "enumFromTo crash #188" $
+      [ regression188 (Proxy :: Proxy Word8)
+      , regression188 (Proxy :: Proxy Word16)
+      , regression188 (Proxy :: Proxy Word32)
+      , regression188 (Proxy :: Proxy Word64)
+      , regression188 (Proxy :: Proxy Word)
+      , regression188 (Proxy :: Proxy Int8)
+      , regression188 (Proxy :: Proxy Int16)
+      , regression188 (Proxy :: Proxy Int32)
+      , regression188 (Proxy :: Proxy Int64)
+      , regression188 (Proxy :: Proxy Int)
+      , regression188 (Proxy :: Proxy Char)
+      ]
+    ]
   ]
+
+regression188
+  :: forall a. (Typeable a, Enum a, Bounded a, Eq a, Show a)
+  => Proxy a -> Test
+regression188 _ = testCase (show (typeOf (undefined :: a)))
+  $ Vector.fromList [maxBound::a] @=? Vector.enumFromTo maxBound maxBound
+{-# INLINE regression188 #-}
 
 alignedDoubleVec :: Storable.Vector (Aligned Double)
 alignedDoubleVec = Storable.fromList $ map Aligned [1, 2, 3, 4, 5]


### PR DESCRIPTION
This is attempt to fix #188. I had to change stream state from `a` to `Maybe a` in order to mark end of the stream. I also added regression tests in case someone will try to optimize these functions in the future

Fix is only partial. `Data.Vector.Fusion.Stream.Monadic` is affected by exactly same problem but it's not fixed yet