### PR TITLE
Fix fusion of `<$` operator

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -340,6 +340,9 @@ instance Functor Vector where
   {-# INLINE fmap #-}
   fmap = map
 
+  {-# INLINE (<$) #-}
+  (<$) = map . const
+
 instance Monad Vector where
   {-# INLINE return #-}
   return = Applicative.pure

--- a/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -287,6 +287,8 @@ drop n Bundle{sElems = s, sSize = sz} =
 instance Monad m => Functor (Bundle m v) where
   {-# INLINE fmap #-}
   fmap = map
+  {-# INLINE (<$) #-}
+  (<$) = map . const
 
 -- | Map a function over a 'Bundle'
 map :: Monad m => (a -> b) -> Bundle m v a -> Bundle m v b

--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -119,6 +119,8 @@ instance Functor (Step s) where
   fmap f (Yield x s) = Yield (f x) s
   fmap _ (Skip s) = Skip s
   fmap _ Done = Done
+  {-# INLINE (<$) #-}
+  (<$) = fmap . const
 
 -- | Monadic streams
 data Stream m a = forall s. Stream (s -> m (Step s a)) s


### PR DESCRIPTION
I've tried both of the suggested approaches from #248 
```haskell
  {-# INLINE (<$) #-}
  (<$) a v = replicate (length v) a
```

and this one https://github.com/haskell/vector/pull/248#issuecomment-583745720 together with
```haskell
  {-# INLINE (<$) #-}
  (<$) x = G.unstream . (x <$) . G.stream
```

None of them prevent this example from diverging:
```haskell
  let v = V.unfoldr (\x -> Just (x, x + 1)) (0 :: Int)
  print $ V.take 4 ((1 :: Int) <$ v) -- diverges
```

Default implementation for `<$` is identical to the one in this PR, but because it does not have an `INLINE` pragma it also fails to fuse.

Approach in this PR is the only one I found that produces the desired output:
```
[1,1,1,1]
```

In other words, this PR does not change the semantics, but fixes fusion for `<$` operator.