### PR TITLE
Bring back `mkType` function and deprecate it. Fix #287 Also:

### DIFF
--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -165,7 +165,7 @@ module Data.Vector.Generic (
   liftShowsPrec, liftReadsPrec,
 
   -- ** @Data@ and @Typeable@
-  gfoldl, gunfold, dataCast, mkVecType, mkVecConstr
+  gfoldl, gunfold, dataCast, mkVecType, mkVecConstr, mkType
 ) where
 
 import           Data.Vector.Generic.Base
@@ -212,9 +212,18 @@ import Data.Typeable ( Typeable1, gcast1 )
 #include "vector.h"
 
 import Data.Data ( Data, DataType, Constr, Fixity(Prefix),
-                   mkDataType, mkConstr, constrIndex )
-
+                   mkDataType, mkConstr, constrIndex,
+#if MIN_VERSION_base(4,2,0)
+                   mkNoRepType )
+#else
+                   mkNorepType )
+#endif
 import qualified Data.Traversable as T (Traversable(mapM))
+
+#if !MIN_VERSION_base(4,2,0)
+mkNoRepType :: String -> DataType
+mkNoRepType = mkNorepType
+#endif
 
 -- Length information
 -- ------------------
@@ -2208,6 +2217,10 @@ mkVecConstr name = mkConstr (mkVecType name) "fromList" [] Prefix
 mkVecType :: String -> DataType
 {-# INLINE mkVecType #-}
 mkVecType name = mkDataType name [mkVecConstr name]
+
+mkType :: String -> DataType
+{-# INLINE mkType #-}
+mkType = mkNoRepType
 
 gunfold :: (Vector v a, Data a)
         => (forall b r. Data b => c (b -> r) -> c r)

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,11 @@
-# Changes in version 0.12.1.1
+# Changes in version 0.12.1.2
+
+ * Fix for lost function `Data.Vector.Generic.mkType`: [#287](https://github.com/haskell/vector/issues/287)
+
+# Changes in version 0.12.1.1 (deprecated)
  * add semigrioups dep to test suite so CI actually runs again on GHC < 8
 
-# Changes in version 0.12.1.0
+# Changes in version 0.12.1.0 (deprecated)
  * Fix integer overflows in specializations of Bundle/Stream enumFromTo on Integral types
  * Fix possibility of OutOfMemory with `take` and very large arguments.
  * Fix `slice` function causing segfault and not checking the bounds properly.
@@ -22,23 +26,22 @@
    `All`, `Alt`, and `Compose`.
  * Add `NFData1` instances for applicable `Vector` types.
 
-#Changes in version 0.12.0.3
+# Changes in version 0.12.0.3
   * Monad Fail support
 
-#Changes in version 0.12.0.2
+# Changes in version 0.12.0.2
   * Fixes issue #220, compact heap operations crashing on boxed vectors constructed
     using traverse.
   * backport injective type family support
   * Cleanup the memset code internal to storable vector modules to be
     compatible with future Primitive releases
 
-
-#Changes in version 0.12.0.1
+# Changes in version 0.12.0.1
 
  * Make sure `length` can be inlined
  * Include modules that test-suites depend on in other-modules
 
-#Changes in version 0.12.0.0
+# Changes in version 0.12.0.0
 
  * Documentation fixes/additions
  * New functions: createT, iscanl/r, iterateNM, unfoldrM, uniq
@@ -50,7 +53,7 @@
    helper functions.
  * Relax context for `Unbox (Complex a)`.
 
-#Changes in version 0.11.0.0
+# Changes in version 0.11.0.0
 
  * Define `Applicative` instances for `Data.Vector.Fusion.Util.{Box,Id}`
  * Define non-bottom `fail` for `instance Monad Vector`
@@ -60,50 +63,50 @@
    - Memory is initialized on creation of unboxed vectors
  * Changes to SPEC usage to allow building under more conditions
 
-#Changes in version 0.10.12.3
+# Changes in version 0.10.12.3
 
  * Allow building with `primtive-0.6`
 
-#Changes in version 0.10.12.2
+# Changes in version 0.10.12.2
 
  * Add support for `deepseq-1.4.0.0`
 
-#Changes in version 0.10.12.1
+# Changes in version 0.10.12.1
 
  * Fixed compilation on non-head GHCs
 
-#Changes in version 0.10.12.0
+# Changes in version 0.10.12.0
 
  * Export MVector constructor from Data.Vector.Primitive to match Vector's
    (which was already exported).
 
  * Fix building on GHC 7.9 by adding Applicative instances for Id and Box
 
-#Changes in version 0.10.11.0
+# Changes in version 0.10.11.0
 
  * Support OverloadedLists for boxed Vector in GHC >= 7.8
 
-#Changes in version 0.10.10.0
+# Changes in version 0.10.10.0
 
  * Minor version bump to rectify PVP violation occured in 0.10.9.3 release
 
-#Changes in version 0.10.9.3 (deprecated)
+# Changes in version 0.10.9.3 (deprecated)
 
  * Add support for OverloadedLists in GHC >= 7.8
 
-#Changes in version 0.10.9.2
+# Changes in version 0.10.9.2
 
  * Fix compilation with GHC 7.9
 
-#Changes in version 0.10.9.1
+# Changes in version 0.10.9.1
 
  * Implement poly-kinded Typeable
 
-#Changes in version 0.10.0.1
+# Changes in version 0.10.0.1
 
  * Require `primitive` to include workaround for a GHC array copying bug
 
-#Changes in version 0.10
+# Changes in version 0.10
 
  * `NFData` instances
  * More efficient block fills

--- a/vector.cabal
+++ b/vector.cabal
@@ -1,5 +1,5 @@
 Name:           vector
-Version:        0.12.1.1
+Version:        0.12.1.2
 -- don't forget to update the changelog file!
 License:        BSD3
 License-File:   LICENSE


### PR DESCRIPTION
* Bump up the version in cabal and update changelog.
* Fix markdown header formatting in changelog.

@lehins  i botched up the metadata, but made the diff less noisy