### PR TITLE
Fix selection of the resulting size when `take` is applied:

### DIFF
--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -269,7 +269,7 @@ tail Bundle{sElems = s, sSize = sz} = fromStream (S.tail s) (sz-1)
 -- | The first @n@ elements
 take :: Monad m => Int -> Bundle m v a -> Bundle m v a
 {-# INLINE_FUSED take #-}
-take n Bundle{sElems = s, sSize = sz} = fromStream (S.take n s) (smaller (Exact n) sz)
+take n Bundle{sElems = s, sSize = sz} = fromStream (S.take n s) (smallerThan n sz)
 
 -- | All but the first @n@ elements
 drop :: Monad m => Int -> Bundle m v a -> Bundle m v a

--- a/Data/Vector/Fusion/Bundle/Size.hs
+++ b/Data/Vector/Fusion/Bundle/Size.hs
@@ -11,7 +11,7 @@
 --
 
 module Data.Vector.Fusion.Bundle.Size (
-  Size(..), clampedSubtract, smaller, larger, toMax, upperBound, lowerBound
+  Size(..), clampedSubtract, smaller, smallerThan, larger, toMax, upperBound, lowerBound
 ) where
 
 import Data.Vector.Fusion.Util ( delay_inline )
@@ -90,6 +90,14 @@ smaller (Max   m) Unknown   = Max   m
 smaller Unknown   (Exact n) = Max   n
 smaller Unknown   (Max   n) = Max   n
 smaller Unknown   Unknown   = Unknown
+
+-- | Select a safe smaller than known size.
+smallerThan :: Int -> Size -> Size
+{-# INLINE smallerThan #-}
+smallerThan m (Exact n) = Exact (delay_inline min m n)
+smallerThan m (Max   n) = Max   (delay_inline min m n)
+smallerThan _ Unknown   = Unknown
+
 
 -- | Maximum of two size hints
 larger :: Size -> Size -> Size

--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 Changes in version next
 
  * Fix integer overflows in specializations of Bundle/Stream enumFromTo on Integral types
+ * Fix possibility of OutOfMemory with `take` and very large arguments.
  * Fix `slice` function causing segfault and not checking the bounds properly.
  * updated specialization rule for EnumFromTo on Float and Double
   to make sure it always matches the version in GHC Base (which changed as of 8.6)


### PR DESCRIPTION
* Fixes #282 - Possibility of OutOfMemory when argument to `take` is too
large