### PR TITLE
Use ST instead of polymorphic m in Vector/MVector type classes

### DIFF
--- a/Data/Vector/Fusion/Util.hs
+++ b/Data/Vector/Fusion/Util.hs
@@ -12,7 +12,7 @@
 --
 
 module Data.Vector.Fusion.Util (
-  Id(..), Box(..),
+  Id(..), Box(..), liftBox,
 
   delay_inline, delayed_min
 ) where
@@ -44,6 +44,10 @@ instance Applicative Box where
 instance Monad Box where
   return = pure
   Box x >>= f = f x
+
+liftBox :: Monad m => Box a -> m a
+liftBox (Box a) = return a
+{-# INLINE liftBox #-}
 
 -- | Delay inlining a function until late in the game (simplifier phase 0).
 delay_inline :: (a -> b) -> a -> b

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -235,7 +235,7 @@ infixl 9 !
 (!) :: Vector v a => v a -> Int -> a
 {-# INLINE_FUSED (!) #-}
 (!) v i = BOUNDS_CHECK(checkIndex) "(!)" i (length v)
-        $ unId (basicUnsafeIndexM v i)
+        $ unBox (basicUnsafeIndexM v i)
 
 infixl 9 !?
 -- | O(1) Safe indexing
@@ -258,7 +258,7 @@ last v = v ! (length v - 1)
 unsafeIndex :: Vector v a => v a -> Int -> a
 {-# INLINE_FUSED unsafeIndex #-}
 unsafeIndex v i = UNSAFE_CHECK(checkIndex) "unsafeIndex" i (length v)
-                $ unId (basicUnsafeIndexM v i)
+                $ unBox (basicUnsafeIndexM v i)
 
 -- | /O(1)/ First element without checking if the vector is empty
 unsafeHead :: Vector v a => v a -> a
@@ -320,6 +320,7 @@ unsafeLast v = unsafeIndex v (length v - 1)
 indexM :: (Vector v a, Monad m) => v a -> Int -> m a
 {-# INLINE_FUSED indexM #-}
 indexM v i = BOUNDS_CHECK(checkIndex) "indexM" i (length v)
+           $ liftBox
            $ basicUnsafeIndexM v i
 
 -- | /O(1)/ First element of a vector in a monad. See 'indexM' for an
@@ -339,6 +340,7 @@ lastM v = indexM v (length v - 1)
 unsafeIndexM :: (Vector v a, Monad m) => v a -> Int -> m a
 {-# INLINE_FUSED unsafeIndexM #-}
 unsafeIndexM v i = UNSAFE_CHECK(checkIndex) "unsafeIndexM" i (length v)
+                 $ liftBox
                  $ basicUnsafeIndexM v i
 
 -- | /O(1)/ First element in a monad without checking for empty vectors.

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -2002,7 +2002,7 @@ convert = unstream . Bundle.reVector . stream
 unsafeFreeze
   :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m (v a)
 {-# INLINE unsafeFreeze #-}
-unsafeFreeze = basicUnsafeFreeze
+unsafeFreeze = stToPrim . basicUnsafeFreeze
 
 -- | /O(n)/ Yield an immutable copy of the mutable vector.
 freeze :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m (v a)
@@ -2013,7 +2013,7 @@ freeze mv = unsafeFreeze =<< M.clone mv
 -- copying. The immutable vector may not be used after this operation.
 unsafeThaw :: (PrimMonad m, Vector v a) => v a -> m (Mutable v (PrimState m) a)
 {-# INLINE_FUSED unsafeThaw #-}
-unsafeThaw = basicUnsafeThaw
+unsafeThaw = stToPrim . basicUnsafeThaw
 
 -- | /O(n)/ Yield a mutable copy of the immutable vector.
 thaw :: (PrimMonad m, Vector v a) => v a -> m (Mutable v (PrimState m) a)
@@ -2072,7 +2072,7 @@ unsafeCopy
 {-# INLINE unsafeCopy #-}
 unsafeCopy dst src = UNSAFE_CHECK(check) "unsafeCopy" "length mismatch"
                                          (M.length dst == basicLength src)
-                   $ (dst `seq` src `seq` basicUnsafeCopy dst src)
+                   $ (dst `seq` src `seq` stToPrim (basicUnsafeCopy dst src))
 
 -- Conversions to/from Bundles
 -- ---------------------------

--- a/Data/Vector/Generic/Base.hs
+++ b/Data/Vector/Generic/Base.hs
@@ -25,6 +25,7 @@ module Data.Vector.Generic.Base (
 import           Data.Vector.Generic.Mutable.Base ( MVector )
 import qualified Data.Vector.Generic.Mutable.Base as M
 
+import Control.Monad.ST
 import Control.Monad.Primitive
 
 -- | @Mutable v s a@ is the mutable version of the pure vector type @v a@ with
@@ -59,13 +60,13 @@ class MVector (Mutable v) a => Vector v a where
   -- Unsafely convert a mutable vector to its immutable version
   -- without copying. The mutable vector may not be used after
   -- this operation.
-  basicUnsafeFreeze :: PrimMonad m => Mutable v (PrimState m) a -> m (v a)
+  basicUnsafeFreeze :: Mutable v s a -> ST s (v a)
 
   -- | /Assumed complexity: O(1)/
   --
   -- Unsafely convert an immutable vector to its mutable version without
   -- copying. The immutable vector may not be used after this operation.
-  basicUnsafeThaw :: PrimMonad m => v a -> m (Mutable v (PrimState m) a)
+  basicUnsafeThaw :: v a -> ST s (Mutable v s a)
 
   -- | /Assumed complexity: O(1)/
   --
@@ -117,7 +118,7 @@ class MVector (Mutable v) a => Vector v a where
   --
   -- Default definition: copying basic on 'basicUnsafeIndexM' and
   -- 'basicUnsafeWrite'.
-  basicUnsafeCopy :: PrimMonad m => Mutable v (PrimState m) a -> v a -> m ()
+  basicUnsafeCopy :: Mutable v s a -> v a -> ST s ()
 
   {-# INLINE basicUnsafeCopy #-}
   basicUnsafeCopy !dst !src = do_copy 0

--- a/Data/Vector/Generic/Base.hs
+++ b/Data/Vector/Generic/Base.hs
@@ -24,6 +24,7 @@ module Data.Vector.Generic.Base (
 
 import           Data.Vector.Generic.Mutable.Base ( MVector )
 import qualified Data.Vector.Generic.Mutable.Base as M
+import           Data.Vector.Fusion.Util (Box(..), liftBox)
 
 import Control.Monad.ST
 import Control.Monad.Primitive
@@ -106,7 +107,7 @@ class MVector (Mutable v) a => Vector v a where
   -- which does not have this problem because indexing (but not the returned
   -- element!) is evaluated immediately.
   --
-  basicUnsafeIndexM  :: Monad m => v a -> Int -> m a
+  basicUnsafeIndexM  :: v a -> Int -> Box a
 
   -- |  /Assumed complexity: O(n)/
   --
@@ -126,7 +127,7 @@ class MVector (Mutable v) a => Vector v a where
       !n = basicLength src
 
       do_copy i | i < n = do
-                            x <- basicUnsafeIndexM src i
+                            x <- liftBox $ basicUnsafeIndexM src i
                             M.basicUnsafeWrite dst i x
                             do_copy (i+1)
                 | otherwise = return ()

--- a/Data/Vector/Generic/Mutable/Base.hs
+++ b/Data/Vector/Generic/Mutable/Base.hs
@@ -15,6 +15,7 @@ module Data.Vector.Generic.Mutable.Base (
   MVector(..)
 ) where
 
+import Control.Monad.ST
 import Control.Monad.Primitive ( PrimMonad, PrimState )
 
 -- Data.Vector.Internal.Check is unused
@@ -41,7 +42,7 @@ class MVector v a where
 
   -- | Create a mutable vector of the given length. This method should not be
   -- called directly, use 'unsafeNew' instead.
-  basicUnsafeNew   :: PrimMonad m => Int -> m (v (PrimState m) a)
+  basicUnsafeNew   :: Int -> ST s (v s a)
 
   -- | Initialize a vector to a standard value. This is intended to be called as
   -- part of the safe new operation (and similar operations), to properly blank
@@ -51,46 +52,45 @@ class MVector v a where
   -- this as a no-op.
   --
   -- @since 0.11.0.0
-  basicInitialize :: PrimMonad m => v (PrimState m) a -> m ()
+  basicInitialize :: v s a -> ST s ()
 
   -- | Create a mutable vector of the given length and fill it with an
   -- initial value. This method should not be called directly, use
   -- 'replicate' instead.
-  basicUnsafeReplicate :: PrimMonad m => Int -> a -> m (v (PrimState m) a)
+  basicUnsafeReplicate :: Int -> a -> ST s (v s a)
 
   -- | Yield the element at the given position. This method should not be
   -- called directly, use 'unsafeRead' instead.
-  basicUnsafeRead  :: PrimMonad m => v (PrimState m) a -> Int -> m a
+  basicUnsafeRead  :: v s a -> Int -> ST s a
 
   -- | Replace the element at the given position. This method should not be
   -- called directly, use 'unsafeWrite' instead.
-  basicUnsafeWrite :: PrimMonad m => v (PrimState m) a -> Int -> a -> m ()
+  basicUnsafeWrite :: v s a -> Int -> a -> ST s ()
 
   -- | Reset all elements of the vector to some undefined value, clearing all
   -- references to external objects. This is usually a noop for unboxed
   -- vectors. This method should not be called directly, use 'clear' instead.
-  basicClear       :: PrimMonad m => v (PrimState m) a -> m ()
+  basicClear       :: v s a -> ST s ()
 
   -- | Set all elements of the vector to the given value. This method should
   -- not be called directly, use 'set' instead.
-  basicSet         :: PrimMonad m => v (PrimState m) a -> a -> m ()
+  basicSet         :: v s a -> a -> ST s ()
 
   -- | Copy a vector. The two vectors may not overlap. This method should not
   -- be called directly, use 'unsafeCopy' instead.
-  basicUnsafeCopy  :: PrimMonad m => v (PrimState m) a   -- ^ target
-                                  -> v (PrimState m) a   -- ^ source
-                                  -> m ()
+  basicUnsafeCopy  :: v s a   -- ^ target
+                   -> v s a   -- ^ source
+                   -> ST s ()
 
   -- | Move the contents of a vector. The two vectors may overlap. This method
   -- should not be called directly, use 'unsafeMove' instead.
-  basicUnsafeMove  :: PrimMonad m => v (PrimState m) a   -- ^ target
-                                  -> v (PrimState m) a   -- ^ source
-                                  -> m ()
+  basicUnsafeMove  :: v s a   -- ^ target
+                   -> v s a   -- ^ source
+                   -> ST s ()
 
   -- | Grow a vector by the given number of elements. This method should not be
   -- called directly, use 'unsafeGrow' instead.
-  basicUnsafeGrow  :: PrimMonad m => v (PrimState m) a -> Int
-                                                       -> m (v (PrimState m) a)
+  basicUnsafeGrow  :: v s a -> Int -> ST s (v s a)
 
   {-# INLINE basicUnsafeReplicate #-}
   basicUnsafeReplicate n x

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -168,7 +168,10 @@ module Data.Vector.Unboxed (
   G.convert,
 
   -- ** Mutable vectors
-  freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy
+  freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy,
+
+  -- ** Deriving via
+  UnboxViaPrim(..)
 ) where
 
 import Data.Vector.Unboxed.Base

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -34,7 +34,26 @@
 --
 -- instance ('RealFloat' a, 'Unbox' a) => 'Unbox' ('Complex' a)
 -- @
-
+--
+-- For newtype defining instances is easier since one could use
+-- GenerazedNewtypeDeriving in order to derive instances for
+-- 'Data.Vector.Generic.Vector' and
+-- 'Data.Vector.Generic.Mutable.MVector' type classes since they're
+-- very cumbersome to write by hand:
+--
+-- >>> :set -XTypeFamilies -XStandaloneDeriving -XMultiParamTypeClasses -XGeneralizedNewtypeDeriving
+-- >>>
+-- >>> import qualified Data.Vector.Unboxed         as U
+-- >>> import qualified Data.Vector.Generic         as G
+-- >>> import qualified Data.Vector.Generic.Mutable as M
+-- >>>
+-- >>> newtype Foo = Foo Int
+-- >>>
+-- >>> newtype instance U.MVector s Foo = MV_Int (U.MVector s Int)
+-- >>> newtype instance U.Vector    Foo = V_Int  (U.Vector    Int)
+-- >>> deriving instance M.MVector MVector Foo
+-- >>> deriving instance G.Vector  Vector  Foo
+-- >>> instance Unbox Foo
 module Data.Vector.Unboxed (
   -- * Unboxed vectors
   Vector, MVector(..), Unbox,

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changes in NEXT_VERSION
 
+ * Methods of type classes `Data.Vector.Generic.Mutable.MVector` and
+   `Data.Vector.Generic.Vector` use concrete monads (ST,etc) being
+   polymorphic. This allows use of GND and deriving via to define
+   instances. Rest of API is unchanged and most existing instances should
+   compiler fine with new definitions.
  * Added `mapMaybeM` & `imapMaybeM`
  * Added `isSameVector` for storable vectors
  * Added `catMaybes`


### PR DESCRIPTION
This is implementation of idea from #315. Instead of using polymorphic `m` in methods of MVector/Vector type class use ST and lift it to PrimMonad at use sites. It's probably easier to illustrate idea with few diffs:

```
-  basicUnsafeNew   :: PrimMonad m => Int -> m (v (PrimState m) a)
+  basicUnsafeNew   :: Int -> ST s (v s a)
```
```
 unsafeRead v i = UNSAFE_CHECK(checkIndex) "unsafeRead" i (length v)
+               $ stToPrim
                $ basicUnsafeRead v i
```

Main motivation for change is to allow GND for those type classes. It's partial success. In following code snippet:

```haskell
newtype instance MVector s (Sum a) = MV_Sum (MVector s a)
newtype instance Vector    (Sum a) = V_Sum  (Vector a)
deriving instance Unbox a => G.Vector  Vector  (Sum a)
deriving instance Unbox a => M.MVector MVector (Sum a)
```

MVector instance derived successfully. Vector fails with:
```
    • Couldn't match representation of type ‘m1 a’
                               with that of ‘m1 (Sum a)’
```
because of `basicUnsafeIndexM  :: Monad m => v a -> Int -> m a`. GHC cannot coerce between `m a` and `m (Sum a)`. I'm a bit at loss here. 