### PR TITLE
Export unstreamM from Data.Vector.Generic

### DIFF
--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -149,7 +149,7 @@ module Data.Vector.Generic (
   -- * Fusion support
 
   -- ** Conversion to/from Bundles
-  stream, unstream, streamR, unstreamR,
+  stream, unstream, unstreamM, streamR, unstreamR,
 
   -- ** Recycling support
   new, clone,


### PR DESCRIPTION
I don't think there's any good reason for not exporting this functions and its
lack caused problems for users (#70).

Fixes #70