### PR TITLE
Fix rewrite rule for zipWithM

### DIFF
--- a/Data/Vector/Fusion/Bundle.hs
+++ b/Data/Vector/Fusion/Bundle.hs
@@ -80,7 +80,7 @@ import Data.Vector.Generic.Base ( Vector )
 import Data.Vector.Fusion.Bundle.Size
 import Data.Vector.Fusion.Util
 import Data.Vector.Fusion.Stream.Monadic ( Stream(..), Step(..) )
-import Data.Vector.Fusion.Bundle.Monadic ( Chunk(..) )
+import Data.Vector.Fusion.Bundle.Monadic ( Chunk(..), lift )
 import qualified Data.Vector.Fusion.Bundle.Monadic as M
 import qualified Data.Vector.Fusion.Stream.Monadic as S
 
@@ -127,14 +127,6 @@ inplace f g b = b `seq` M.fromStream (f (M.elements b)) (g (M.size b))
          g1 g2 s.
   inplace f1 g1 (inplace f2 g2 s) = inplace (f1 . f2) (g1 . g2) s   #-}
 
-
-
--- | Convert a pure stream to a monadic stream
-lift :: Monad m => Bundle v a -> M.Bundle m v a
-{-# INLINE_FUSED lift #-}
-lift (M.Bundle (Stream step s) (Stream vstep t) v sz)
-    = M.Bundle (Stream (return . unId . step) s)
-               (Stream (return . unId . vstep) t) v sz
 
 -- | 'Size' hint of a 'Bundle'
 size :: Bundle v a -> Size

--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -338,7 +338,7 @@ zipWithM f Bundle{sElems = sa, sSize = na}
 {-# RULES
 
 "zipWithM xs xs [Vector.Bundle]" forall f xs.
-  zipWithM f xs xs = mapM (\x -> f x x) xs   #-}
+  zipWithM f (lift xs) (lift xs) = mapM (\x -> f x x) (lift xs) #-}
 
 
 zipWithM_ :: Monad m => (a -> b -> m c) -> Bundle m v a -> Bundle m v b -> m ()

--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -13,7 +13,7 @@
 --
 
 module Data.Vector.Fusion.Bundle.Monadic (
-  Bundle(..), Chunk(..),
+  Bundle(..), Chunk(..), lift,
 
   -- * Size hints
   size, sized,
@@ -80,7 +80,7 @@ module Data.Vector.Fusion.Bundle.Monadic (
 import Data.Vector.Generic.Base
 import qualified Data.Vector.Generic.Mutable.Base as M
 import Data.Vector.Fusion.Bundle.Size
-import Data.Vector.Fusion.Util ( Box(..), delay_inline )
+import Data.Vector.Fusion.Util ( Box(..), delay_inline, Id(..) )
 import Data.Vector.Fusion.Stream.Monadic ( Stream(..), Step(..) )
 import qualified Data.Vector.Fusion.Stream.Monadic as S
 import Control.Monad.Primitive
@@ -120,6 +120,13 @@ data Bundle m v a = Bundle { sElems  :: Stream m a
                            , sVector :: Maybe (v a)
                            , sSize   :: Size
                            }
+
+-- | Convert a pure stream to a monadic stream
+lift :: Monad m => Bundle Id v a -> Bundle m v a
+{-# INLINE_FUSED lift #-}
+lift (Bundle (Stream step s) (Stream vstep t) v sz)
+    = Bundle (Stream (return . unId . step) s)
+             (Stream (return . unId . vstep) t) v sz
 
 fromStream :: Monad m => Stream m a -> Size -> Bundle m v a
 {-# INLINE fromStream #-}

--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -496,13 +496,6 @@ zipWithM f (Stream stepa ta) (Stream stepb tb) = Stream step (ta, tb, Nothing)
                                  Skip    sb' -> return $ Skip (sa, sb', Just x)
                                  Done        -> return $ Done
 
--- FIXME: This might expose an opportunity for inplace execution.
-{-# RULES
-
-"zipWithM xs xs [Vector.Stream]" forall f xs.
-  zipWithM f xs xs = mapM (\x -> f x x) xs   #-}
-
-
 zipWithM_ :: Monad m => (a -> b -> m c) -> Stream m a -> Stream m b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ f sa sb = consume (zipWithM f sa sb)


### PR DESCRIPTION
For description of bug see #252. Fix is rather simple RULE now only matches pure streams which is safe since there's no chance of performing some effect only once instead of twice.

In order to be able to do so `lift` was moved from Bundle to Bundle.Monadic

Fixes #252 