### PR TITLE
Separate section for primitive and storable re-exports. Fix #348

### DIFF
--- a/Data/Vector/Generic/Mutable.hs
+++ b/Data/Vector/Generic/Mutable.hs
@@ -58,8 +58,8 @@ module Data.Vector.Generic.Mutable (
   unsafeAccum, accum, unsafeUpdate, update, reverse,
   unstablePartition, unstablePartitionBundle, partitionBundle,
   partitionWithBundle,
-  -- * Reexports
-  PrimMonad(..), RealWorld
+  -- * Re-exports
+  PrimMonad, PrimState, RealWorld
 ) where
 
 import           Data.Vector.Generic.Mutable.Base

--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -52,8 +52,8 @@ module Data.Vector.Mutable (
   -- ** Arrays
   fromMutableArray, toMutableArray,
 
-  -- * Reexports
-  PrimMonad(..), RealWorld
+  -- * Re-exports
+  PrimMonad, PrimState, RealWorld
 ) where
 
 import           Control.Monad (when, liftM)

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -18,7 +18,7 @@
 
 module Data.Vector.Primitive (
   -- * Primitive vectors
-  Vector(..), MVector(..), Prim,
+  Vector(..), MVector(..),
 
   -- * Accessors
 
@@ -143,7 +143,10 @@ module Data.Vector.Primitive (
   unsafeCoerceVector,
 
   -- ** Mutable vectors
-  freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy
+  freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy,
+
+  -- ** Re-exports
+  Prim
 ) where
 
 import qualified Data.Vector.Generic           as G

--- a/Data/Vector/Primitive/Mutable.hs
+++ b/Data/Vector/Primitive/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Primitive.Mutable (
   -- * Mutable vectors of primitive types
-  MVector(..), IOVector, STVector, Prim,
+  MVector(..), IOVector, STVector,
 
   -- * Accessors
 
@@ -51,8 +51,8 @@ module Data.Vector.Primitive.Mutable (
 
   -- * Unsafe conversions
   unsafeCoerceMVector,
-  -- * Reexports
-  PrimMonad(..), RealWorld
+  -- * Re-exports
+  Prim, PrimMonad, PrimState, RealWorld
 ) where
 
 import qualified Data.Vector.Generic.Mutable as G

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Storable (
   -- * Storable vectors
-  Vector, MVector(..), Storable,
+  Vector, MVector(..),
 
   -- * Accessors
 
@@ -148,7 +148,10 @@ module Data.Vector.Storable (
   -- * Raw pointers
   unsafeFromForeignPtr, unsafeFromForeignPtr0,
   unsafeToForeignPtr,   unsafeToForeignPtr0,
-  unsafeWith
+  unsafeWith,
+
+  -- * Re-exports
+  Storable
 ) where
 
 import qualified Data.Vector.Generic          as G

--- a/Data/Vector/Storable/Mutable.hs
+++ b/Data/Vector/Storable/Mutable.hs
@@ -14,7 +14,7 @@
 
 module Data.Vector.Storable.Mutable(
   -- * Mutable vectors of 'Storable' types
-  MVector(..), IOVector, STVector, Storable,
+  MVector(..), IOVector, STVector,
 
   -- * Accessors
 
@@ -56,8 +56,8 @@ module Data.Vector.Storable.Mutable(
   unsafeFromForeignPtr, unsafeFromForeignPtr0,
   unsafeToForeignPtr,   unsafeToForeignPtr0,
   unsafeWith,
-  -- * Reexports
-  PrimMonad(..), RealWorld,
+  -- * Re-exports
+  Storable, PrimMonad, PrimState, RealWorld
 ) where
 
 import Control.DeepSeq ( NFData(rnf)

--- a/Data/Vector/Unboxed/Mutable.hs
+++ b/Data/Vector/Unboxed/Mutable.hs
@@ -52,8 +52,8 @@ module Data.Vector.Unboxed.Mutable (
 
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
-  -- * Reexports
-  PrimMonad(..), RealWorld,
+  -- * Re-exports
+  PrimMonad, PrimState, RealWorld
 ) where
 
 import Data.Vector.Unboxed.Base


### PR DESCRIPTION
Avoid re-exporting `primitive` function. 