### PR TITLE
Forward port changes from 0.12.1 branch

### DIFF
--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -2210,7 +2210,7 @@ mkVecType name = mkDataType name [mkVecConstr name]
 
 mkType :: String -> DataType
 {-# INLINE mkType #-}
-{-# DEPRECATE mkType "Use Data.Data.mkNoRepType: #-}
+{-# DEPRECATED mkType "Use Data.Data.mkNoRepType" #-}
 mkType = mkNoRepType
 
 gunfold :: (Vector v a, Data a)

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -165,7 +165,7 @@ module Data.Vector.Generic (
   liftShowsPrec, liftReadsPrec,
 
   -- ** @Data@ and @Typeable@
-  gfoldl, gunfold, dataCast, mkVecType, mkVecConstr
+  gfoldl, gunfold, dataCast, mkVecType, mkVecConstr, mkType
 ) where
 
 import           Data.Vector.Generic.Base
@@ -212,9 +212,18 @@ import Data.Typeable ( Typeable1, gcast1 )
 #include "vector.h"
 
 import Data.Data ( Data, DataType, Constr, Fixity(Prefix),
-                   mkDataType, mkConstr, constrIndex )
-
+                   mkDataType, mkConstr, constrIndex,
+#if MIN_VERSION_base(4,2,0)
+                   mkNoRepType )
+#else
+                   mkNorepType )
+#endif
 import qualified Data.Traversable as T (Traversable(mapM))
+
+#if !MIN_VERSION_base(4,2,0)
+mkNoRepType :: String -> DataType
+mkNoRepType = mkNorepType
+#endif
 
 -- Length information
 -- ------------------
@@ -2208,6 +2217,10 @@ mkVecConstr name = mkConstr (mkVecType name) "fromList" [] Prefix
 mkVecType :: String -> DataType
 {-# INLINE mkVecType #-}
 mkVecType name = mkDataType name [mkVecConstr name]
+
+mkType :: String -> DataType
+{-# INLINE mkType #-}
+mkType = mkNoRepType
 
 gunfold :: (Vector v a, Data a)
         => (forall b r. Data b => c (b -> r) -> c r)

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -212,18 +212,8 @@ import Data.Typeable ( Typeable1, gcast1 )
 #include "vector.h"
 
 import Data.Data ( Data, DataType, Constr, Fixity(Prefix),
-                   mkDataType, mkConstr, constrIndex,
-#if MIN_VERSION_base(4,2,0)
-                   mkNoRepType )
-#else
-                   mkNorepType )
-#endif
+                   mkDataType, mkConstr, constrIndex, mkNoRepType )
 import qualified Data.Traversable as T (Traversable(mapM))
-
-#if !MIN_VERSION_base(4,2,0)
-mkNoRepType :: String -> DataType
-mkNoRepType = mkNorepType
-#endif
 
 -- Length information
 -- ------------------

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -2210,6 +2210,7 @@ mkVecType name = mkDataType name [mkVecConstr name]
 
 mkType :: String -> DataType
 {-# INLINE mkType #-}
+{-# DEPRECATE mkType "Use Data.Data.mkNoRepType: #-}
 mkType = mkNoRepType
 
 gunfold :: (Vector v a, Data a)

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,11 @@
-# Changes in version 0.12.1.1
+# Changes in version 0.12.1.2
+
+ * Fix for lost function `Data.Vector.Generic.mkType`: [#287](https://github.com/haskell/vector/issues/287)
+
+# Changes in version 0.12.1.1 (deprecated)
  * add semigrioups dep to test suite so CI actually runs again on GHC < 8
 
-# Changes in version 0.12.1.0
+# Changes in version 0.12.1.0 (deprecated)
  * Fix integer overflows in specializations of Bundle/Stream enumFromTo on Integral types
  * Fix possibility of OutOfMemory with `take` and very large arguments.
  * Fix `slice` function causing segfault and not checking the bounds properly.
@@ -22,23 +26,22 @@
    `All`, `Alt`, and `Compose`.
  * Add `NFData1` instances for applicable `Vector` types.
 
-#Changes in version 0.12.0.3
+# Changes in version 0.12.0.3
   * Monad Fail support
 
-#Changes in version 0.12.0.2
+# Changes in version 0.12.0.2
   * Fixes issue #220, compact heap operations crashing on boxed vectors constructed
     using traverse.
   * backport injective type family support
   * Cleanup the memset code internal to storable vector modules to be
     compatible with future Primitive releases
 
-
-#Changes in version 0.12.0.1
+# Changes in version 0.12.0.1
 
  * Make sure `length` can be inlined
  * Include modules that test-suites depend on in other-modules
 
-#Changes in version 0.12.0.0
+# Changes in version 0.12.0.0
 
  * Documentation fixes/additions
  * New functions: createT, iscanl/r, iterateNM, unfoldrM, uniq
@@ -50,7 +53,7 @@
    helper functions.
  * Relax context for `Unbox (Complex a)`.
 
-#Changes in version 0.11.0.0
+# Changes in version 0.11.0.0
 
  * Define `Applicative` instances for `Data.Vector.Fusion.Util.{Box,Id}`
  * Define non-bottom `fail` for `instance Monad Vector`
@@ -60,50 +63,50 @@
    - Memory is initialized on creation of unboxed vectors
  * Changes to SPEC usage to allow building under more conditions
 
-#Changes in version 0.10.12.3
+# Changes in version 0.10.12.3
 
  * Allow building with `primtive-0.6`
 
-#Changes in version 0.10.12.2
+# Changes in version 0.10.12.2
 
  * Add support for `deepseq-1.4.0.0`
 
-#Changes in version 0.10.12.1
+# Changes in version 0.10.12.1
 
  * Fixed compilation on non-head GHCs
 
-#Changes in version 0.10.12.0
+# Changes in version 0.10.12.0
 
  * Export MVector constructor from Data.Vector.Primitive to match Vector's
    (which was already exported).
 
  * Fix building on GHC 7.9 by adding Applicative instances for Id and Box
 
-#Changes in version 0.10.11.0
+# Changes in version 0.10.11.0
 
  * Support OverloadedLists for boxed Vector in GHC >= 7.8
 
-#Changes in version 0.10.10.0
+# Changes in version 0.10.10.0
 
  * Minor version bump to rectify PVP violation occured in 0.10.9.3 release
 
-#Changes in version 0.10.9.3 (deprecated)
+# Changes in version 0.10.9.3 (deprecated)
 
  * Add support for OverloadedLists in GHC >= 7.8
 
-#Changes in version 0.10.9.2
+# Changes in version 0.10.9.2
 
  * Fix compilation with GHC 7.9
 
-#Changes in version 0.10.9.1
+# Changes in version 0.10.9.1
 
  * Implement poly-kinded Typeable
 
-#Changes in version 0.10.0.1
+# Changes in version 0.10.0.1
 
  * Require `primitive` to include workaround for a GHC array copying bug
 
-#Changes in version 0.10
+# Changes in version 0.10
 
  * `NFData` instances
  * More efficient block fills

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,37 @@
 
  * `mkType` from `Data.Vector.Generic` is deprecated in favor of
    `Data.Data.mkNoRepType`
+ * `maximumBy` now behaves like its counterpart in `Data.List` in that if
+   `maximumBy` has to choose between several elements which could be
+   considered the maximum, it will now choose the last element (previously,
+   it would choose the first element). Similarly, `maxIndexBy` will also
+   now pick the last element if several elements could be considered the
+   maximum.
+ * The role signatures on several `Vector` types were too permissive, so they
+   have been tightened up:
+   * The role signature for `Data.Vector.Mutable.MVector` is now
+     `type role MVector nominal representational` (previously, both arguments
+     were `phantom`).
+   * The role signature for `Data.Vector.Primitive.Vector` is now
+     `type role Vector representational` (previously, it was `phantom`).
+   * The role signature for `Data.Vector.Storable.Vector` is now
+     `type role Vector nominal` (previous, it was `phantom`), and the signature
+     for `Data.Vector.Storable.Mutable.MVector` is now
+     `type role MVector nominal nominal` (previous, both arguments were
+     `phantom`).
+
+     We pick `nominal` for the role of the last argument instead of
+     `representational` since the internal structure of a `Storable` vector
+     is determined by the `Storable` instance of the element type, and it is
+     not guaranteed that the `Storable` instances between two
+     representationally equal types will preserve this internal structure.
+     One consequence of this choice is that it is no longer possible to
+     `coerce` between `Storable.Vector a` and `Storable.Vector b` if `a` and
+     `b` are nominally distinct but representationally equal types. We now
+     provide `unsafeCoerce{M}Vector` functions in
+     `Data.Vector.Storable{.Mutable}` to allow this (the onus is on the user
+     to ensure that no `Storable` invariants are broken when using these
+     functions).
 
 # Changes in version 0.12.1.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,39 +9,7 @@ Changes in version next
  * fast rejection short circuiting in eqBy operations
  * the O2 test suite now has reasonable memory usage on every GHC version,
     special thanks to Alexey Kuleshevich (@lehins).
- * `maximumBy` now behaves like its counterpart in `Data.List` in that if
-   `maximumBy` has to choose between several elements which could be
-   considered the maximum, it will now choose the last element (previously,
-   it would choose the first element). Similarly, `maxIndexBy` will also
-   now pick the last element if several elements could be considered the
-   maximum.
 
-TODO: should this be in the next release
- * The role signatures on several `Vector` types were too permissive, so they
-   have been tightened up:
-   * The role signature for `Data.Vector.Mutable.MVector` is now
-     `type role MVector nominal representational` (previously, both arguments
-     were `phantom`).
-   * The role signature for `Data.Vector.Primitive.Vector` is now
-     `type role Vector representational` (previously, it was `phantom`).
-   * The role signature for `Data.Vector.Storable.Vector` is now
-     `type role Vector nominal` (previous, it was `phantom`), and the signature
-     for `Data.Vector.Storable.Mutable.MVector` is now
-     `type role MVector nominal nominal` (previous, both arguments were
-     `phantom`).
-
-     We pick `nominal` for the role of the last argument instead of
-     `representational` since the internal structure of a `Storable` vector
-     is determined by the `Storable` instance of the element type, and it is
-     not guaranteed that the `Storable` instances between two
-     representationally equal types will preserve this internal structure.
-     One consequence of this choice is that it is no longer possible to
-     `coerce` between `Storable.Vector a` and `Storable.Vector b` if `a` and
-     `b` are nominally distinct but representationally equal types. We now
-     provide `unsafeCoerce{M}Vector` functions in
-     `Data.Vector.Storable{.Mutable}` to allow this (the onus is on the user
-     to ensure that no `Storable` invariants are broken when using these
-     functions).
  * The `Mutable` type family is now injective on GHC 8.0 or later.
  * Using empty `Storable` vectors no longer results in division-by-zero
    errors.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# Changes in NEXT_VERSION
+
+ * `mkType` from `Data.Vector.Generic` is deprecated in favor of
+   `Data.Data.mkNoRepType`
+
 # Changes in version 0.12.1.2
 
  * Fix for lost function `Data.Vector.Generic.mkType`: [#287](https://github.com/haskell/vector/issues/287)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Changes in version 0.12.1.1
+ * add semigrioups dep to test suite so CI actually runs again on GHC < 8
+
 # Changes in version 0.12.1.0
  * Fix integer overflows in specializations of Bundle/Stream enumFromTo on Integral types
  * Fix possibility of OutOfMemory with `take` and very large arguments.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,4 @@
-Changes in version next
-
+# Changes in version 0.12.1.0
  * Fix integer overflows in specializations of Bundle/Stream enumFromTo on Integral types
  * Fix possibility of OutOfMemory with `take` and very large arguments.
  * Fix `slice` function causing segfault and not checking the bounds properly.
@@ -9,7 +8,6 @@ Changes in version next
  * fast rejection short circuiting in eqBy operations
  * the O2 test suite now has reasonable memory usage on every GHC version,
     special thanks to Alexey Kuleshevich (@lehins).
-
  * The `Mutable` type family is now injective on GHC 8.0 or later.
  * Using empty `Storable` vectors no longer results in division-by-zero
    errors.
@@ -21,10 +19,10 @@ Changes in version next
    `All`, `Alt`, and `Compose`.
  * Add `NFData1` instances for applicable `Vector` types.
 
-Changes in version 0.12.0.3
+#Changes in version 0.12.0.3
   * Monad Fail support
 
-Changes in version 0.12.0.2
+#Changes in version 0.12.0.2
   * Fixes issue #220, compact heap operations crashing on boxed vectors constructed
     using traverse.
   * backport injective type family support
@@ -32,12 +30,12 @@ Changes in version 0.12.0.2
     compatible with future Primitive releases
 
 
-Changes in version 0.12.0.1
+#Changes in version 0.12.0.1
 
  * Make sure `length` can be inlined
  * Include modules that test-suites depend on in other-modules
 
-Changes in version 0.12.0.0
+#Changes in version 0.12.0.0
 
  * Documentation fixes/additions
  * New functions: createT, iscanl/r, iterateNM, unfoldrM, uniq
@@ -49,7 +47,7 @@ Changes in version 0.12.0.0
    helper functions.
  * Relax context for `Unbox (Complex a)`.
 
-Changes in version 0.11.0.0
+#Changes in version 0.11.0.0
 
  * Define `Applicative` instances for `Data.Vector.Fusion.Util.{Box,Id}`
  * Define non-bottom `fail` for `instance Monad Vector`
@@ -59,50 +57,50 @@ Changes in version 0.11.0.0
    - Memory is initialized on creation of unboxed vectors
  * Changes to SPEC usage to allow building under more conditions
 
-Changes in version 0.10.12.3
+#Changes in version 0.10.12.3
 
  * Allow building with `primtive-0.6`
 
-Changes in version 0.10.12.2
+#Changes in version 0.10.12.2
 
  * Add support for `deepseq-1.4.0.0`
 
-Changes in version 0.10.12.1
+#Changes in version 0.10.12.1
 
  * Fixed compilation on non-head GHCs
 
-Changes in version 0.10.12.0
+#Changes in version 0.10.12.0
 
  * Export MVector constructor from Data.Vector.Primitive to match Vector's
    (which was already exported).
 
  * Fix building on GHC 7.9 by adding Applicative instances for Id and Box
 
-Changes in version 0.10.11.0
+#Changes in version 0.10.11.0
 
  * Support OverloadedLists for boxed Vector in GHC >= 7.8
 
-Changes in version 0.10.10.0
+#Changes in version 0.10.10.0
 
  * Minor version bump to rectify PVP violation occured in 0.10.9.3 release
 
-Changes in version 0.10.9.3 (deprecated)
+#Changes in version 0.10.9.3 (deprecated)
 
  * Add support for OverloadedLists in GHC >= 7.8
 
-Changes in version 0.10.9.2
+#Changes in version 0.10.9.2
 
  * Fix compilation with GHC 7.9
 
-Changes in version 0.10.9.1
+#Changes in version 0.10.9.1
 
  * Implement poly-kinded Typeable
 
-Changes in version 0.10.0.1
+#Changes in version 0.10.0.1
 
  * Require `primitive` to include workaround for a GHC array copying bug
 
-Changes in version 0.10
+#Changes in version 0.10
 
  * `NFData` instances
  * More efficient block fills

--- a/tests/Boilerplater.hs
+++ b/tests/Boilerplater.hs
@@ -1,6 +1,6 @@
 module Boilerplater where
 
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty.QuickCheck
 
 import Language.Haskell.TH
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,10 +5,10 @@ import qualified Tests.Vector.UnitTests
 import qualified Tests.Bundle
 import qualified Tests.Move
 
-import Test.Framework (defaultMain)
+import Test.Tasty (defaultMain,testGroup)
 
 main :: IO ()
-main = defaultMain $ Tests.Bundle.tests
+main = defaultMain $ testGroup "toplevel" $ Tests.Bundle.tests
                   ++ Tests.Vector.tests
                   ++ Tests.Vector.UnitTests.tests
                   ++ Tests.Move.tests

--- a/tests/Tests/Bundle.hs
+++ b/tests/Tests/Bundle.hs
@@ -7,11 +7,14 @@ import qualified Data.Vector.Fusion.Bundle as S
 
 import Test.QuickCheck
 
-import Test.Framework
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty
+import Test.Tasty.QuickCheck hiding (testProperties)
 
 import Text.Show.Functions ()
 import Data.List           (foldl', foldl1', unfoldr, find, findIndex)
+
+-- migration from testframework to tasty
+type Test = TestTree
 
 #define COMMON_CONTEXT(a) \
  VANILLA_CONTEXT(a)

--- a/tests/Tests/Move.hs
+++ b/tests/Tests/Move.hs
@@ -1,7 +1,7 @@
 module Tests.Move (tests) where
 
 import Test.QuickCheck
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty.QuickCheck
 import Test.QuickCheck.Property (Property(..))
 
 import Utilities ()

--- a/tests/Tests/Vector.hs
+++ b/tests/Tests/Vector.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector (tests) where
 
-import Test.Framework (testGroup)
+import Test.Tasty (testGroup)
 import qualified Tests.Vector.Boxed
 import qualified Tests.Vector.Primitive
 import qualified Tests.Vector.Storable

--- a/tests/Tests/Vector/Boxed.hs
+++ b/tests/Tests/Vector/Boxed.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector.Boxed (tests) where
 
-import Test.Framework
+import Test.Tasty
 import qualified Data.Vector
 import Tests.Vector.Property
 

--- a/tests/Tests/Vector/Primitive.hs
+++ b/tests/Tests/Vector/Primitive.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector.Primitive (tests) where
 
-import Test.Framework
+import Test.Tasty
 import qualified Data.Vector.Primitive
 import Tests.Vector.Property
 

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -20,6 +20,7 @@ module Tests.Vector.Property
   -- re-exports
   , Data
   , Random
+  ,Test
   ) where
 
 import Boilerplater
@@ -35,8 +36,8 @@ import qualified Data.Vector.Fusion.Bundle as S
 
 import Test.QuickCheck
 
-import Test.Framework
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty
+import Test.Tasty.QuickCheck hiding (testProperties)
 
 import Text.Show.Functions ()
 import Data.List
@@ -57,6 +58,8 @@ type VanillaContext a   = ( Eq a , Show a, Arbitrary a, CoArbitrary a
 type VectorContext  a v = ( Eq (v a), Show (v a), Arbitrary (v a), CoArbitrary (v a)
                           , TestData (v a), Model (v a) ~ [a],  EqTest (v a) ~ Property, V.Vector v a)
 
+-- | migration hack for moving from TestFramework to Tasty
+type Test = TestTree
 -- TODO: implement Vector equivalents of list functions for some of the commented out properties
 
 -- TODO: test and implement some of these other Prelude functions:

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -528,14 +528,13 @@ testOrdFunctions _ = $(testProperties
     prop_maximum :: P (v a -> a) = not . V.null ===> V.maximum `eq` maximum
     prop_minimum :: P (v a -> a) = not . V.null ===> V.minimum `eq` minimum
     prop_minIndex :: P (v a -> Int) = not . V.null ===> V.minIndex `eq` minIndex
-    prop_maxIndex :: P (v a -> Int) = not . V.null ===> V.maxIndex `eq` listMaxIndexFMW
+    prop_maxIndex :: P (v a -> Int) = not . V.null ===> V.maxIndex `eq` maxIndex
     prop_maximumBy :: P (v a -> a) =
       not . V.null ===> V.maximumBy compare `eq` maximum
     prop_minimumBy :: P (v a -> a) =
       not . V.null ===> V.minimumBy compare `eq` minimum
     prop_maxIndexBy :: P (v a -> Int) =
-      not . V.null ===> V.maxIndexBy compare `eq`  listMaxIndexFMW
-                                          ---   (maxIndex)
+      not . V.null ===> V.maxIndexBy compare `eq` maxIndex
     prop_ListLastMaxIndexWins ::  P (v a -> Int) =
         not . V.null ===> ( maxIndex . V.toList) `eq` listMaxIndexLMW
     prop_FalseListFirstMaxIndexWinsDesc ::  P (v a -> Int) =

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -522,7 +522,7 @@ testOrdFunctions _ = $(testProperties
    'prop_minIndex, 'prop_maxIndex,
    'prop_maximumBy, 'prop_minimumBy,
    'prop_maxIndexBy, 'prop_minIndexBy,
-   'prop_ListLastMaxIndexWins ])
+   'prop_ListLastMaxIndexWins, 'prop_FalseListFirstMaxIndexWins ])
   where
     prop_compare :: P (v a -> v a -> Ordering) = compare `eq` compare
     prop_maximum :: P (v a -> a) = not . V.null ===> V.maximum `eq` maximum

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -30,7 +30,7 @@ import Data.Functor.Identity
 import qualified Data.Traversable as T (Traversable(..))
 import Data.Foldable (Foldable(foldMap))
 import Data.Orphans ()
-
+import Data.Monoid
 import qualified Data.Vector.Generic as V
 import qualified Data.Vector.Fusion.Bundle as S
 

--- a/tests/Tests/Vector/Storable.hs
+++ b/tests/Tests/Vector/Storable.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector.Storable (tests) where
 
-import Test.Framework
+import Test.Tasty
 import qualified Data.Vector.Storable
 import Tests.Vector.Property
 

--- a/tests/Tests/Vector/Unboxed.hs
+++ b/tests/Tests/Vector/Unboxed.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector.Unboxed (tests) where
 
-import Test.Framework
+import Test.Tasty
 import qualified Data.Vector.Unboxed
 import Tests.Vector.Property
+
 
 
 testGeneralUnboxedVector :: forall a. (CommonContext a Data.Vector.Unboxed.Vector, Data.Vector.Unboxed.Unbox a, Ord a, Data a) => Data.Vector.Unboxed.Vector a -> [Test]

--- a/tests/Tests/Vector/UnitTests.hs
+++ b/tests/Tests/Vector/UnitTests.hs
@@ -20,9 +20,9 @@ import Foreign.Ptr
 import Foreign.Storable
 import Text.Printf
 
-import Test.Framework
-import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit (Assertion, assertBool, (@=?), assertFailure)
+import Test.Tasty
+import Test.Tasty.HUnit (testCase,Assertion, assertBool, (@=?), assertFailure)
+-- import Test.HUnit ()
 
 newtype Aligned a = Aligned { getAligned :: a }
 
@@ -43,7 +43,7 @@ checkAddressAlignment xs = Storable.unsafeWith xs $ \ptr -> do
     dummy :: a
     dummy = undefined
 
-tests :: [Test]
+tests :: [TestTree]
 tests =
   [ testGroup "Data.Vector.Storable.Vector Alignment"
       [ testCase "Aligned Double" $
@@ -83,7 +83,7 @@ tests =
   ]
 
 testsSliceOutOfBounds ::
-     (Show (v Int), Generic.Vector v Int) => (Int -> Int -> v Int -> v Int) -> [Test]
+     (Show (v Int), Generic.Vector v Int) => (Int -> Int -> v Int -> v Int) -> [TestTree]
 testsSliceOutOfBounds sliceWith =
   [ testCase "Negative ix" $ sliceTest sliceWith (-2) 2 xs
   , testCase "Negative size" $ sliceTest sliceWith 2 (-2) xs
@@ -139,7 +139,7 @@ testTakeOutOfMemory takeWith =
 
 regression188
   :: forall proxy a. (Typeable a, Enum a, Bounded a, Eq a, Show a)
-  => proxy a -> Test
+  => proxy a -> TestTree
 regression188 _ = testCase (show (typeOf (undefined :: a)))
   $ Vector.fromList [maxBound::a] @=? Vector.enumFromTo maxBound maxBound
 {-# INLINE regression188 #-}

--- a/vector.cabal
+++ b/vector.cabal
@@ -204,8 +204,8 @@ test-suite vector-tests-O0
   hs-source-dirs: tests
   Build-Depends: base >= 4.5 && < 5, template-haskell, base-orphans >= 0.6, vector,
                  primitive, random,
-                 QuickCheck >= 2.9 && < 2.14 , HUnit, test-framework,
-                 test-framework-hunit, test-framework-quickcheck2,
+                 QuickCheck >= 2.9 && < 2.14 , HUnit, tasty,
+                 tasty-hunit, tasty-quickcheck,
                  transformers >= 0.2.0.0
 
   default-extensions: CPP,
@@ -218,7 +218,7 @@ test-suite vector-tests-O0
               TypeFamilies,
               TemplateHaskell
 
-  Ghc-Options: -O0
+  Ghc-Options: -O0 -threaded
   Ghc-Options: -Wall
 
   if !flag(Wall)
@@ -247,8 +247,8 @@ test-suite vector-tests-O2
   hs-source-dirs: tests
   Build-Depends: base >= 4.5 && < 5, template-haskell, base-orphans >= 0.6, vector,
                  primitive, random,
-                 QuickCheck >= 2.9 && < 2.14 , HUnit, test-framework,
-                 test-framework-hunit, test-framework-quickcheck2,
+                 QuickCheck >= 2.9 && < 2.14 , HUnit,  tasty,
+                 tasty-hunit, tasty-quickcheck,
                  transformers >= 0.2.0.0
 
   default-extensions: CPP,
@@ -262,7 +262,7 @@ test-suite vector-tests-O2
               TemplateHaskell
 
   Ghc-Options: -Wall
-  Ghc-Options:  -O2
+  Ghc-Options:  -O2 -threaded
   if !flag(Wall)
     Ghc-Options: -fno-warn-orphans -fno-warn-missing-signatures
     if impl(ghc >= 8.0) && impl(ghc < 8.1)

--- a/vector.cabal
+++ b/vector.cabal
@@ -99,7 +99,6 @@ Flag Wall
   Manual: True
 
 
-
 Library
   Default-Language: Haskell2010
   Other-Extensions:

--- a/vector.cabal
+++ b/vector.cabal
@@ -205,7 +205,7 @@ test-suite vector-tests-O0
                  primitive, random,
                  QuickCheck >= 2.9 && < 2.14 , HUnit, tasty,
                  tasty-hunit, tasty-quickcheck,
-                 transformers >= 0.2.0.0
+                 transformers >= 0.2.0.0,semigroups
 
   default-extensions: CPP,
               ScopedTypeVariables,
@@ -248,7 +248,7 @@ test-suite vector-tests-O2
                  primitive, random,
                  QuickCheck >= 2.9 && < 2.14 , HUnit,  tasty,
                  tasty-hunit, tasty-quickcheck,
-                 transformers >= 0.2.0.0
+                 transformers >= 0.2.0.0,semigroups
 
   default-extensions: CPP,
               ScopedTypeVariables,


### PR DESCRIPTION
What is ported:

 - Changelog updates
 - Transition from test-framework to tasty
 - mkType (#287) is restored but deprecated
 - New tests for maxIndex & Co. I had to change them because of change of behavior