### PR TITLE
Wip/carter/forward port 0.12.1 tests into master

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,25 @@ TODO: should this be in the next release
      `Data.Vector.Storable{.Mutable}` to allow this (the onus is on the user
      to ensure that no `Storable` invariants are broken when using these
      functions).
+
+# Changes in version 0.12.1.2
+
+ * Fix for lost function `Data.Vector.Generic.mkType`: [#287](https://github.com/haskell/vector/issues/287)
+ * all the changes in 0.12.1.0 and 0.12.1.1
+
+# Changes in version 0.12.1.1 (deprecated)
+ * add semigrioups dep to test suite so CI actually runs again on GHC < 8
+
+# Changes in version 0.12.1.0 (deprecated)
+ * Fix integer overflows in specializations of Bundle/Stream enumFromTo on Integral types
+ * Fix possibility of OutOfMemory with `take` and very large arguments.
+ * Fix `slice` function causing segfault and not checking the bounds properly.
+ * updated specialization rule for EnumFromTo on Float and Double
+  to make sure it always matches the version in GHC Base (which changed as of 8.6)
+  Thanks to Aleksey Khudyakov @Shimuuar for this fix.
+ * fast rejection short circuiting in eqBy operations
+ * the O2 test suite now has reasonable memory usage on every GHC version,
+    special thanks to Alexey Kuleshevich (@lehins).
  * The `Mutable` type family is now injective on GHC 8.0 or later.
  * Using empty `Storable` vectors no longer results in division-by-zero
    errors.
@@ -53,23 +72,22 @@ TODO: should this be in the next release
    `All`, `Alt`, and `Compose`.
  * Add `NFData1` instances for applicable `Vector` types.
 
-Changes in version 0.12.0.3
+# Changes in version 0.12.0.3
   * Monad Fail support
 
-Changes in version 0.12.0.2
+# Changes in version 0.12.0.2
   * Fixes issue #220, compact heap operations crashing on boxed vectors constructed
     using traverse.
   * backport injective type family support
   * Cleanup the memset code internal to storable vector modules to be
     compatible with future Primitive releases
 
-
-Changes in version 0.12.0.1
+# Changes in version 0.12.0.1
 
  * Make sure `length` can be inlined
  * Include modules that test-suites depend on in other-modules
 
-Changes in version 0.12.0.0
+# Changes in version 0.12.0.0
 
  * Documentation fixes/additions
  * New functions: createT, iscanl/r, iterateNM, unfoldrM, uniq
@@ -81,7 +99,7 @@ Changes in version 0.12.0.0
    helper functions.
  * Relax context for `Unbox (Complex a)`.
 
-Changes in version 0.11.0.0
+# Changes in version 0.11.0.0
 
  * Define `Applicative` instances for `Data.Vector.Fusion.Util.{Box,Id}`
  * Define non-bottom `fail` for `instance Monad Vector`
@@ -91,50 +109,50 @@ Changes in version 0.11.0.0
    - Memory is initialized on creation of unboxed vectors
  * Changes to SPEC usage to allow building under more conditions
 
-Changes in version 0.10.12.3
+# Changes in version 0.10.12.3
 
  * Allow building with `primtive-0.6`
 
-Changes in version 0.10.12.2
+# Changes in version 0.10.12.2
 
  * Add support for `deepseq-1.4.0.0`
 
-Changes in version 0.10.12.1
+# Changes in version 0.10.12.1
 
  * Fixed compilation on non-head GHCs
 
-Changes in version 0.10.12.0
+# Changes in version 0.10.12.0
 
  * Export MVector constructor from Data.Vector.Primitive to match Vector's
    (which was already exported).
 
  * Fix building on GHC 7.9 by adding Applicative instances for Id and Box
 
-Changes in version 0.10.11.0
+# Changes in version 0.10.11.0
 
  * Support OverloadedLists for boxed Vector in GHC >= 7.8
 
-Changes in version 0.10.10.0
+# Changes in version 0.10.10.0
 
  * Minor version bump to rectify PVP violation occured in 0.10.9.3 release
 
-Changes in version 0.10.9.3 (deprecated)
+# Changes in version 0.10.9.3 (deprecated)
 
  * Add support for OverloadedLists in GHC >= 7.8
 
-Changes in version 0.10.9.2
+# Changes in version 0.10.9.2
 
  * Fix compilation with GHC 7.9
 
-Changes in version 0.10.9.1
+# Changes in version 0.10.9.1
 
  * Implement poly-kinded Typeable
 
-Changes in version 0.10.0.1
+# Changes in version 0.10.0.1
 
  * Require `primitive` to include workaround for a GHC array copying bug
 
-Changes in version 0.10
+# Changes in version 0.10
 
  * `NFData` instances
  * More efficient block fills

--- a/tests/Boilerplater.hs
+++ b/tests/Boilerplater.hs
@@ -1,6 +1,6 @@
 module Boilerplater where
 
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty.QuickCheck
 
 import Language.Haskell.TH
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,10 +5,10 @@ import qualified Tests.Vector.UnitTests
 import qualified Tests.Bundle
 import qualified Tests.Move
 
-import Test.Framework (defaultMain)
+import Test.Tasty (defaultMain,testGroup)
 
 main :: IO ()
-main = defaultMain $ Tests.Bundle.tests
+main = defaultMain $ testGroup "toplevel" $ Tests.Bundle.tests
                   ++ Tests.Vector.tests
                   ++ Tests.Vector.UnitTests.tests
                   ++ Tests.Move.tests

--- a/tests/Tests/Bundle.hs
+++ b/tests/Tests/Bundle.hs
@@ -7,11 +7,14 @@ import qualified Data.Vector.Fusion.Bundle as S
 
 import Test.QuickCheck
 
-import Test.Framework
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty
+import Test.Tasty.QuickCheck hiding (testProperties)
 
 import Text.Show.Functions ()
 import Data.List           (foldl', foldl1', unfoldr, find, findIndex)
+
+-- migration from testframework to tasty
+type Test = TestTree
 
 #define COMMON_CONTEXT(a) \
  VANILLA_CONTEXT(a)

--- a/tests/Tests/Move.hs
+++ b/tests/Tests/Move.hs
@@ -1,7 +1,7 @@
 module Tests.Move (tests) where
 
 import Test.QuickCheck
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty.QuickCheck
 import Test.QuickCheck.Property (Property(..))
 
 import Utilities ()

--- a/tests/Tests/Vector.hs
+++ b/tests/Tests/Vector.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector (tests) where
 
-import Test.Framework (testGroup)
+import Test.Tasty (testGroup)
 import qualified Tests.Vector.Boxed
 import qualified Tests.Vector.Primitive
 import qualified Tests.Vector.Storable

--- a/tests/Tests/Vector/Boxed.hs
+++ b/tests/Tests/Vector/Boxed.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector.Boxed (tests) where
 
-import Test.Framework
+import Test.Tasty
 import qualified Data.Vector
 import Tests.Vector.Property
 

--- a/tests/Tests/Vector/Primitive.hs
+++ b/tests/Tests/Vector/Primitive.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector.Primitive (tests) where
 
-import Test.Framework
+import Test.Tasty
 import qualified Data.Vector.Primitive
 import Tests.Vector.Property
 

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -525,7 +525,9 @@ testOrdFunctions _ = $(testProperties
    'prop_minIndex, 'prop_maxIndex,
    'prop_maximumBy, 'prop_minimumBy,
    'prop_maxIndexBy, 'prop_minIndexBy,
-   'prop_ListLastMaxIndexWins, 'prop_FalseListFirstMaxIndexWins ])
+   'prop_ListLastMaxIndexWins
+   -- 'prop_FalseListFirstMaxIndexWins
+    ])
   where
     prop_compare :: P (v a -> v a -> Ordering) = compare `eq` compare
     prop_maximum :: P (v a -> a) = not . V.null ===> V.maximum `eq` maximum

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -555,14 +555,18 @@ testOrdFunctions _ = $(testProperties
           ===> ( maxIndex . V.toList) `eq` listMaxIndexLMW
 
     prop_FalseListFirstMaxIndexWinsDesc ::  P (v a -> Int) =
-        (\x ->( not $ V.null x) && (V.uniq x /= x ) )
+        --(\x ->( not $ V.null x) && (V.uniq x /= x ) )
+        (not . V.null)
            ===>
            ( maxIndex . V.toList) `eq` listMaxIndexFMW
 
-    prop_FalseListFirstMaxIndexWins :: Property
-    prop_FalseListFirstMaxIndexWins = expectFailure prop_FalseListFirstMaxIndexWinsDesc
-    prop_minIndexBy :: P (v a -> Int) =
-      not . V.null ===> V.minIndexBy compare `eq` minIndex
+    ---TODO: can't use vanilla quickech instances for this contra positive
+    --- property until either in the test suite we copy the genreator from
+    --- https://github.com/nick8325/quickcheck/issues/295 is in our QC release version
+    --prop_FalseListFirstMaxIndexWins :: Property
+    --prop_FalseListFirstMaxIndexWins = expectFailure prop_FalseListFirstMaxIndexWinsDesc
+    --prop_minIndexBy :: P (v a -> Int) =
+    --  not . V.null ===> V.minIndexBy compare `eq` minIndex
 
 listMaxIndexFMW :: Ord a => [a] -> Int
 listMaxIndexFMW  = ( fst  . extractFMW .  sconcat . DLE.fromList . fmap FMW . zip [0 :: Int ..])

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -20,6 +20,7 @@ module Tests.Vector.Property
   -- re-exports
   , Data
   , Random
+  ,Test
   ) where
 
 import Boilerplater
@@ -35,8 +36,8 @@ import qualified Data.Vector.Fusion.Bundle as S
 
 import Test.QuickCheck
 
-import Test.Framework
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty
+import Test.Tasty.QuickCheck hiding (testProperties)
 
 import Text.Show.Functions ()
 import Data.List
@@ -57,6 +58,8 @@ type VanillaContext a   = ( Eq a , Show a, Arbitrary a, CoArbitrary a
 type VectorContext  a v = ( Eq (v a), Show (v a), Arbitrary (v a), CoArbitrary (v a)
                           , TestData (v a), Model (v a) ~ [a],  EqTest (v a) ~ Property, V.Vector v a)
 
+-- | migration hack for moving from TestFramework to Tasty
+type Test = TestTree
 -- TODO: implement Vector equivalents of list functions for some of the commented out properties
 
 -- TODO: test and implement some of these other Prelude functions:
@@ -514,7 +517,7 @@ testOrdFunctions _ = $(testProperties
    'prop_maximum, 'prop_minimum,
    'prop_minIndex, 'prop_maxIndex,
    'prop_maximumBy, 'prop_minimumBy,
-   'prop_maxIndexBy, 'prop_minIndexBy])
+   'prop_maxIndexBy, 'prop_minIndexBy,
   where
     prop_compare :: P (v a -> v a -> Ordering) = compare `eq` compare
     prop_maximum :: P (v a -> a) = not . V.null ===> V.maximum `eq` maximum

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -556,19 +556,22 @@ testOrdFunctions _ = $(testProperties
         not . V.null
           ===> ( maxIndex . V.toList) `eq` listMaxIndexLMW
 
-    prop_FalseListFirstMaxIndexWinsDesc ::  P (v a -> Int) =
+    prop_minIndexBy :: P (v a -> Int) =
+      not . V.null ===> V.minIndexBy compare `eq` minIndex
+     {-
+     prop_FalseListFirstMaxIndexWinsDesc ::  P (v a -> Int) =
         --(\x ->( not $ V.null x) && (V.uniq x /= x ) )
         (not . V.null)
            ===>
            ( maxIndex . V.toList) `eq` listMaxIndexFMW
 
-    ---TODO: can't use vanilla quickech instances for this contra positive
-    --- property until either in the test suite we copy the genreator from
+    ---TODO: can't use vanilla quickech instances for this negative
+    --- property until either in the test suite we copy the generator from
     --- https://github.com/nick8325/quickcheck/issues/295 is in our QC release version
-    --prop_FalseListFirstMaxIndexWins :: Property
-    --prop_FalseListFirstMaxIndexWins = expectFailure prop_FalseListFirstMaxIndexWinsDesc
-    --prop_minIndexBy :: P (v a -> Int) =
-    --  not . V.null ===> V.minIndexBy compare `eq` minIndex
+    prop_FalseListFirstMaxIndexWins :: Property
+    prop_FalseListFirstMaxIndexWins = expectFailure prop_FalseListFirstMaxIndexWinsDesc-}
+
+
 
 listMaxIndexFMW :: Ord a => [a] -> Int
 listMaxIndexFMW  = ( fst  . extractFMW .  sconcat . DLE.fromList . fmap FMW . zip [0 :: Int ..])

--- a/tests/Tests/Vector/Storable.hs
+++ b/tests/Tests/Vector/Storable.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector.Storable (tests) where
 
-import Test.Framework
+import Test.Tasty
 import qualified Data.Vector.Storable
 import Tests.Vector.Property
 

--- a/tests/Tests/Vector/Unboxed.hs
+++ b/tests/Tests/Vector/Unboxed.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Tests.Vector.Unboxed (tests) where
 
-import Test.Framework
+import Test.Tasty
 import qualified Data.Vector.Unboxed
 import Tests.Vector.Property
+
 
 
 testGeneralUnboxedVector :: forall a. (CommonContext a Data.Vector.Unboxed.Vector, Data.Vector.Unboxed.Unbox a, Ord a, Data a) => Data.Vector.Unboxed.Vector a -> [Test]

--- a/tests/Tests/Vector/UnitTests.hs
+++ b/tests/Tests/Vector/UnitTests.hs
@@ -20,9 +20,9 @@ import Foreign.Ptr
 import Foreign.Storable
 import Text.Printf
 
-import Test.Framework
-import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit (Assertion, assertBool, (@=?), assertFailure)
+import Test.Tasty
+import Test.Tasty.HUnit (testCase,Assertion, assertBool, (@=?), assertFailure)
+-- import Test.HUnit ()
 
 newtype Aligned a = Aligned { getAligned :: a }
 
@@ -43,7 +43,7 @@ checkAddressAlignment xs = Storable.unsafeWith xs $ \ptr -> do
     dummy :: a
     dummy = undefined
 
-tests :: [Test]
+tests :: [TestTree]
 tests =
   [ testGroup "Data.Vector.Storable.Vector Alignment"
       [ testCase "Aligned Double" $
@@ -83,7 +83,7 @@ tests =
   ]
 
 testsSliceOutOfBounds ::
-     (Show (v Int), Generic.Vector v Int) => (Int -> Int -> v Int -> v Int) -> [Test]
+     (Show (v Int), Generic.Vector v Int) => (Int -> Int -> v Int -> v Int) -> [TestTree]
 testsSliceOutOfBounds sliceWith =
   [ testCase "Negative ix" $ sliceTest sliceWith (-2) 2 xs
   , testCase "Negative size" $ sliceTest sliceWith 2 (-2) xs
@@ -139,7 +139,7 @@ testTakeOutOfMemory takeWith =
 
 regression188
   :: forall proxy a. (Typeable a, Enum a, Bounded a, Eq a, Show a)
-  => proxy a -> Test
+  => proxy a -> TestTree
 regression188 _ = testCase (show (typeOf (undefined :: a)))
   $ Vector.fromList [maxBound::a] @=? Vector.enumFromTo maxBound maxBound
 {-# INLINE regression188 #-}

--- a/vector.cabal
+++ b/vector.cabal
@@ -99,7 +99,6 @@ Flag Wall
   Manual: True
 
 
-
 Library
   Default-Language: Haskell2010
   Other-Extensions:
@@ -204,9 +203,9 @@ test-suite vector-tests-O0
   hs-source-dirs: tests
   Build-Depends: base >= 4.5 && < 5, template-haskell, base-orphans >= 0.6, vector,
                  primitive, random,
-                 QuickCheck >= 2.9 && < 2.14 , HUnit, test-framework,
-                 test-framework-hunit, test-framework-quickcheck2,
-                 transformers >= 0.2.0.0
+                 QuickCheck >= 2.9 && < 2.14 , HUnit, tasty,
+                 tasty-hunit, tasty-quickcheck,
+                 transformers >= 0.2.0.0,semigroups
 
   default-extensions: CPP,
               ScopedTypeVariables,
@@ -218,7 +217,7 @@ test-suite vector-tests-O0
               TypeFamilies,
               TemplateHaskell
 
-  Ghc-Options: -O0
+  Ghc-Options: -O0 -threaded
   Ghc-Options: -Wall
 
   if !flag(Wall)
@@ -247,9 +246,9 @@ test-suite vector-tests-O2
   hs-source-dirs: tests
   Build-Depends: base >= 4.5 && < 5, template-haskell, base-orphans >= 0.6, vector,
                  primitive, random,
-                 QuickCheck >= 2.9 && < 2.14 , HUnit, test-framework,
-                 test-framework-hunit, test-framework-quickcheck2,
-                 transformers >= 0.2.0.0
+                 QuickCheck >= 2.9 && < 2.14 , HUnit,  tasty,
+                 tasty-hunit, tasty-quickcheck,
+                 transformers >= 0.2.0.0,semigroups
 
   default-extensions: CPP,
               ScopedTypeVariables,
@@ -261,8 +260,9 @@ test-suite vector-tests-O2
               TypeFamilies,
               TemplateHaskell
 
+
   Ghc-Options: -Wall
-  Ghc-Options:  -O2
+  Ghc-Options:  -O2 -threaded
   if !flag(Wall)
     Ghc-Options: -fno-warn-orphans -fno-warn-missing-signatures
     if impl(ghc >= 8.0) && impl(ghc < 8.1)


### PR DESCRIPTION
@Shimuuar  @lehins  heres a hopefully simpler forward port that should be largely the same as 
https://github.com/haskell/vector/pull/302, but which keeps the semigroup trick for describing the associativities of the maxBy and MinBy