### PR TITLE
Add nubOrd and nubOrdBy

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -1248,11 +1248,26 @@ dropWhile :: (a -> Bool) -> Vector a -> Vector a
 dropWhile = G.dropWhile
 
 -- | /O(n * log n)/ Remove duplicate elements.
+--
+-- nubOrd may have unexpected behaviour for `Ord` instances
+-- which do not implement a partial ordering meaning they satisfy the following
+-- properties:
+--
+-- [__Transitivity__]: if @x <= y && y <= z@ = 'True', then @x <= z@ = 'True'
+-- [__Reflexivity__]: @x <= x@ = 'True'
+-- [__Antisymmetry__]: if @x <= y && y <= x@ = 'True', then @x == y@ = 'True'
 nubOrd :: Ord a => Vector a -> Vector a
 {-# INLINE nubOrd #-}
 nubOrd = G.nubOrd
 
 -- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+--
+-- nubOrd may have unexpected behaviour for comparison functions `cmp`
+-- which do not satisfy the following properties:
+--
+-- 1. if @cmp x y == LT && cmp y z == LT@ = 'True', then @cmp x z@ = 'True'
+-- 2. @cmp x x@ = 'EQ'
+-- 3. if @cmp x y@ = 'LT', then @cmp y x@ = 'GT'
 nubOrdBy :: (a -> a -> Ordering) -> Vector a -> Vector a
 {-# INLINE nubOrdBy #-}
 nubOrdBy = G.nubOrdBy

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -117,6 +117,7 @@ module Data.Vector (
   mapMaybe, imapMaybe,
   filterM,
   takeWhile, dropWhile,
+  nubOrd, nubOrdBy,
 
   -- ** Partitioning
   partition, unstablePartition, partitionWith, span, break,
@@ -1245,6 +1246,16 @@ takeWhile = G.takeWhile
 dropWhile :: (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
 dropWhile = G.dropWhile
+
+-- | /O(n * log n)/ Remove duplicate elements.
+nubOrd :: Ord a => Vector a -> Vector a
+{-# INLINE nubOrd #-}
+nubOrd = G.nubOrd
+
+-- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+nubOrdBy :: (a -> a -> Ordering) -> Vector a -> Vector a
+{-# INLINE nubOrdBy #-}
+nubOrdBy = G.nubOrdBy
 
 -- Parititioning
 -- -------------

--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -796,12 +796,27 @@ dropWhileM f (Stream step t) = Stream step' (DropWhile_Drop t)
         ) (step s)
 
 -- | Remove duplicate elements
+--
+-- nubOrd may have unexpected behaviour for `Ord` instances
+-- which do not implement a partial ordering meaning they satisfy the following
+-- properties:
+--
+-- [__Transitivity__]: if @x <= y && y <= z@ = 'True', then @x <= z@ = 'True'
+-- [__Reflexivity__]: @x <= x@ = 'True'
+-- [__Antisymmetry__]: if @x <= y && y <= x@ = 'True', then @x == y@ = 'True'
 nubOrd :: (Ord a, Monad m) => Stream m a -> Stream m a
 {-# INLINE_FUSED nubOrd #-}
 nubOrd = nubOrdBy compare
 
 
 -- | Remove duplicate elements based on custom predicate.
+--
+-- nubOrd may have unexpected behaviour for comparison functions `cmp`
+-- which do not satisfy the following properties:
+--
+-- 1. if @cmp x y == LT && cmp y z == LT@ = 'True', then @cmp x z@ = 'True'
+-- 2. @cmp x x@ = 'EQ'
+-- 3. if @cmp x y@ = 'LT', then @cmp y x@ = 'GT'
 nubOrdBy :: Monad m => (a -> a -> Ordering) -> Stream m a -> Stream m a
 {-# INLINE_FUSED nubOrdBy #-}
 nubOrdBy cmp (Stream step st) = Stream step' (E, st)

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -100,6 +100,7 @@ module Data.Vector.Generic (
   mapMaybe, imapMaybe,
   filterM,
   takeWhile, dropWhile,
+  nubOrd, nubOrdBy,
 
   -- ** Partitioning
   partition, partitionWith, unstablePartition, span, break,
@@ -1347,6 +1348,17 @@ takeWhile f = unstream . Bundle.takeWhile f . stream
 dropWhile :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE dropWhile #-}
 dropWhile f = unstream . Bundle.dropWhile f . stream
+
+
+-- | /O(n * log n)/ Remove duplicate elements.
+nubOrd :: (Vector v a, Ord a) => v a -> v a
+{-# INLINE nubOrd #-}
+nubOrd = unstream . inplace S.nubOrd toMax . stream
+
+-- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+nubOrdBy :: (Vector v a) => (a -> a -> Ordering) -> v a -> v a
+{-# INLINE nubOrdBy #-}
+nubOrdBy comp = unstream . inplace (S.nubOrdBy comp) toMax . stream
 
 -- Parititioning
 -- -------------

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1351,11 +1351,26 @@ dropWhile f = unstream . Bundle.dropWhile f . stream
 
 
 -- | /O(n * log n)/ Remove duplicate elements.
+--
+-- nubOrd may have unexpected behaviour for `Ord` instances
+-- which do not implement a partial ordering meaning they satisfy the following
+-- properties:
+--
+-- [__Transitivity__]: if @x <= y && y <= z@ = 'True', then @x <= z@ = 'True'
+-- [__Reflexivity__]: @x <= x@ = 'True'
+-- [__Antisymmetry__]: if @x <= y && y <= x@ = 'True', then @x == y@ = 'True'
 nubOrd :: (Vector v a, Ord a) => v a -> v a
 {-# INLINE nubOrd #-}
 nubOrd = unstream . inplace S.nubOrd toMax . stream
 
 -- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+--
+-- nubOrd may have unexpected behaviour for comparison functions `cmp`
+-- which do not satisfy the following properties:
+--
+-- 1. if @cmp x y == LT && cmp y z == LT@ = 'True', then @cmp x z@ = 'True'
+-- 2. @cmp x x@ = 'EQ'
+-- 3. if @cmp x y@ = 'LT', then @cmp y x@ = 'GT'
 nubOrdBy :: (Vector v a) => (a -> a -> Ordering) -> v a -> v a
 {-# INLINE nubOrdBy #-}
 nubOrdBy comp = unstream . inplace (S.nubOrdBy comp) toMax . stream

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -100,6 +100,7 @@ module Data.Vector.Primitive (
   mapMaybe, imapMaybe,
   filterM,
   takeWhile, dropWhile,
+  nubOrd, nubOrdBy,
 
   -- ** Partitioning
   partition, unstablePartition, partitionWith, span, break,
@@ -977,6 +978,16 @@ takeWhile = G.takeWhile
 dropWhile :: Prim a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
 dropWhile = G.dropWhile
+
+-- | /O(n * log n)/ Remove duplicate elements.
+nubOrd :: (Ord a, Prim a) => Vector a -> Vector a
+{-# INLINE nubOrd #-}
+nubOrd = G.nubOrd
+
+-- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+nubOrdBy :: (Prim a) => (a -> a -> Ordering) -> Vector a -> Vector a
+{-# INLINE nubOrdBy #-}
+nubOrdBy = G.nubOrdBy
 
 -- Parititioning
 -- -------------

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -980,11 +980,26 @@ dropWhile :: Prim a => (a -> Bool) -> Vector a -> Vector a
 dropWhile = G.dropWhile
 
 -- | /O(n * log n)/ Remove duplicate elements.
+--
+-- nubOrd may have unexpected behaviour for `Ord` instances
+-- which do not implement a partial ordering meaning they satisfy the following
+-- properties:
+--
+-- [__Transitivity__]: if @x <= y && y <= z@ = 'True', then @x <= z@ = 'True'
+-- [__Reflexivity__]: @x <= x@ = 'True'
+-- [__Antisymmetry__]: if @x <= y && y <= x@ = 'True', then @x == y@ = 'True'
 nubOrd :: (Ord a, Prim a) => Vector a -> Vector a
 {-# INLINE nubOrd #-}
 nubOrd = G.nubOrd
 
 -- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+--
+-- nubOrd may have unexpected behaviour for comparison functions `cmp`
+-- which do not satisfy the following properties:
+--
+-- 1. if @cmp x y == LT && cmp y z == LT@ = 'True', then @cmp x z@ = 'True'
+-- 2. @cmp x x@ = 'EQ'
+-- 3. if @cmp x y@ = 'LT', then @cmp y x@ = 'GT'
 nubOrdBy :: (Prim a) => (a -> a -> Ordering) -> Vector a -> Vector a
 {-# INLINE nubOrdBy #-}
 nubOrdBy = G.nubOrdBy

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -1007,11 +1007,26 @@ dropWhile :: Storable a => (a -> Bool) -> Vector a -> Vector a
 dropWhile = G.dropWhile
 
 -- | /O(n * log n)/ Remove duplicate elements.
+--
+-- nubOrd may have unexpected behaviour for `Ord` instances
+-- which do not implement a partial ordering meaning they satisfy the following
+-- properties:
+--
+-- [__Transitivity__]: if @x <= y && y <= z@ = 'True', then @x <= z@ = 'True'
+-- [__Reflexivity__]: @x <= x@ = 'True'
+-- [__Antisymmetry__]: if @x <= y && y <= x@ = 'True', then @x == y@ = 'True'
 nubOrd :: (Storable a, Ord a) => Vector a -> Vector a
 {-# INLINE nubOrd #-}
 nubOrd = G.nubOrd
 
 -- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+--
+-- nubOrd may have unexpected behaviour for comparison functions `cmp`
+-- which do not satisfy the following properties:
+--
+-- 1. if @cmp x y == LT && cmp y z == LT@ = 'True', then @cmp x z@ = 'True'
+-- 2. @cmp x x@ = 'EQ'
+-- 3. if @cmp x y@ = 'LT', then @cmp y x@ = 'GT'
 nubOrdBy :: (Storable a) => (a -> a -> Ordering) -> Vector a -> Vector a
 {-# INLINE nubOrdBy #-}
 nubOrdBy = G.nubOrdBy

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -97,6 +97,7 @@ module Data.Vector.Storable (
   mapMaybe, imapMaybe,
   filterM,
   takeWhile, dropWhile,
+  nubOrd, nubOrdBy,
 
   -- ** Partitioning
   partition, unstablePartition, partitionWith, span, break,
@@ -1004,6 +1005,16 @@ takeWhile = G.takeWhile
 dropWhile :: Storable a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
 dropWhile = G.dropWhile
+
+-- | /O(n * log n)/ Remove duplicate elements.
+nubOrd :: (Storable a, Ord a) => Vector a -> Vector a
+{-# INLINE nubOrd #-}
+nubOrd = G.nubOrd
+
+-- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+nubOrdBy :: (Storable a) => (a -> a -> Ordering) -> Vector a -> Vector a
+{-# INLINE nubOrdBy #-}
+nubOrdBy = G.nubOrdBy
 
 -- Parititioning
 -- -------------

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -1019,11 +1019,26 @@ dropWhile :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 dropWhile = G.dropWhile
 
 -- | /O(n * log n)/ Remove duplicate elements.
+--
+-- nubOrd may have unexpected behaviour for `Ord` instances
+-- which do not implement a partial ordering meaning they satisfy the following
+-- properties:
+--
+-- [__Transitivity__]: if @x <= y && y <= z@ = 'True', then @x <= z@ = 'True'
+-- [__Reflexivity__]: @x <= x@ = 'True'
+-- [__Antisymmetry__]: if @x <= y && y <= x@ = 'True', then @x == y@ = 'True'
 nubOrd :: (Unbox a, Ord a) => Vector a -> Vector a
 {-# INLINE nubOrd #-}
 nubOrd = G.nubOrd
 
 -- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+--
+-- nubOrd may have unexpected behaviour for comparison functions `cmp`
+-- which do not satisfy the following properties:
+--
+-- 1. if @cmp x y == LT && cmp y z == LT@ = 'True', then @cmp x z@ = 'True'
+-- 2. @cmp x x@ = 'EQ'
+-- 3. if @cmp x y@ = 'LT', then @cmp y x@ = 'GT'
 nubOrdBy :: (Unbox a) => (a -> a -> Ordering) -> Vector a -> Vector a
 {-# INLINE nubOrdBy #-}
 nubOrdBy = G.nubOrdBy

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -123,6 +123,7 @@ module Data.Vector.Unboxed (
   mapMaybe, imapMaybe,
   filterM,
   takeWhile, dropWhile,
+  nubOrd, nubOrdBy,
 
   -- ** Partitioning
   partition, unstablePartition, partitionWith, span, break,
@@ -1016,6 +1017,16 @@ takeWhile = G.takeWhile
 dropWhile :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
 dropWhile = G.dropWhile
+
+-- | /O(n * log n)/ Remove duplicate elements.
+nubOrd :: (Unbox a, Ord a) => Vector a -> Vector a
+{-# INLINE nubOrd #-}
+nubOrd = G.nubOrd
+
+-- | /O(n * log n)/ Remove duplicate elements using a custom predicate.
+nubOrdBy :: (Unbox a) => (a -> a -> Ordering) -> Vector a -> Vector a
+{-# INLINE nubOrdBy #-}
+nubOrdBy = G.nubOrdBy
 
 -- Parititioning
 -- -------------

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 Changes in version next
 
+ * Add nubOrd and nubOrdBy functions.
  * Fix integer overflows in specializations of Bundle/Stream enumFromTo on Integral types
  * Fix possibility of OutOfMemory with `take` and very large arguments.
  * Fix `slice` function causing segfault and not checking the bounds properly.

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -52,7 +52,7 @@ import Control.Monad.Zip
 import Data.Data
 
 type CommonContext  a v = (VanillaContext a, VectorContext a v)
-type VanillaContext a   = ( Eq a , Show a, Arbitrary a, CoArbitrary a
+type VanillaContext a   = ( Eq a , Ord a, Show a, Arbitrary a, CoArbitrary a
                           , TestData a, Model a ~ a, EqTest a ~ Property)
 type VectorContext  a v = ( Eq (v a), Show (v a), Arbitrary (v a), CoArbitrary (v a)
                           , TestData (v a), Model (v a) ~ [a],  EqTest (v a) ~ Property, V.Vector v a)
@@ -190,6 +190,7 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_uniq,
         'prop_mapMaybe, 'prop_imapMaybe,
         'prop_takeWhile, 'prop_dropWhile,
+        'prop_nubOrd,
 
         -- Paritioning
         'prop_partition, {- 'prop_unstablePartition, -}
@@ -431,6 +432,8 @@ testPolymorphicFunctions _ = $(testProperties [
 
     prop_uniq :: P (v a -> v a)
       = V.uniq `eq` (map head . group)
+
+    prop_nubOrd :: P (v a -> v a) = V.nubOrd `eq` nub
     --prop_span         = (V.span :: (a -> Bool) -> v a -> (v a, v a))  `eq2` span
     --prop_break        = (V.break :: (a -> Bool) -> v a -> (v a, v a)) `eq2` break
     --prop_splitAt      = (V.splitAt :: Int -> v a -> (v a, v a))       `eq2` splitAt


### PR DESCRIPTION
This adds nubOrd functions addressing https://github.com/haskell/vector/issues/145. The implementation of a red black tree for testing membership is taken directly from the `extra` package.

I have not looked at the internals of vector before seriously so apologies for anything glaringly wrong.

The issue also mentions adding uniqBy which looks completely straightforward and I am happy to do in a separate PR.