### PR TITLE
Reexport PrimMonad from mutable vectors

### DIFF
--- a/Data/Vector/Generic/Mutable.hs
+++ b/Data/Vector/Generic/Mutable.hs
@@ -13,7 +13,7 @@
 
 module Data.Vector.Generic.Mutable (
   -- * Class of mutable vector types
-  MVector(..),
+  MVector(..), PrimMonad(..),
 
   -- * Accessors
 

--- a/Data/Vector/Generic/Mutable.hs
+++ b/Data/Vector/Generic/Mutable.hs
@@ -13,7 +13,7 @@
 
 module Data.Vector.Generic.Mutable (
   -- * Class of mutable vector types
-  MVector(..), PrimMonad(..),
+  MVector(..),
 
   -- * Accessors
 
@@ -57,7 +57,9 @@ module Data.Vector.Generic.Mutable (
   fill, fillR,
   unsafeAccum, accum, unsafeUpdate, update, reverse,
   unstablePartition, unstablePartitionBundle, partitionBundle,
-  partitionWithBundle
+  partitionWithBundle,
+  -- * Reexports
+  PrimMonad(..), RealWorld
 ) where
 
 import           Data.Vector.Generic.Mutable.Base
@@ -71,7 +73,7 @@ import qualified Data.Vector.Fusion.Stream.Monadic as Stream
 import           Data.Vector.Fusion.Bundle.Size
 import           Data.Vector.Fusion.Util        ( delay_inline )
 
-import Control.Monad.Primitive ( PrimMonad, PrimState )
+import Control.Monad.Primitive ( PrimMonad(..), RealWorld )
 
 import Prelude hiding ( length, null, replicate, reverse, map, read,
                         take, drop, splitAt, init, tail )

--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Mutable (
   -- * Mutable boxed vectors
-  MVector(..), IOVector, STVector, PrimMonad(..),
+  MVector(..), IOVector, STVector,
 
   -- * Accessors
 
@@ -47,7 +47,10 @@ module Data.Vector.Mutable (
   nextPermutation,
 
   -- ** Filling and copying
-  set, copy, move, unsafeCopy, unsafeMove
+  set, copy, move, unsafeCopy, unsafeMove,
+
+  -- * Reexports
+  PrimMonad(..), RealWorld
 ) where
 
 import           Control.Monad (when)

--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Mutable (
   -- * Mutable boxed vectors
-  MVector(..), IOVector, STVector,
+  MVector(..), IOVector, STVector, PrimMonad(..),
 
   -- * Accessors
 

--- a/Data/Vector/Primitive/Mutable.hs
+++ b/Data/Vector/Primitive/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Primitive.Mutable (
   -- * Mutable vectors of primitive types
-  MVector(..), IOVector, STVector, Prim,
+  MVector(..), IOVector, STVector, Prim, PrimMonad(..),
 
   -- * Accessors
 

--- a/Data/Vector/Primitive/Mutable.hs
+++ b/Data/Vector/Primitive/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Primitive.Mutable (
   -- * Mutable vectors of primitive types
-  MVector(..), IOVector, STVector, Prim, PrimMonad(..),
+  MVector(..), IOVector, STVector, Prim,
 
   -- * Accessors
 
@@ -50,7 +50,9 @@ module Data.Vector.Primitive.Mutable (
   set, copy, move, unsafeCopy, unsafeMove,
 
   -- * Unsafe conversions
-  unsafeCoerceMVector
+  unsafeCoerceMVector,
+  -- * Reexports
+  PrimMonad(..), RealWorld
 ) where
 
 import qualified Data.Vector.Generic.Mutable as G

--- a/Data/Vector/Storable/Mutable.hs
+++ b/Data/Vector/Storable/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Storable.Mutable(
   -- * Mutable vectors of 'Storable' types
-  MVector(..), IOVector, STVector, Storable, PrimMonad(..),
+  MVector(..), IOVector, STVector, Storable,
 
   -- * Accessors
 
@@ -55,7 +55,9 @@ module Data.Vector.Storable.Mutable(
   -- * Raw pointers
   unsafeFromForeignPtr, unsafeFromForeignPtr0,
   unsafeToForeignPtr,   unsafeToForeignPtr0,
-  unsafeWith
+  unsafeWith,
+  -- * Reexports
+  PrimMonad(..), RealWorld,
 ) where
 
 import Control.DeepSeq ( NFData(rnf)

--- a/Data/Vector/Storable/Mutable.hs
+++ b/Data/Vector/Storable/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Storable.Mutable(
   -- * Mutable vectors of 'Storable' types
-  MVector(..), IOVector, STVector, Storable,
+  MVector(..), IOVector, STVector, Storable, PrimMonad(..),
 
   -- * Accessors
 

--- a/Data/Vector/Unboxed/Mutable.hs
+++ b/Data/Vector/Unboxed/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Unboxed.Mutable (
   -- * Mutable vectors of primitive types
-  MVector(..), IOVector, STVector, Unbox,
+  MVector(..), IOVector, STVector, Unbox, PrimMonad(..),
 
   -- * Accessors
 

--- a/Data/Vector/Unboxed/Mutable.hs
+++ b/Data/Vector/Unboxed/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Unboxed.Mutable (
   -- * Mutable vectors of primitive types
-  MVector(..), IOVector, STVector, Unbox, PrimMonad(..),
+  MVector(..), IOVector, STVector, Unbox,
 
   -- * Accessors
 
@@ -51,7 +51,9 @@ module Data.Vector.Unboxed.Mutable (
   nextPermutation,
 
   -- ** Filling and copying
-  set, copy, move, unsafeCopy, unsafeMove
+  set, copy, move, unsafeCopy, unsafeMove,
+  -- * Reexports
+  PrimMonad(..), RealWorld,
 ) where
 
 import Data.Vector.Unboxed.Base


### PR DESCRIPTION
This allows to avoid extra import from primitive (and adding it to cabal file)
It's also in line with reexposrt of Storable and Prim type classes

Fixes #262