### PR TITLE
Add equality that uses pointer equality as optimization

### DIFF
--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -129,6 +129,10 @@ module Data.Vector.Storable (
   -- ** Comparisons
   eqBy, cmpBy,
 
+  -- * Utilities
+  -- ** Comparisons
+  isSameVector,
+
   -- * Conversions
 
   -- ** Lists
@@ -979,6 +983,16 @@ izipWith6 :: (Storable a, Storable b, Storable c, Storable d, Storable e,
           -> Vector f -> Vector g
 {-# INLINE izipWith6 #-}
 izipWith6 = G.izipWith6
+
+-- | Checks whether two values are same vector: they have same length
+--   and share same buffer.
+--
+-- >>> let xs = fromList [0/0::Double] in isSameVector xs xs
+-- True
+isSameVector :: (Storable a) => Vector a -> Vector a -> Bool
+{-# INLINE isSameVector #-}
+isSameVector (Vector n1 ptr1) (Vector n2 ptr2) = n1 == n2 && ptr1 == ptr2
+
 
 -- Monadic zipping
 -- ---------------

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changes in NEXT_VERSION
 
+ * Added `isSameVector` for storable vectors
  * Added `catMaybes`
  * Added `MonadFix` instance for boxed vectors
  * New functions: `unfoldrExactN` and `unfoldrExactNM`

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changes in NEXT_VERSION
 
+ * Added `mapMaybeM` & `imapMaybeM`
  * Added `isSameVector` for storable vectors
  * Added `catMaybes`
  * Added `MonadFix` instance for boxed vectors

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -1,0 +1,4 @@
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = doctest ["-Iinclude", "-Iinternal", "Data"]

--- a/vector.cabal
+++ b/vector.cabal
@@ -266,3 +266,17 @@ test-suite vector-tests-O2
     Ghc-Options: -fno-warn-orphans -fno-warn-missing-signatures
     if impl(ghc >= 8.0) && impl(ghc < 8.1)
       Ghc-Options: -Wno-redundant-constraints
+
+test-suite vector-doctest
+  type:             exitcode-stdio-1.0
+  main-is:          doctests.hs
+  hs-source-dirs:   tests
+  default-language: Haskell2010
+  -- Older GHC choke on {-# UNPACK #-} pragma for some reason
+  if impl(ghc < 8.6)
+    buildable: False
+  build-depends:
+        base      -any
+      , doctest   >=0.15 && <0.18
+      , primitive >= 0.6.4.0 && < 0.8
+      , vector    -any


### PR DESCRIPTION
Fixes #239 

Also adds doctests. Those don't test anything beyond fastEq but adding more should be easy