### PR TITLE
Add MINIMAL pragma to Vector & MVector type classes

### DIFF
--- a/Data/Vector/Generic/Base.hs
+++ b/Data/Vector/Generic/Base.hs
@@ -145,4 +145,5 @@ class MVector (Mutable v) a => Vector v a where
   {-# INLINE elemseq #-}
   elemseq _ = \_ x -> x
 
-
+  {-# MINIMAL basicUnsafeFreeze, basicUnsafeThaw, basicLength,
+              basicUnsafeSlice, basicUnsafeIndexM #-}

--- a/Data/Vector/Generic/Mutable.hs
+++ b/Data/Vector/Generic/Mutable.hs
@@ -595,8 +595,10 @@ new n = BOUNDS_CHECK(checkLength) "new" n
 --   should be presumed uninitialized. However exact semantics depends
 --   on vector implementation. For example unboxed and storable
 --   vectors will create vector filled with whatever underlying memory
---   buffer happens to contain, while boxed vector initializes every
---   element to @error "..."@.
+--   buffer happens to contain, while boxed vector's elements are
+--   initialized to bottoms which will throw exception when evaluated.
+--
+-- @since 0.4
 unsafeNew :: (PrimMonad m, MVector v a) => Int -> m (v (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew n = UNSAFE_CHECK(checkLength) "unsafeNew" n

--- a/Data/Vector/Generic/Mutable.hs
+++ b/Data/Vector/Generic/Mutable.hs
@@ -591,7 +591,12 @@ new :: (PrimMonad m, MVector v a) => Int -> m (v (PrimState m) a)
 new n = BOUNDS_CHECK(checkLength) "new" n
       $ unsafeNew n >>= \v -> basicInitialize v >> return v
 
--- | Create a mutable vector of the given length. The memory is not initialized.
+-- | Create a mutable vector of the given length. The vector content
+--   should be presumed uninitialized. However exact semantics depends
+--   on vector implementation. For example unboxed and storable
+--   vectors will create vector filled with whatever underlying memory
+--   buffer happens to contain, while boxed vector initializes every
+--   element to @error "..."@.
 unsafeNew :: (PrimMonad m, MVector v a) => Int -> m (v (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew n = UNSAFE_CHECK(checkLength) "unsafeNew" n

--- a/Data/Vector/Generic/Mutable/Base.hs
+++ b/Data/Vector/Generic/Mutable/Base.hs
@@ -145,3 +145,6 @@ class MVector v a where
     where
       n = basicLength v
 
+  {-# MINIMAL basicLength, basicUnsafeSlice, basicOverlaps,
+              basicUnsafeNew, basicInitialize, basicUnsafeRead,
+              basicUnsafeWrite #-}

--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -281,12 +281,10 @@ new :: PrimMonad m => Int -> m (MVector (PrimState m) a)
 {-# INLINE new #-}
 new = G.new
 
--- | Create a mutable vector of the given length. The vector content
---   should be presumed uninitialized. However exact semantics depends
---   on vector implementation. For example unboxed and storable
---   vectors will create vector filled with whatever underlying memory
---   buffer happens to contain, while boxed vector initializes every
---   element to @error "..."@.
+-- | Create a mutable vector of the given length. The vector elements
+--   are set to bottom so accessing them will cause an exception.
+--
+-- @since 0.5
 unsafeNew :: PrimMonad m => Int -> m (MVector (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew = G.unsafeNew

--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -281,7 +281,12 @@ new :: PrimMonad m => Int -> m (MVector (PrimState m) a)
 {-# INLINE new #-}
 new = G.new
 
--- | Create a mutable vector of the given length. The memory is not initialized.
+-- | Create a mutable vector of the given length. The vector content
+--   should be presumed uninitialized. However exact semantics depends
+--   on vector implementation. For example unboxed and storable
+--   vectors will create vector filled with whatever underlying memory
+--   buffer happens to contain, while boxed vector initializes every
+--   element to @error "..."@.
 unsafeNew :: PrimMonad m => Int -> m (MVector (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew = G.unsafeNew

--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -71,9 +71,9 @@ type role MVector nominal representational
 #endif
 
 -- | Mutable boxed vectors keyed on the monad they live in ('IO' or @'ST' s@).
-data MVector s a = MVector {-# UNPACK #-} !Int
-                           {-# UNPACK #-} !Int
-                           {-# UNPACK #-} !(MutableArray s a)
+data MVector s a = MVector {-# UNPACK #-} !Int                -- ^ Offset in underlying array
+                           {-# UNPACK #-} !Int                -- ^ Size of slice
+                           {-# UNPACK #-} !(MutableArray s a) -- ^ Underlying array
         deriving ( Typeable )
 
 type IOVector = MVector RealWorld

--- a/Data/Vector/Primitive/Mutable.hs
+++ b/Data/Vector/Primitive/Mutable.hs
@@ -227,11 +227,10 @@ new :: (PrimMonad m, Prim a) => Int -> m (MVector (PrimState m) a)
 new = G.new
 
 -- | Create a mutable vector of the given length. The vector content
---   should be presumed uninitialized. However exact semantics depends
---   on vector implementation. For example unboxed and storable
---   vectors will create vector filled with whatever underlying memory
---   buffer happens to contain, while boxed vector initializes every
---   element to @error "..."@.
+--   is uninitialized, which means it is filled with whatever underlying memory
+--   buffer happens to contain.
+--
+-- @since 0.5
 unsafeNew :: (PrimMonad m, Prim a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew = G.unsafeNew

--- a/Data/Vector/Primitive/Mutable.hs
+++ b/Data/Vector/Primitive/Mutable.hs
@@ -226,7 +226,12 @@ new :: (PrimMonad m, Prim a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE new #-}
 new = G.new
 
--- | Create a mutable vector of the given length. The memory is not initialized.
+-- | Create a mutable vector of the given length. The vector content
+--   should be presumed uninitialized. However exact semantics depends
+--   on vector implementation. For example unboxed and storable
+--   vectors will create vector filled with whatever underlying memory
+--   buffer happens to contain, while boxed vector initializes every
+--   element to @error "..."@.
 unsafeNew :: (PrimMonad m, Prim a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew = G.unsafeNew

--- a/Data/Vector/Storable/Mutable.hs
+++ b/Data/Vector/Storable/Mutable.hs
@@ -375,7 +375,12 @@ new :: (PrimMonad m, Storable a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE new #-}
 new = G.new
 
--- | Create a mutable vector of the given length. The memory is not initialized.
+-- | Create a mutable vector of the given length. The vector content
+--   should be presumed uninitialized. However exact semantics depends
+--   on vector implementation. For example unboxed and storable
+--   vectors will create vector filled with whatever underlying memory
+--   buffer happens to contain, while boxed vector initializes every
+--   element to @error "..."@.
 unsafeNew :: (PrimMonad m, Storable a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew = G.unsafeNew

--- a/Data/Vector/Storable/Mutable.hs
+++ b/Data/Vector/Storable/Mutable.hs
@@ -376,11 +376,10 @@ new :: (PrimMonad m, Storable a) => Int -> m (MVector (PrimState m) a)
 new = G.new
 
 -- | Create a mutable vector of the given length. The vector content
---   should be presumed uninitialized. However exact semantics depends
---   on vector implementation. For example unboxed and storable
---   vectors will create vector filled with whatever underlying memory
---   buffer happens to contain, while boxed vector initializes every
---   element to @error "..."@.
+--   is uninitialized, which means it is filled with whatever underlying memory
+--   buffer happens to contain.
+--
+-- @since 0.5
 unsafeNew :: (PrimMonad m, Storable a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew = G.unsafeNew
@@ -609,4 +608,3 @@ unsafeToForeignPtr0 (MVector n fp) = (fp, n)
 unsafeWith :: Storable a => IOVector a -> (Ptr a -> IO b) -> IO b
 {-# INLINE unsafeWith #-}
 unsafeWith (MVector _ fp) = withForeignPtr fp
-

--- a/Data/Vector/Unboxed/Mutable.hs
+++ b/Data/Vector/Unboxed/Mutable.hs
@@ -155,7 +155,12 @@ new :: (PrimMonad m, Unbox a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE new #-}
 new = G.new
 
--- | Create a mutable vector of the given length. The memory is not initialized.
+-- | Create a mutable vector of the given length. The vector content
+--   should be presumed uninitialized. However exact semantics depends
+--   on vector implementation. For example unboxed and storable
+--   vectors will create vector filled with whatever underlying memory
+--   buffer happens to contain, while boxed vector initializes every
+--   element to @error "..."@.
 unsafeNew :: (PrimMonad m, Unbox a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew = G.unsafeNew

--- a/Data/Vector/Unboxed/Mutable.hs
+++ b/Data/Vector/Unboxed/Mutable.hs
@@ -156,11 +156,10 @@ new :: (PrimMonad m, Unbox a) => Int -> m (MVector (PrimState m) a)
 new = G.new
 
 -- | Create a mutable vector of the given length. The vector content
---   should be presumed uninitialized. However exact semantics depends
---   on vector implementation. For example unboxed and storable
---   vectors will create vector filled with whatever underlying memory
---   buffer happens to contain, while boxed vector initializes every
---   element to @error "..."@.
+--   is uninitialized, which means it is filled with whatever underlying memory
+--   buffer happens to contain.
+--
+-- @since 0.5
 unsafeNew :: (PrimMonad m, Unbox a) => Int -> m (MVector (PrimState m) a)
 {-# INLINE unsafeNew #-}
 unsafeNew = G.unsafeNew


### PR DESCRIPTION
At the moment only checked that MINIMAL is indeed minimal and no method is ⊥ by visual inspection

Fixes #11