### PR TITLE
Ignore upper bounds on vector in dependencies

### DIFF
--- a/benchmarks/cabal.project
+++ b/benchmarks/cabal.project
@@ -1,1 +1,4 @@
 packages: ../vector.cabal vector-benchmarks.cabal
+
+allow-newer:
+  *:vector


### PR DESCRIPTION
Any dependency in the benchmarks that uses vector and has an upper bound will not allow this to build on master so we should ignore those bounds.