### PR TITLE
make dropWhile fusion adaptive

### DIFF
--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1381,8 +1381,19 @@ takeWhile f = unstream . Bundle.takeWhile f . stream
 -- | /O(n)/ Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Vector v a => (a -> Bool) -> v a -> v a
-{-# INLINE dropWhile #-}
-dropWhile f = unstream . Bundle.dropWhile f . stream
+{-# INLINE_FUSED dropWhile #-}
+-- In the case that the argument is an actual vector,
+-- this is a faster solution than stream fusion.
+dropWhile f xs = case findIndex (not . f) xs of
+                   Just i  -> unsafeDrop i xs
+                   Nothing -> empty
+
+-- If the argument to 'dropWhile' comes from a stream,
+-- we need to avoid unnecessary allocation.
+{-# RULES
+"dropWhile/unstream [Vector]" forall f p.
+  dropWhile f (new (New.unstream p)) = new (New.unstream (Bundle.dropWhile f p))
+  #-}
 
 -- Parititioning
 -- -------------

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1388,8 +1388,13 @@ dropWhile f xs = case findIndex (not . f) xs of
                    Just i  -> unsafeDrop i xs
                    Nothing -> empty
 
--- If the argument to 'dropWhile' comes from a stream,
--- we need to avoid unnecessary allocation.
+-- If we have optimization turned on
+-- and the argument to 'dropWhile' comes from a stream,
+-- we never allocate the argument vector, and
+-- whenever possible, we avoid creating the resulting vector actually in heap.
+--
+-- Also note that @'new' . 'New.unstream'@
+-- is the definition (to be @INLINE@d) of 'unstream'.
 {-# RULES
 "dropWhile/unstream [Vector]" forall f p.
   dropWhile f (new (New.unstream p)) = new (New.unstream (Bundle.dropWhile f p))


### PR DESCRIPTION
Now dropWhile's implementation uses stream
only in case the stream fusion is already running.
This is expected to reduce unnecessary re-allocation.
This is an improvement of #146, which does not admit stream fusion in any case.

I've executed the tests included in the package with GHC 8.6.5 and 8.8.3.
If you wish to have other tests done, please tell me.
 
cf. https://github.com/haskell/vector/issues/141
https://github.com/haskell/vector/issues/108