### PR TITLE
Address TODOs in test suite

### DIFF
--- a/tests/Tests/Vector/Boxed.hs
+++ b/tests/Tests/Vector/Boxed.hs
@@ -23,6 +23,7 @@ testGeneralBoxedVector dummy = concatMap ($ dummy)
   , testMonadFunctions
   , testApplicativeFunctions
   , testAlternativeFunctions
+  , testSequenceFunctions
   , testDataFunctions
   ]
 

--- a/tests/Tests/Vector/Boxed.hs
+++ b/tests/Tests/Vector/Boxed.hs
@@ -8,7 +8,9 @@ import Tests.Vector.Property
 import GHC.Exts (inline)
 
 
-testGeneralBoxedVector :: forall a. (CommonContext a Data.Vector.Vector, Ord a, Data a) => Data.Vector.Vector a -> [Test]
+testGeneralBoxedVector
+  :: forall a. (CommonContext a Data.Vector.Vector, Ord a, Data a)
+  => Data.Vector.Vector a -> [Test]
 testGeneralBoxedVector dummy = concatMap ($ dummy)
   [
     testSanity
@@ -30,7 +32,9 @@ testBoolBoxedVector dummy = concatMap ($ dummy)
   , testBoolFunctions
   ]
 
-testNumericBoxedVector :: forall a. (CommonContext a Data.Vector.Vector, Ord a, Num a, Enum a, Random a, Data a) => Data.Vector.Vector a -> [Test]
+testNumericBoxedVector
+  :: forall a. (CommonContext a Data.Vector.Vector, Ord a, Num a, Enum a, Random a, Data a)
+  => Data.Vector.Vector a -> [Test]
 testNumericBoxedVector dummy = concatMap ($ dummy)
   [
     testGeneralBoxedVector

--- a/tests/Tests/Vector/Primitive.hs
+++ b/tests/Tests/Vector/Primitive.hs
@@ -7,7 +7,10 @@ import Tests.Vector.Property
 
 import GHC.Exts (inline)
 
-testGeneralPrimitiveVector :: forall a. (CommonContext a Data.Vector.Primitive.Vector, Data.Vector.Primitive.Prim a, Ord a, Data a) => Data.Vector.Primitive.Vector a -> [Test]
+testGeneralPrimitiveVector
+  :: forall a. ( CommonContext a Data.Vector.Primitive.Vector
+               , Data.Vector.Primitive.Prim a, Ord a, Data a)
+  => Data.Vector.Primitive.Vector a -> [Test]
 testGeneralPrimitiveVector dummy = concatMap ($ dummy)
   [
     testSanity
@@ -17,7 +20,10 @@ testGeneralPrimitiveVector dummy = concatMap ($ dummy)
   , testDataFunctions
   ]
 
-testNumericPrimitiveVector :: forall a. (CommonContext a Data.Vector.Primitive.Vector, Data.Vector.Primitive.Prim a, Ord a, Num a, Enum a, Random a, Data a) => Data.Vector.Primitive.Vector a -> [Test]
+testNumericPrimitiveVector
+  :: forall a. ( CommonContext a Data.Vector.Primitive.Vector
+               , Data.Vector.Primitive.Prim a, Ord a, Num a, Enum a, Random a, Data a)
+  => Data.Vector.Primitive.Vector a -> [Test]
 testNumericPrimitiveVector dummy = concatMap ($ dummy)
   [
     testGeneralPrimitiveVector

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -186,13 +186,9 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_zipWith, 'prop_zipWith3, {- ... -}
         'prop_izipWith, 'prop_izipWith3, {- ... -}
         'prop_izipWithM, 'prop_izipWithM_,
-        {- 'prop_zip, ... -}
 
         -- Monadic zipping
         {- 'prop_zipWithM, 'prop_zipWithM_, -}
-
-        -- Unzipping
-        {- 'prop_unzip, ... -}
 
         -- Filtering
         'prop_filter, 'prop_ifilter, {- prop_filterM, -}

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -151,9 +151,6 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_reverse, 'prop_backpermute,
         {- 'prop_unsafeBackpermute, -}
 
-        -- Elementwise indexing
-        {- 'prop_indexed, -}
-
         -- Mapping
         'prop_map, 'prop_imap, 'prop_concatMap,
 
@@ -478,16 +475,24 @@ partitionWith f (x:xs) = case f x of
                          Right c -> (bs, c:cs)
     where (bs,cs) = partitionWith f xs
 
-testTuplyFunctions :: forall a v. (CommonContext a v, VectorContext (a, a) v, VectorContext (a, a, a) v) => v a -> [Test]
+testTuplyFunctions
+  :: forall a v. ( CommonContext a v
+                 , VectorContext (a, a)    v
+                 , VectorContext (a, a, a) v
+                 , VectorContext (Int, a)  v
+                 )
+  => v a -> [Test]
 {-# INLINE testTuplyFunctions #-}
 testTuplyFunctions _ = $(testProperties [ 'prop_zip, 'prop_zip3
                                         , 'prop_unzip, 'prop_unzip3
+                                        , 'prop_indexed
                                         ])
   where
-    prop_zip    :: P (v a -> v a -> v (a, a))           = V.zip `eq` zip
-    prop_zip3   :: P (v a -> v a -> v a -> v (a, a, a)) = V.zip3 `eq` zip3
-    prop_unzip  :: P (v (a, a) -> (v a, v a))           = V.unzip `eq` unzip
-    prop_unzip3 :: P (v (a, a, a) -> (v a, v a, v a))   = V.unzip3 `eq` unzip3
+    prop_zip     :: P (v a -> v a -> v (a, a))           = V.zip `eq` zip
+    prop_zip3    :: P (v a -> v a -> v a -> v (a, a, a)) = V.zip3 `eq` zip3
+    prop_unzip   :: P (v (a, a) -> (v a, v a))           = V.unzip `eq` unzip
+    prop_unzip3  :: P (v (a, a, a) -> (v a, v a, v a))   = V.unzip3 `eq` unzip3
+    prop_indexed :: P (v a -> v (Int, a))                = V.indexed `eq` (\xs -> [0..] `zip` xs)
 
 testOrdFunctions :: forall a v. (CommonContext a v, Ord a, Ord (v a)) => v a -> [Test]
 {-# INLINE testOrdFunctions #-}

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -71,7 +71,6 @@ type Test = TestTree
 -- TODO: add tests for the other extra functions
 -- IVector exports still needing tests:
 --  copy,
---  (//), update,
 --  new,
 --  unsafeSlice, unsafeIndex,
 
@@ -135,7 +134,7 @@ testPolymorphicFunctions _ = $(testProperties [
 
         -- Bulk updates (FIXME)
         'prop_upd,
-        {- 'prop_update, 'prop_update_,
+        {- 'prop_update_,
         'prop_unsafeUpd, 'prop_unsafeUpdate, 'prop_unsafeUpdate_, -}
 
         -- Accumulations (FIXME)
@@ -489,6 +488,7 @@ testTuplyFunctions
 testTuplyFunctions _ = $(testProperties [ 'prop_zip, 'prop_zip3
                                         , 'prop_unzip, 'prop_unzip3
                                         , 'prop_indexed
+                                        , 'prop_update
                                         ])
   where
     prop_zip     :: P (v a -> v a -> v (a, a))           = V.zip `eq` zip
@@ -496,6 +496,11 @@ testTuplyFunctions _ = $(testProperties [ 'prop_zip, 'prop_zip3
     prop_unzip   :: P (v (a, a) -> (v a, v a))           = V.unzip `eq` unzip
     prop_unzip3  :: P (v (a, a, a) -> (v a, v a, v a))   = V.unzip3 `eq` unzip3
     prop_indexed :: P (v a -> v (Int, a))                = V.indexed `eq` (\xs -> [0..] `zip` xs)
+    prop_update = \xs ->
+      forAll (index_value_pairs (V.length xs)) $ \ps ->
+      unP prop xs ps
+      where
+        prop :: P (v a -> [(Int,a)] -> v a) = (V.//) `eq` (//)
 
 testOrdFunctions :: forall a v. (CommonContext a v, Ord a, Ord (v a)) => v a -> [Test]
 {-# INLINE testOrdFunctions #-}

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -72,17 +72,6 @@ type Test = TestTree
 --  mapM_ *
 --  sequence
 --  sequence_
---  sum *
---  product *
---  scanl *
---  scanl1 *
---  scanr *
---  scanr1 *
---  lookup *
---  lines
---  words
---  unlines
---  unwords
 -- NB: this is an exhaustive list of all Prelude list functions that make sense for vectors.
 -- Ones with *s are the most plausible candidates.
 
@@ -91,7 +80,6 @@ type Test = TestTree
 --  copy,
 --  slice,
 --  (//), update, bpermute,
---  prescanl, prescanl',
 --  new,
 --  unsafeSlice, unsafeIndex,
 --  vlength, vnew

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -148,8 +148,6 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_unfoldrM, 'prop_unfoldrNM, 'prop_unfoldrExactNM,
         'prop_constructN, 'prop_constructrN,
 
-        -- Enumeration? (FIXME?)
-
         -- Concatenation (FIXME)
         'prop_cons, 'prop_snoc, 'prop_append,
         'prop_concat,

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -651,10 +651,12 @@ testNumFunctions _ = $(testProperties ['prop_sum, 'prop_product])
 
 testNestedVectorFunctions :: forall a v. (CommonContext a v) => v a -> [Test]
 {-# INLINE testNestedVectorFunctions #-}
-testNestedVectorFunctions _ = $(testProperties [])
+testNestedVectorFunctions _ = $(testProperties
+  [ 'prop_concat
+  ])
   where
     -- Prelude
-    --prop_concat       = (V.concat :: [v a] -> v a)                    `eq1` concat
+    prop_concat :: P ([v a] -> v a) = V.concat `eq` concat
 
     -- Data.List
     --prop_transpose    = V.transpose   `eq1` (transpose   :: [v a] -> [v a])

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -71,13 +71,9 @@ type Test = TestTree
 -- TODO: add tests for the other extra functions
 -- IVector exports still needing tests:
 --  copy,
---  slice,
---  (//), update, bpermute,
+--  (//), update,
 --  new,
 --  unsafeSlice, unsafeIndex,
---  vlength, vnew
-
--- TODO: test non-IVector stuff?
 
 testSanity :: forall a v. (CommonContext a v) => v a -> [Test]
 {-# INLINE testSanity #-}

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -122,8 +122,7 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_generateM, 'prop_replicateM,
 
         -- Monadic initialisation (FIXME)
-        'prop_createT,
-        {- 'prop_create, -}
+        'prop_create, 'prop_createT,
 
         -- Unfolding
         'prop_unfoldr, 'prop_unfoldrN, 'prop_unfoldrExactN,
@@ -229,6 +228,8 @@ testPolymorphicFunctions _ = $(testProperties [
               = (\n _ _ -> n < 1000) ===> V.iterateN `eq` (\n f -> take n . iterate f)
     prop_iterateNM :: P (Int -> (a -> Writer [Int] a) -> a -> Writer [Int] (v a))
               = (\n _ _ -> n < 1000) ===> V.iterateNM `eq` Util.iterateNM
+    prop_create :: P (v a -> v a)
+    prop_create = (\v -> V.create (V.thaw v)) `eq` id
     prop_createT :: P ((a, v a) -> (a, v a))
     prop_createT = (\v -> V.createT (T.mapM V.thaw v)) `eq` id
 

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -121,7 +121,7 @@ testPolymorphicFunctions _ = $(testProperties [
         -- Length information
         'prop_length, 'prop_null,
 
-        -- Indexing (FIXME)
+        -- Indexing
         'prop_index, 'prop_safeIndex, 'prop_head, 'prop_last,
         'prop_unsafeIndex, 'prop_unsafeHead, 'prop_unsafeLast,
 

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -119,10 +119,11 @@ testPolymorphicFunctions _ = $(testProperties [
         -- Initialisation (FIXME)
         'prop_empty, 'prop_singleton, 'prop_replicate,
         'prop_generate, 'prop_iterateN, 'prop_iterateNM,
+        'prop_generateM, 'prop_replicateM,
 
         -- Monadic initialisation (FIXME)
         'prop_createT,
-        {- 'prop_replicateM, 'prop_generateM, 'prop_create, -}
+        {- 'prop_create, -}
 
         -- Unfolding
         'prop_unfoldr, 'prop_unfoldrN, 'prop_unfoldrExactN,
@@ -167,7 +168,7 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_zipWithM, 'prop_zipWithM_,
 
         -- Filtering
-        'prop_filter, 'prop_ifilter, {- prop_filterM, -}
+        'prop_filter, 'prop_ifilter, 'prop_filterM,
         'prop_uniq,
         'prop_mapMaybe, 'prop_imapMaybe,
         'prop_takeWhile, 'prop_dropWhile,
@@ -213,6 +214,8 @@ testPolymorphicFunctions _ = $(testProperties [
     prop_singleton :: P (a -> v a)    = V.singleton `eq` singleton
     prop_replicate :: P (Int -> a -> v a)
               = (\n _ -> n < 1000) ===> V.replicate `eq` replicate
+    prop_replicateM :: P (Int -> Writer [a] a -> Writer [a] (v a))
+              = (\n _ -> n < 1000) ===> V.replicateM `eq` replicateM
     prop_cons      :: P (a -> v a -> v a) = V.cons `eq` (:)
     prop_snoc      :: P (v a -> a -> v a) = V.snoc `eq` snoc
     prop_append    :: P (v a -> v a -> v a) = (V.++) `eq` (++)
@@ -220,6 +223,8 @@ testPolymorphicFunctions _ = $(testProperties [
     prop_force     :: P (v a -> v a)        = V.force `eq` id
     prop_generate  :: P (Int -> (Int -> a) -> v a)
               = (\n _ -> n < 1000) ===> V.generate `eq` Util.generate
+    prop_generateM  :: P (Int -> (Int -> Writer [a] a) -> Writer [a] (v a))
+              = (\n _ -> n < 1000) ===> V.generateM `eq` Util.generateM
     prop_iterateN  :: P (Int -> (a -> a) -> a -> v a)
               = (\n _ _ -> n < 1000) ===> V.iterateN `eq` (\n f -> take n . iterate f)
     prop_iterateNM :: P (Int -> (a -> Writer [Int] a) -> a -> Writer [Int] (v a))
@@ -314,6 +319,7 @@ testPolymorphicFunctions _ = $(testProperties [
 
     prop_filter :: P ((a -> Bool) -> v a -> v a) = V.filter `eq` filter
     prop_ifilter :: P ((Int -> a -> Bool) -> v a -> v a) = V.ifilter `eq` ifilter
+    prop_filterM :: P ((a -> Writer [a] Bool) -> v a -> Writer [a] (v a)) = V.filterM `eq` filterM
     prop_mapMaybe :: P ((a -> Maybe a) -> v a -> v a) = V.mapMaybe `eq` mapMaybe
     prop_imapMaybe :: P ((Int -> a -> Maybe a) -> v a -> v a) = V.imapMaybe `eq` imapMaybe
     prop_takeWhile :: P ((a -> Bool) -> v a -> v a) = V.takeWhile `eq` takeWhile

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -438,18 +438,8 @@ testPolymorphicFunctions _ = $(testProperties [
 
     prop_uniq :: P (v a -> v a)
       = V.uniq `eq` (map head . group)
-    --prop_span         = (V.span :: (a -> Bool) -> v a -> (v a, v a))  `eq2` span
-    --prop_break        = (V.break :: (a -> Bool) -> v a -> (v a, v a)) `eq2` break
-    --prop_splitAt      = (V.splitAt :: Int -> v a -> (v a, v a))       `eq2` splitAt
-    --prop_all          = (V.all :: (a -> Bool) -> v a -> Bool)         `eq2` all
-    --prop_any          = (V.any :: (a -> Bool) -> v a -> Bool)         `eq2` any
 
     -- Data.List
-    --prop_findIndices  = V.findIndices `eq2` (findIndices :: (a -> Bool) -> v a -> v Int)
-    --prop_isPrefixOf   = V.isPrefixOf  `eq2` (isPrefixOf  :: v a -> v a -> Bool)
-    --prop_elemIndex    = V.elemIndex   `eq2` (elemIndex   :: a -> v a -> Maybe Int)
-    --prop_elemIndices  = V.elemIndices `eq2` (elemIndices :: a -> v a -> v Int)
-    --
     --prop_mapAccumL  = eq3
     --    (V.mapAccumL :: (X -> W -> (X,W)) -> X -> B   -> (X, B))
     --    (  mapAccumL :: (X -> W -> (X,W)) -> X -> [W] -> (X, [W]))

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -655,14 +655,7 @@ testNestedVectorFunctions _ = $(testProperties
   [ 'prop_concat
   ])
   where
-    -- Prelude
     prop_concat :: P ([v a] -> v a) = V.concat `eq` concat
-
-    -- Data.List
-    --prop_transpose    = V.transpose   `eq1` (transpose   :: [v a] -> [v a])
-    --prop_group        = V.group       `eq1` (group       :: v a -> [v a])
-    --prop_inits        = V.inits       `eq1` (inits       :: v a -> [v a])
-    --prop_tails        = V.tails       `eq1` (tails       :: v a -> [v a])
 
 testDataFunctions :: forall a v. (CommonContext a v, Data a, Data (v a)) => v a -> [Test]
 {-# INLINE testDataFunctions #-}

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -68,8 +68,6 @@ type Test = TestTree
 -- TODO: implement Vector equivalents of list functions for some of the commented out properties
 
 -- TODO: test and implement some of these other Prelude functions:
---  mapM *
---  mapM_ *
 --  sequence
 --  sequence_
 -- NB: this is an exhaustive list of all Prelude list functions that make sense for vectors.
@@ -165,7 +163,7 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_map, 'prop_imap, 'prop_concatMap,
 
         -- Monadic mapping
-        {- 'prop_mapM, 'prop_mapM_, 'prop_forM, 'prop_forM_, -}
+        'prop_mapM, 'prop_mapM_, 'prop_forM, 'prop_forM_,
         'prop_imapM, 'prop_imapM_,
 
         -- Zipping
@@ -302,6 +300,14 @@ testPolymorphicFunctions _ = $(testProperties [
     prop_reverse :: P (v a -> v a) = V.reverse `eq` reverse
 
     prop_map :: P ((a -> a) -> v a -> v a) = V.map `eq` map
+    prop_mapM :: P ((a -> Identity a) -> v a -> Identity (v a))
+            = V.mapM `eq` mapM
+    prop_mapM_ :: P ((a -> Writer [a] ()) -> v a -> Writer [a] ())
+            = V.mapM_ `eq` mapM_
+    prop_forM :: P (v a -> (a -> Identity a) -> Identity (v a))
+            = V.forM `eq` forM
+    prop_forM_ :: P (v a -> (a -> Writer [a] ()) -> Writer [a] ())
+            = V.forM_ `eq` forM_
     prop_zipWith :: P ((a -> a -> a) -> v a -> v a -> v a) = V.zipWith `eq` zipWith
     prop_zipWith3 :: P ((a -> a -> a -> a) -> v a -> v a -> v a -> v a)
              = V.zipWith3 `eq` zipWith3

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -193,8 +193,6 @@ testPolymorphicFunctions _ = $(testProperties [
 
         -- Specialised folds
         'prop_all, 'prop_any,
-        {- 'prop_maximumBy, 'prop_minimumBy,
-        'prop_maxIndexBy, 'prop_minIndexBy, -}
 
         -- Monadic folds
         {- ... -}

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -162,8 +162,8 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_imapM, 'prop_imapM_,
 
         -- Zipping
-        'prop_zipWith, 'prop_zipWith3, {- ... -}
-        'prop_izipWith, 'prop_izipWith3, {- ... -}
+        'prop_zipWith, 'prop_zipWith3,
+        'prop_izipWith, 'prop_izipWith3,
         'prop_izipWithM, 'prop_izipWithM_,
 
         -- Monadic zipping
@@ -193,9 +193,6 @@ testPolymorphicFunctions _ = $(testProperties [
 
         -- Specialised folds
         'prop_all, 'prop_any,
-
-        -- Monadic folds
-        {- ... -}
 
         -- Scans
         'prop_prescanl, 'prop_prescanl',

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -186,7 +186,7 @@ testPolymorphicFunctions _ = $(testProperties [
         'prop_izipWithM, 'prop_izipWithM_,
 
         -- Monadic zipping
-        {- 'prop_zipWithM, 'prop_zipWithM_, -}
+        'prop_zipWithM, 'prop_zipWithM_,
 
         -- Filtering
         'prop_filter, 'prop_ifilter, {- prop_filterM, -}
@@ -323,6 +323,10 @@ testPolymorphicFunctions _ = $(testProperties [
     prop_imapM_ :: P ((Int -> a -> Writer [a] ()) -> v a -> Writer [a] ())
             = V.imapM_ `eq` imapM_
     prop_izipWith :: P ((Int -> a -> a -> a) -> v a -> v a -> v a) = V.izipWith `eq` izipWith
+    prop_zipWithM :: P ((a -> a -> Identity a) -> v a -> v a -> Identity (v a))
+            = V.zipWithM `eq` zipWithM
+    prop_zipWithM_ :: P ((a -> a -> Writer [a] ()) -> v a -> v a -> Writer [a] ())
+            = V.zipWithM_ `eq` zipWithM_
     prop_izipWithM :: P ((Int -> a -> a -> Identity a) -> v a -> v a -> Identity (v a))
             = V.izipWithM `eq` izipWithM
     prop_izipWithM_ :: P ((Int -> a -> a -> Writer [a] ()) -> v a -> v a -> Writer [a] ())

--- a/tests/Tests/Vector/Storable.hs
+++ b/tests/Tests/Vector/Storable.hs
@@ -7,7 +7,10 @@ import Tests.Vector.Property
 
 import GHC.Exts (inline)
 
-testGeneralStorableVector :: forall a. (CommonContext a Data.Vector.Storable.Vector, Data.Vector.Storable.Storable a, Ord a, Data a) => Data.Vector.Storable.Vector a -> [Test]
+testGeneralStorableVector
+  :: forall a. ( CommonContext a Data.Vector.Storable.Vector
+               , Data.Vector.Storable.Storable a, Ord a, Data a)
+  => Data.Vector.Storable.Vector a -> [Test]
 testGeneralStorableVector dummy = concatMap ($ dummy)
   [
     testSanity
@@ -17,7 +20,10 @@ testGeneralStorableVector dummy = concatMap ($ dummy)
   , testDataFunctions
   ]
 
-testNumericStorableVector :: forall a. (CommonContext a Data.Vector.Storable.Vector, Data.Vector.Storable.Storable a, Ord a, Num a, Enum a, Random a, Data a) => Data.Vector.Storable.Vector a -> [Test]
+testNumericStorableVector
+  :: forall a. ( CommonContext a Data.Vector.Storable.Vector
+               , Data.Vector.Storable.Storable a, Ord a, Num a, Enum a, Random a, Data a)
+  => Data.Vector.Storable.Vector a -> [Test]
 testNumericStorableVector dummy = concatMap ($ dummy)
   [
     testGeneralStorableVector

--- a/tests/Tests/Vector/Unboxed.hs
+++ b/tests/Tests/Vector/Unboxed.hs
@@ -7,7 +7,9 @@ import Tests.Vector.Property
 
 
 
-testGeneralUnboxedVector :: forall a. (CommonContext a Data.Vector.Unboxed.Vector, Data.Vector.Unboxed.Unbox a, Ord a, Data a) => Data.Vector.Unboxed.Vector a -> [Test]
+testGeneralUnboxedVector
+  :: forall a. (CommonContext a Data.Vector.Unboxed.Vector, Data.Vector.Unboxed.Unbox a, Ord a, Data a)
+  => Data.Vector.Unboxed.Vector a -> [Test]
 testGeneralUnboxedVector dummy = concatMap ($ dummy)
   [
     testSanity
@@ -28,7 +30,10 @@ testBoolUnboxedVector dummy = concatMap ($ dummy)
   , testBoolFunctions
   ]
 
-testNumericUnboxedVector :: forall a. (CommonContext a Data.Vector.Unboxed.Vector, Data.Vector.Unboxed.Unbox a, Ord a, Num a, Enum a, Random a, Data a) => Data.Vector.Unboxed.Vector a -> [Test]
+testNumericUnboxedVector
+  :: forall a. ( CommonContext a Data.Vector.Unboxed.Vector
+               , Data.Vector.Unboxed.Unbox a, Ord a, Num a, Enum a, Random a, Data a)
+  => Data.Vector.Unboxed.Vector a -> [Test]
 testNumericUnboxedVector dummy = concatMap ($ dummy)
   [
     testGeneralUnboxedVector
@@ -36,7 +41,9 @@ testNumericUnboxedVector dummy = concatMap ($ dummy)
   , testEnumFunctions
   ]
 
-testTupleUnboxedVector :: forall a. (CommonContext a Data.Vector.Unboxed.Vector, Data.Vector.Unboxed.Unbox a, Ord a, Data a) => Data.Vector.Unboxed.Vector a -> [Test]
+testTupleUnboxedVector
+  :: forall a. ( CommonContext a Data.Vector.Unboxed.Vector
+               , Data.Vector.Unboxed.Unbox a, Ord a, Data a) => Data.Vector.Unboxed.Vector a -> [Test]
 testTupleUnboxedVector dummy = concatMap ($ dummy)
   [
     testGeneralUnboxedVector
@@ -50,7 +57,7 @@ tests =
   , testGroup "(Int)" $
     testNumericUnboxedVector (undefined :: Data.Vector.Unboxed.Vector Int)
   , testGroup "(Float)" $
-  testNumericUnboxedVector (undefined :: Data.Vector.Unboxed.Vector Float)
+    testNumericUnboxedVector (undefined :: Data.Vector.Unboxed.Vector Float)
   , testGroup "(Double)" $
     testNumericUnboxedVector (undefined :: Data.Vector.Unboxed.Vector Double)
   , testGroup "(Int,Bool)" $

--- a/tests/Tests/Vector/Unboxed.hs
+++ b/tests/Tests/Vector/Unboxed.hs
@@ -15,6 +15,7 @@ testGeneralUnboxedVector dummy = concatMap ($ dummy)
     testSanity
   , testPolymorphicFunctions
   , testOrdFunctions
+  , testTuplyFunctions
   , testMonoidFunctions
   , testDataFunctions
   ]

--- a/tests/Utilities.hs
+++ b/tests/Utilities.hs
@@ -68,42 +68,42 @@ class (Testable (EqTest a), Conclusion (EqTest a)) => TestData a where
   type EqTest a
   equal :: a -> a -> EqTest a
 
-instance Eq a => TestData (S.Bundle v a) where
-  type Model (S.Bundle v a) = [a]
-  model = S.toList
-  unmodel = S.fromList
+instance (Eq a, TestData a) => TestData (S.Bundle v a) where
+  type Model (S.Bundle v a) = [Model a]
+  model   = map model  . S.toList
+  unmodel = S.fromList . map unmodel
 
   type EqTest (S.Bundle v a) = Property
   equal x y = property (x == y)
 
-instance Eq a => TestData (DV.Vector a) where
-  type Model (DV.Vector a) = [a]
-  model = DV.toList
-  unmodel = DV.fromList
+instance (Eq a, TestData a) => TestData (DV.Vector a) where
+  type Model (DV.Vector a) = [Model a]
+  model   = map model    . DV.toList
+  unmodel = DV.fromList . map unmodel
 
   type EqTest (DV.Vector a) = Property
   equal x y = property (x == y)
 
-instance (Eq a, DVP.Prim a) => TestData (DVP.Vector a) where
-  type Model (DVP.Vector a) = [a]
-  model = DVP.toList
-  unmodel = DVP.fromList
+instance (Eq a, DVP.Prim a, TestData a) => TestData (DVP.Vector a) where
+  type Model (DVP.Vector a) = [Model a]
+  model   = map model    . DVP.toList
+  unmodel = DVP.fromList . map unmodel
 
   type EqTest (DVP.Vector a) = Property
   equal x y = property (x == y)
 
-instance (Eq a, DVS.Storable a) => TestData (DVS.Vector a) where
-  type Model (DVS.Vector a) = [a]
-  model = DVS.toList
-  unmodel = DVS.fromList
+instance (Eq a, DVS.Storable a, TestData a) => TestData (DVS.Vector a) where
+  type Model (DVS.Vector a) = [Model a]
+  model   = map model    . DVS.toList
+  unmodel = DVS.fromList . map unmodel
 
   type EqTest (DVS.Vector a) = Property
   equal x y = property (x == y)
 
-instance (Eq a, DVU.Unbox a) => TestData (DVU.Vector a) where
-  type Model (DVU.Vector a) = [a]
-  model = DVU.toList
-  unmodel = DVU.fromList
+instance (Eq a, DVU.Unbox a, TestData a) => TestData (DVU.Vector a) where
+  type Model (DVU.Vector a) = [Model a]
+  model   = map model    . DVU.toList
+  unmodel = DVU.fromList . map unmodel
 
   type EqTest (DVU.Vector a) = Property
   equal x y = property (x == y)

--- a/tests/Utilities.hs
+++ b/tests/Utilities.hs
@@ -247,6 +247,7 @@ indices m = sized $ \n ->
 singleton x = [x]
 snoc xs x = xs ++ [x]
 generate n f = [f i | i <- [0 .. n-1]]
+generateM n f = sequence [f i | i <- [0 .. n-1]]
 slice i n xs = take n (drop i xs)
 backpermute xs is = map (xs!!) is
 prescanl f z = init . scanl f z


### PR DESCRIPTION
This PR either adds tests for functions mentioned in TODO list or just removes mention if test is already present. Some tweaks in test machinery were necessary to implement `sequence` tests.

Hopefully travis won't choke on test suite again. I noticed some increase of memory consumption during build but I'm not sure how bad is it. 

I guess when it get merged we could close #12