### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/vector.cabal
+++ b/vector.cabal
@@ -201,7 +201,9 @@ test-suite vector-tests-O0
                  primitive, random,
                  QuickCheck >= 2.9 && < 2.14 , HUnit, tasty,
                  tasty-hunit, tasty-quickcheck,
-                 transformers >= 0.2.0.0, semigroups
+                 transformers >= 0.2.0.0
+  if !impl(ghc > 8.0)
+    Build-Depends: semigroups
 
   default-extensions: CPP,
               ScopedTypeVariables,
@@ -244,7 +246,9 @@ test-suite vector-tests-O2
                  primitive, random,
                  QuickCheck >= 2.9 && < 2.14 , HUnit,  tasty,
                  tasty-hunit, tasty-quickcheck,
-                 transformers >= 0.2.0.0, semigroups
+                 transformers >= 0.2.0.0
+  if !impl(ghc > 8.0)
+    Build-Depends: semigroups
 
   default-extensions: CPP,
               ScopedTypeVariables,


### PR DESCRIPTION
They are not needed on newer GHC.