### PR TITLE
Add doctests for minmum/maximum related functions

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -1638,15 +1638,33 @@ maximum :: Ord a => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | /O(n)/ Yield the maximum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the maximum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie the last occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector as V
+-- >>> V.maximumBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- (2.0,'a')
+-- >>> V.maximumBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'b')
 maximumBy :: (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the first occurrence
+-- of a key function on each element. In case of a tie, the last occurrence
 -- wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.maximumOn fst $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- (2.0,'a')
+-- >>> V.maximumOn fst $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'b')
 maximumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
@@ -1657,8 +1675,18 @@ minimum :: Ord a => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | /O(n)/ Yield the minimum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the minimum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie, the first occurrence wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector as V
+-- >>> V.minimumBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- (1.0,'b')
+-- >>> V.minimumBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'a')
 minimumBy :: (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
@@ -1666,6 +1694,14 @@ minimumBy = G.minimumBy
 -- | /O(n)/ Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.minimumOn fst $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- (1.0,'b')
+-- >>> V.minimumOn fst $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'a')
 minimumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
@@ -1676,8 +1712,18 @@ maxIndex :: Ord a => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | /O(n)/ Yield the index of the maximum element of the vector according to
--- the given comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the index of the maximum element of the vector
+-- according to the given comparison function. The vector may not be
+-- empty. In case of a tie, the last occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector as V
+-- >>> V.maxIndexBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- 0
+-- >>> V.maxIndexBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- 1
 maxIndexBy :: (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
@@ -1690,6 +1736,15 @@ minIndex = G.minIndex
 
 -- | /O(n)/ Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector as V
+-- >>> V.minIndexBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- 1
+-- >>> V.minIndexBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- 0
 minIndexBy :: (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE minIndexBy #-}
 minIndexBy = G.minIndexBy

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -1647,7 +1647,10 @@ product = G.product
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector as V
+-- >>> import qualified Data.Vector.Generic as VG
 -- >>> V.maximum $ V.fromList [2.0, 1.0]
+-- 2.0
+-- >>> VG.maximum $ V.fromList [2.0, 1.0]
 -- 2.0
 -- >>> import Data.Semigroup
 -- >>> V.maximum $ V.fromList [Arg 1.0 'a', Arg 2.0 'b']

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -1633,7 +1633,18 @@ product :: Num a => Vector a -> a
 product = G.product
 
 -- | /O(n)/ Yield the maximum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.maximum $ V.fromList [2.0, 1.0]
+-- 2.0
+-- >>> import Data.Semigroup
+-- >>> V.maximum $ V.fromList [Arg 1.0 'a', Arg 2.0 'b']
+-- Arg 2.0 'b'
+-- >>> V.maximum $ V.fromList [Arg 1.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'a'
 maximum :: Ord a => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
@@ -1670,7 +1681,18 @@ maximumOn :: Ord b => (a -> b) -> Vector a -> a
 maximumOn = G.maximumOn
 
 -- | /O(n)/ Yield the minimum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.minimum $ V.fromList [2.0, 1.0]
+-- 1.0
+-- >>> import Data.Semigroup
+-- >>> V.minimum $ V.fromList [Arg 2.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'b'
+-- >>> V.minimum $ V.fromList [Arg 1.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'a'
 minimum :: Ord a => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -1647,10 +1647,7 @@ product = G.product
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector as V
--- >>> import qualified Data.Vector.Generic as VG
 -- >>> V.maximum $ V.fromList [2.0, 1.0]
--- 2.0
--- >>> VG.maximum $ V.fromList [2.0, 1.0]
 -- 2.0
 -- >>> import Data.Semigroup
 -- >>> V.maximum $ V.fromList [Arg 1.0 'a', Arg 2.0 'b']
@@ -1663,7 +1660,8 @@ maximum = G.maximum
 
 -- | /O(n)/ Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie the last occurrence wins.
+-- a tie the first occurrence wins. This behavior is different from
+-- 'Data.List.maximumBy' which returns the last tie.
 --
 -- ==== __Examples__
 --
@@ -1672,7 +1670,7 @@ maximum = G.maximum
 -- >>> V.maximumBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
 -- (2.0,'a')
 -- >>> V.maximumBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
--- (1.0,'b')
+-- (1.0,'a')
 maximumBy :: (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
@@ -1711,7 +1709,7 @@ minimum = G.minimum
 
 -- | /O(n)/ Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie, the first occurrence wins. The vector may not be empty.
+-- a tie, the first occurrence wins.
 --
 -- ==== __Examples__
 --
@@ -1748,7 +1746,7 @@ maxIndex = G.maxIndex
 
 -- | /O(n)/ Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
--- empty. In case of a tie, the last occurrence wins.
+-- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
 --
@@ -1757,7 +1755,7 @@ maxIndex = G.maxIndex
 -- >>> V.maxIndexBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
 -- 0
 -- >>> V.maxIndexBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
--- 1
+-- 0
 maxIndexBy :: (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -1676,7 +1676,7 @@ maximumBy :: (a -> a -> Ordering) -> Vector a -> a
 maximumBy = G.maximumBy
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the last occurrence
+-- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1685,7 +1685,7 @@ maximumBy = G.maximumBy
 -- >>> V.maximumOn fst $ V.fromList [(2.0,'a'), (1.0,'b')]
 -- (2.0,'a')
 -- >>> V.maximumOn fst $ V.fromList [(1.0,'a'), (1.0,'b')]
--- (1.0,'b')
+-- (1.0,'a')
 maximumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn

--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -1318,7 +1318,16 @@ ifilter :: (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | /O(n)/ Drop repeated adjacent elements.
+-- | /O(n)/ Drop repeated adjacent elements. First element in group is returned.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.uniq $ V.fromList [1.0,3.0,3.0,200.0,3.0]
+-- [1.0,3.0,200.0,3.0]
+-- >>> import Data.Semigroup
+-- >>> V.uniq $ V.fromList [ Arg 1 'a', Arg 1 'b', Arg (1 :: Int) 'c']
+-- [Arg 1 'a']
 uniq :: (Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1792,7 +1792,10 @@ product = Bundle.foldl' (*) 1 . stream
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector as V
+-- >>> import qualified Data.Vector.Generic as VG
 -- >>> V.maximum $ V.fromList [2.0, 1.0]
+-- 2.0
+-- >>> VG.maximum $ V.fromList [2.0, 1.0]
 -- 2.0
 -- >>> import Data.Semigroup
 -- >>> V.maximum $ V.fromList [Arg 1.0 'a', Arg 2.0 'b']

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1824,8 +1824,8 @@ maximumBy cmpr = Bundle.foldl1' maxBy . stream
   where
     {-# INLINE maxBy #-}
     maxBy x y = case cmpr x y of
-                  GT -> x
-                  _  -> y
+                  LT -> y
+                  _  -> x
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the last occurrence

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1385,7 +1385,16 @@ ifilter f = unstream
           . inplace (S.map snd . S.filter (uncurry f) . S.indexed) toMax
           . stream
 
--- | /O(n)/ Drop repeated adjacent elements.
+-- | /O(n)/ Drop repeated adjacent elements. First element in group is returned.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.uniq $ V.fromList [1.0,3.0,3.0,200.0,3.0]
+-- [1.0,3.0,200.0,3.0]
+-- >>> import Data.Semigroup
+-- >>> V.uniq $ V.fromList [ Arg 1 'a', Arg 1 'b', Arg (1 :: Int) 'c']
+-- [Arg 1 'a']
 uniq :: (Vector v a, Eq a) => v a -> v a
 {-# INLINE uniq #-}
 uniq = unstream . inplace S.uniq toMax . stream

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1929,8 +1929,8 @@ maxIndexBy cmpr = fst . Bundle.foldl1' imax . Bundle.indexed . stream
   where
     imax (i,x) (j,y) = i `seq` j `seq`
                        case cmpr x y of
-                         GT -> (i,x)
-                         _  -> (j,y)
+                         LT -> (j,y)
+                         _  -> (i,x)
 
 -- | /O(n)/ Yield the index of the minimum element of the vector. The vector
 -- may not be empty.

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1783,8 +1783,18 @@ maximum :: (Vector v a, Ord a) => v a -> a
 {-# INLINE maximum #-}
 maximum = Bundle.foldl1' max . stream
 
--- | /O(n)/ Yield the maximum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the maximum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie the last occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector as V
+-- >>> V.maximumBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- (2.0,'a')
+-- >>> V.maximumBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'b')
 maximumBy :: Vector v a => (a -> a -> Ordering) -> v a -> a
 {-# INLINE maximumBy #-}
 maximumBy cmpr = Bundle.foldl1' maxBy . stream
@@ -1795,8 +1805,16 @@ maximumBy cmpr = Bundle.foldl1' maxBy . stream
                   _  -> y
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the first occurrence
+-- of a key function on each element. In case of a tie, the last occurrence
 -- wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.maximumOn fst $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- (2.0,'a')
+-- >>> V.maximumOn fst $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'b')
 maximumOn :: (Ord b, Vector v a) => (a -> b) -> v a -> a
 {-# INLINE maximumOn #-}
 maximumOn f = fst . Bundle.foldl1' maxBy . Bundle.map (\a -> (a, f a)) . stream
@@ -1812,8 +1830,18 @@ minimum :: (Vector v a, Ord a) => v a -> a
 {-# INLINE minimum #-}
 minimum = Bundle.foldl1' min . stream
 
--- | /O(n)/ Yield the minimum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the minimum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie, the first occurrence wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector as V
+-- >>> V.minimumBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- (1.0,'b')
+-- >>> V.minimumBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'a')
 minimumBy :: Vector v a => (a -> a -> Ordering) -> v a -> a
 {-# INLINE minimumBy #-}
 minimumBy cmpr = Bundle.foldl1' minBy . stream
@@ -1826,6 +1854,14 @@ minimumBy cmpr = Bundle.foldl1' minBy . stream
 -- | /O(n)/ Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.minimumOn fst $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- (1.0,'b')
+-- >>> V.minimumOn fst $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'a')
 minimumOn :: (Ord b, Vector v a) => (a -> b) -> v a -> a
 {-# INLINE minimumOn #-}
 minimumOn f = fst . Bundle.foldl1' minBy . Bundle.map (\a -> (a, f a)) . stream
@@ -1841,8 +1877,18 @@ maxIndex :: (Vector v a, Ord a) => v a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = maxIndexBy compare
 
--- | /O(n)/ Yield the index of the maximum element of the vector according to
--- the given comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the index of the maximum element of the vector
+-- according to the given comparison function. The vector may not be
+-- empty. In case of a tie, the last occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector as V
+-- >>> V.maxIndexBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- 0
+-- >>> V.maxIndexBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- 1
 maxIndexBy :: Vector v a => (a -> a -> Ordering) -> v a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy cmpr = fst . Bundle.foldl1' imax . Bundle.indexed . stream
@@ -1860,6 +1906,15 @@ minIndex = minIndexBy compare
 
 -- | /O(n)/ Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector as V
+-- >>> V.minIndexBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
+-- 1
+-- >>> V.minIndexBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
+-- 0
 minIndexBy :: Vector v a => (a -> a -> Ordering) -> v a -> Int
 {-# INLINE minIndexBy #-}
 minIndexBy cmpr = fst . Bundle.foldl1' imin . Bundle.indexed . stream

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1778,7 +1778,18 @@ product :: (Vector v a, Num a) => v a -> a
 product = Bundle.foldl' (*) 1 . stream
 
 -- | /O(n)/ Yield the maximum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.maximum $ V.fromList [2.0, 1.0]
+-- 2.0
+-- >>> import Data.Semigroup
+-- >>> V.maximum $ V.fromList [Arg 1.0 'a', Arg 2.0 'b']
+-- Arg 2.0 'b'
+-- >>> V.maximum $ V.fromList [Arg 1.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'a'
 maximum :: (Vector v a, Ord a) => v a -> a
 {-# INLINE maximum #-}
 maximum = Bundle.foldl1' max . stream
@@ -1825,7 +1836,18 @@ maximumOn f = fst . Bundle.foldl1' maxBy . Bundle.map (\a -> (a, f a)) . stream
                   _  -> y
 
 -- | /O(n)/ Yield the minimum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector as V
+-- >>> V.minimum $ V.fromList [2.0, 1.0]
+-- 1.0
+-- >>> import Data.Semigroup
+-- >>> V.minimum $ V.fromList [Arg 2.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'b'
+-- >>> V.minimum $ V.fromList [Arg 1.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'a'
 minimum :: (Vector v a, Ord a) => v a -> a
 {-# INLINE minimum #-}
 minimum = Bundle.foldl1' min . stream

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1792,10 +1792,7 @@ product = Bundle.foldl' (*) 1 . stream
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector as V
--- >>> import qualified Data.Vector.Generic as VG
 -- >>> V.maximum $ V.fromList [2.0, 1.0]
--- 2.0
--- >>> VG.maximum $ V.fromList [2.0, 1.0]
 -- 2.0
 -- >>> import Data.Semigroup
 -- >>> V.maximum $ V.fromList [Arg 1.0 'a', Arg 2.0 'b']
@@ -1808,7 +1805,8 @@ maximum = Bundle.foldl1' max . stream
 
 -- | /O(n)/ Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie the last occurrence wins.
+-- a tie the first occurrence wins. This behavior is different from
+-- 'Data.List.maximumBy' which returns the last tie.
 --
 -- ==== __Examples__
 --
@@ -1817,7 +1815,7 @@ maximum = Bundle.foldl1' max . stream
 -- >>> V.maximumBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
 -- (2.0,'a')
 -- >>> V.maximumBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
--- (1.0,'b')
+-- (1.0,'a')
 maximumBy :: Vector v a => (a -> a -> Ordering) -> v a -> a
 {-# INLINE maximumBy #-}
 maximumBy cmpr = Bundle.foldl1' maxBy . stream
@@ -1828,7 +1826,7 @@ maximumBy cmpr = Bundle.foldl1' maxBy . stream
                   _  -> x
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the last occurrence
+-- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1837,7 +1835,7 @@ maximumBy cmpr = Bundle.foldl1' maxBy . stream
 -- >>> V.maximumOn fst $ V.fromList [(2.0,'a'), (1.0,'b')]
 -- (2.0,'a')
 -- >>> V.maximumOn fst $ V.fromList [(1.0,'a'), (1.0,'b')]
--- (1.0,'b')
+-- (1.0,'a')
 maximumOn :: (Ord b, Vector v a) => (a -> b) -> v a -> a
 {-# INLINE maximumOn #-}
 maximumOn f = fst . Bundle.foldl1' maxBy . Bundle.map (\a -> (a, f a)) . stream
@@ -1866,7 +1864,7 @@ minimum = Bundle.foldl1' min . stream
 
 -- | /O(n)/ Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie, the first occurrence wins. The vector may not be empty.
+-- a tie, the first occurrence wins.
 --
 -- ==== __Examples__
 --
@@ -1913,7 +1911,7 @@ maxIndex = maxIndexBy compare
 
 -- | /O(n)/ Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
--- empty. In case of a tie, the last occurrence wins.
+-- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
 --
@@ -1922,7 +1920,7 @@ maxIndex = maxIndexBy compare
 -- >>> V.maxIndexBy (comparing fst) $ V.fromList [(2.0,'a'), (1.0,'b')]
 -- 0
 -- >>> V.maxIndexBy (comparing fst) $ V.fromList [(1.0,'a'), (1.0,'b')]
--- 1
+-- 0
 maxIndexBy :: Vector v a => (a -> a -> Ordering) -> v a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy cmpr = fst . Bundle.foldl1' imax . Bundle.indexed . stream

--- a/Data/Vector/Generic.hs
+++ b/Data/Vector/Generic.hs
@@ -1842,8 +1842,8 @@ maximumOn f = fst . Bundle.foldl1' maxBy . Bundle.map (\a -> (a, f a)) . stream
   where
     {-# INLINE maxBy #-}
     maxBy x y = case compare (snd x) (snd y) of
-                  GT -> x
-                  _  -> y
+                  LT -> y
+                  _  -> x
 
 -- | /O(n)/ Yield the minimum element of the vector. The vector may not be
 -- empty. In a case of a tie the first occurrence wins.

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -1365,7 +1365,10 @@ product = G.product
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Primitive as VP
+-- >>> import qualified Data.Vector.Generic as VG
 -- >>> VP.maximum $ VP.fromList [2.0, 1.0]
+-- 2.0
+-- >>> VG.maximum $ VP.fromList [2.0, 1.0]
 -- 2.0
 maximum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -1380,7 +1380,7 @@ maximumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 maximumBy = G.maximumBy
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the last occurrence
+-- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 maximumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -1354,7 +1354,13 @@ product :: (Prim a, Num a) => Vector a -> a
 product = G.product
 
 -- | /O(n)/ Yield the maximum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Primitive as VP
+-- >>> VP.maximum $ VP.fromList [2.0, 1.0]
+-- 2.0
 maximum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
@@ -1374,7 +1380,13 @@ maximumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 maximumOn = G.maximumOn
 
 -- | /O(n)/ Yield the minimum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Primitive as VP
+-- >>> VP.minimum $ VP.fromList [2.0, 1.0]
+-- 1.0
 minimum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -1359,14 +1359,15 @@ maximum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | /O(n)/ Yield the maximum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the maximum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie the last occurrence wins.
 maximumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the first occurrence
+-- of a key function on each element. In case of a tie, the last occurrence
 -- wins. The vector may not be empty.
 maximumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
@@ -1378,8 +1379,9 @@ minimum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | /O(n)/ Yield the minimum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the minimum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie, the first occurrence wins. The vector may not be empty.
 minimumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
@@ -1397,8 +1399,9 @@ maxIndex :: (Prim a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | /O(n)/ Yield the index of the maximum element of the vector according to
--- the given comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the index of the maximum element of the vector
+-- according to the given comparison function. The vector may not be
+-- empty. In case of a tie, the last occurrence wins.
 maxIndexBy :: Prim a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -1069,7 +1069,13 @@ ifilter :: Prim a => (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | /O(n)/ Drop repeated adjacent elements.
+-- | /O(n)/ Drop repeated adjacent elements. First element in group is returned.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Primitive as VP
+-- >>> VP.uniq $ VP.fromList [1.0,3.0,3.0,200.0,3.0]
+-- [1.0,3.0,200.0,3.0]
 uniq :: (Prim a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq

--- a/Data/Vector/Primitive.hs
+++ b/Data/Vector/Primitive.hs
@@ -1365,10 +1365,7 @@ product = G.product
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Primitive as VP
--- >>> import qualified Data.Vector.Generic as VG
 -- >>> VP.maximum $ VP.fromList [2.0, 1.0]
--- 2.0
--- >>> VG.maximum $ VP.fromList [2.0, 1.0]
 -- 2.0
 maximum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
@@ -1376,7 +1373,8 @@ maximum = G.maximum
 
 -- | /O(n)/ Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie the last occurrence wins.
+-- a tie the first occurrence wins. This behavior is different from
+-- 'Data.List.maximumBy' which returns the last tie.
 maximumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
@@ -1402,7 +1400,7 @@ minimum = G.minimum
 
 -- | /O(n)/ Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie, the first occurrence wins. The vector may not be empty.
+-- a tie, the first occurrence wins.
 minimumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
@@ -1422,7 +1420,7 @@ maxIndex = G.maxIndex
 
 -- | /O(n)/ Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
--- empty. In case of a tie, the last occurrence wins.
+-- empty. In case of a tie, the first occurrence wins.
 maxIndexBy :: Prim a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -1401,7 +1401,13 @@ product :: (Storable a, Num a) => Vector a -> a
 product = G.product
 
 -- | /O(n)/ Yield the maximum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Storable as VS
+-- >>> VS.maximum $ VS.fromList [2.0, 1.0]
+-- 2.0
 maximum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
@@ -1421,7 +1427,13 @@ maximumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 maximumOn = G.maximumOn
 
 -- | /O(n)/ Yield the minimum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Storable as VS
+-- >>> VS.minimum $ VS.fromList [2.0, 1.0]
+-- 1.0
 minimum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -1406,14 +1406,15 @@ maximum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | /O(n)/ Yield the maximum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the maximum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie the last occurrence wins.
 maximumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the first occurrence
+-- of a key function on each element. In case of a tie, the last occurrence
 -- wins. The vector may not be empty.
 maximumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
@@ -1425,8 +1426,9 @@ minimum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | /O(n)/ Yield the minimum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the minimum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie, the first occurrence wins. The vector may not be empty.
 minimumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
@@ -1444,8 +1446,9 @@ maxIndex :: (Storable a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | /O(n)/ Yield the index of the maximum element of the vector according to
--- the given comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the index of the maximum element of the vector
+-- according to the given comparison function. The vector may not be
+-- empty. In case of a tie, the last occurrence wins.
 maxIndexBy :: Storable a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -1412,10 +1412,7 @@ product = G.product
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Storable as VS
--- >>> import qualified Data.Vector.Generic as VG
 -- >>> VS.maximum $ VS.fromList [2.0, 1.0]
--- 2.0
--- >>> VG.maximum $ VS.fromList [2.0, 1.0]
 -- 2.0
 maximum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
@@ -1423,7 +1420,8 @@ maximum = G.maximum
 
 -- | /O(n)/ Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie the last occurrence wins.
+-- a tie the first occurrence wins. This behavior is different from
+-- 'Data.List.maximumBy' which returns the last tie.
 maximumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
@@ -1449,7 +1447,7 @@ minimum = G.minimum
 
 -- | /O(n)/ Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie, the first occurrence wins. The vector may not be empty.
+-- a tie, the first occurrence wins.
 minimumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
@@ -1469,7 +1467,7 @@ maxIndex = G.maxIndex
 
 -- | /O(n)/ Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
--- empty. In case of a tie, the last occurrence wins.
+-- empty. In case of a tie, the first occurrence wins.
 maxIndexBy :: Storable a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -1090,7 +1090,13 @@ ifilter :: Storable a => (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | /O(n)/ Drop repeated adjacent elements.
+-- | /O(n)/ Drop repeated adjacent elements. First element in group is returned.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Storable as VS
+-- >>> VS.uniq $ VS.fromList [1.0,3.0,3.0,200.0,3.0]
+-- [1.0,3.0,200.0,3.0]
 uniq :: (Storable a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -1427,7 +1427,7 @@ maximumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 maximumBy = G.maximumBy
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the last occurrence
+-- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 maximumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}

--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -1412,7 +1412,10 @@ product = G.product
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Storable as VS
+-- >>> import qualified Data.Vector.Generic as VG
 -- >>> VS.maximum $ VS.fromList [2.0, 1.0]
+-- 2.0
+-- >>> VG.maximum $ VS.fromList [2.0, 1.0]
 -- 2.0
 maximum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -1406,7 +1406,10 @@ product = G.product
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> import qualified Data.Vector.Generic as VG
 -- >>> VU.maximum $ VU.fromList [2.0, 1.0]
+-- 2.0
+-- >>> VG.maximum $ VU.fromList [2.0, 1.0]
 -- 2.0
 -- >>> import Data.Semigroup
 -- >>> VU.maximum $ VU.fromList [Arg 1.0 'a', Arg 2.0 'b']

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -1406,10 +1406,7 @@ product = G.product
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Unboxed as VU
--- >>> import qualified Data.Vector.Generic as VG
 -- >>> VU.maximum $ VU.fromList [2.0, 1.0]
--- 2.0
--- >>> VG.maximum $ VU.fromList [2.0, 1.0]
 -- 2.0
 -- >>> import Data.Semigroup
 -- >>> VU.maximum $ VU.fromList [Arg 1.0 'a', Arg 2.0 'b']
@@ -1422,7 +1419,8 @@ maximum = G.maximum
 
 -- | /O(n)/ Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie the last occurrence wins.
+-- a tie the first occurrence wins. This behavior is different from
+-- 'Data.List.maximumBy' which returns the last tie.
 --
 -- ==== __Examples__
 --
@@ -1431,7 +1429,7 @@ maximum = G.maximum
 -- >>> VU.maximumBy (comparing fst) $ VU.fromList [(2.0,'a'), (1.0,'b')]
 -- (2.0,'a')
 -- >>> VU.maximumBy (comparing fst) $ VU.fromList [(1.0,'a'), (1.0,'b')]
--- (1.0,'b')
+-- (1.0,'a')
 maximumBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
@@ -1469,7 +1467,7 @@ minimum :: (Unbox a, Ord a) => Vector a -> a
 minimum = G.minimum
 -- | /O(n)/ Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
--- a tie, the first occurrence wins. The vector may not be empty.
+-- a tie, the first occurrence wins.
 --
 -- ==== __Examples__
 --
@@ -1509,7 +1507,7 @@ maxIndex = G.maxIndex
 
 -- | /O(n)/ Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
--- empty. In case of a tie, the last occurrence wins.
+-- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
 --
@@ -1518,7 +1516,7 @@ maxIndex = G.maxIndex
 -- >>> VU.maxIndexBy (comparing fst) $ VU.fromList [(2.0,'a'), (1.0,'b')]
 -- 0
 -- >>> VU.maxIndexBy (comparing fst) $ VU.fromList [(1.0,'a'), (1.0,'b')]
--- 1
+-- 0
 maxIndexBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -1079,7 +1079,16 @@ filter :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | /O(n)/ Drop repeated adjacent elements.
+-- | /O(n)/ Drop repeated adjacent elements. First element in group is returned.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.uniq $ VU.fromList [1.0,3.0,3.0,200.0,3.0]
+-- [1.0,3.0,200.0,3.0]
+-- >>> import Data.Semigroup
+-- >>> VU.uniq $ VU.fromList [ Arg 1 'a', Arg 1 'b', Arg (1 :: Int) 'c']
+-- [Arg 1 'a']
 uniq :: (Unbox a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -1397,15 +1397,33 @@ maximum :: (Unbox a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | /O(n)/ Yield the maximum element of the vector according to the given
--- comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the maximum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie the last occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.maximumBy (comparing fst) $ VU.fromList [(2.0,'a'), (1.0,'b')]
+-- (2.0,'a')
+-- >>> VU.maximumBy (comparing fst) $ VU.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'b')
 maximumBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the first occurrence
+-- of a key function on each element. In case of a tie, the last occurrence
 -- wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.maximumOn fst $ VU.fromList [(2.0,'a'), (1.0,'b')]
+-- (2.0,'a')
+-- >>> VU.maximumOn fst $ VU.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'b')
 maximumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
@@ -1415,6 +1433,18 @@ maximumOn = G.maximumOn
 minimum :: (Unbox a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
+-- | /O(n)/ Yield the minimum element of the vector according to the
+-- given comparison function. The vector may not be empty. In case of
+-- a tie, the first occurrence wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.minimumBy (comparing fst) $ VU.fromList [(2.0,'a'), (1.0,'b')]
+-- (1.0,'b')
+-- >>> VU.minimumBy (comparing fst) $ VU.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'a')
 
 minimumBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> a
 -- | /O(n)/ Yield the minimum element of the vector according to the given
@@ -1425,6 +1455,14 @@ minimumBy = G.minimumBy
 -- | /O(n)/ Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.minimumOn fst $ VU.fromList [(2.0,'a'), (1.0,'b')]
+-- (1.0,'b')
+-- >>> VU.minimumOn fst $ VU.fromList [(1.0,'a'), (1.0,'b')]
+-- (1.0,'a')
 minimumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
@@ -1435,8 +1473,18 @@ maxIndex :: (Unbox a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | /O(n)/ Yield the index of the maximum element of the vector according to
--- the given comparison function. The vector may not be empty.
+-- | /O(n)/ Yield the index of the maximum element of the vector
+-- according to the given comparison function. The vector may not be
+-- empty. In case of a tie, the last occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.maxIndexBy (comparing fst) $ VU.fromList [(2.0,'a'), (1.0,'b')]
+-- 0
+-- >>> VU.maxIndexBy (comparing fst) $ VU.fromList [(1.0,'a'), (1.0,'b')]
+-- 1
 maxIndexBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
@@ -1449,6 +1497,15 @@ minIndex = G.minIndex
 
 -- | /O(n)/ Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
+--
+-- ==== __Examples__
+--
+-- >>> import Data.Ord
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.minIndexBy (comparing fst) $ VU.fromList [(2.0,'a'), (1.0,'b')]
+-- 1
+-- >>> VU.minIndexBy (comparing fst) $ VU.fromList [(1.0,'a'), (1.0,'b')]
+-- 0
 minIndexBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE minIndexBy #-}
 minIndexBy = G.minIndexBy

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -1435,7 +1435,7 @@ maximumBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> a
 maximumBy = G.maximumBy
 
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
--- of a key function on each element. In case of a tie, the last occurrence
+-- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1444,7 +1444,7 @@ maximumBy = G.maximumBy
 -- >>> VU.maximumOn fst $ VU.fromList [(2.0,'a'), (1.0,'b')]
 -- (2.0,'a')
 -- >>> VU.maximumOn fst $ VU.fromList [(1.0,'a'), (1.0,'b')]
--- (1.0,'b')
+-- (1.0,'a')
 maximumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn

--- a/Data/Vector/Unboxed.hs
+++ b/Data/Vector/Unboxed.hs
@@ -1392,7 +1392,18 @@ product :: (Unbox a, Num a) => Vector a -> a
 product = G.product
 
 -- | /O(n)/ Yield the maximum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.maximum $ VU.fromList [2.0, 1.0]
+-- 2.0
+-- >>> import Data.Semigroup
+-- >>> VU.maximum $ VU.fromList [Arg 1.0 'a', Arg 2.0 'b']
+-- Arg 2.0 'b'
+-- >>> VU.maximum $ VU.fromList [Arg 1.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'a'
 maximum :: (Unbox a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
@@ -1429,7 +1440,18 @@ maximumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 maximumOn = G.maximumOn
 
 -- | /O(n)/ Yield the minimum element of the vector. The vector may not be
--- empty.
+-- empty. In a case of a tie the first occurrence wins.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Unboxed as VU
+-- >>> VU.minimum $ VU.fromList [2.0, 1.0]
+-- 1.0
+-- >>> import Data.Semigroup
+-- >>> VU.minimum $ VU.fromList [Arg 2.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'b'
+-- >>> VU.minimum $ VU.fromList [Arg 1.0 'a', Arg 1.0 'b']
+-- Arg 1.0 'a'
 minimum :: (Unbox a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum

--- a/changelog.md
+++ b/changelog.md
@@ -7,12 +7,6 @@
    compiler fine with new definitions.
  * `mkType` from `Data.Vector.Generic` is deprecated in favor of
    `Data.Data.mkNoRepType`
- * `maximumBy` now behaves like its counterpart in `Data.List` in that if
-   `maximumBy` has to choose between several elements which could be
-   considered the maximum, it will now choose the last element (previously,
-   it would choose the first element). Similarly, `maxIndexBy` will also
-   now pick the last element if several elements could be considered the
-   maximum.
  * The role signatures on several `Vector` types were too permissive, so they
    have been tightened up:
    * The role signature for `Data.Vector.Mutable.MVector` is now

--- a/tests/Tests/Vector/Property.hs
+++ b/tests/Tests/Vector/Property.hs
@@ -512,7 +512,7 @@ testOrdFunctions _ = $(testProperties
    'prop_maximumBy, 'prop_minimumBy,
    'prop_maximumOn, 'prop_minimumOn,
    'prop_maxIndexBy, 'prop_minIndexBy,
-   'prop_ListLastMaxIndexWins, 'prop_FalseListFirstMaxIndexWins ])
+   'prop_ListFirstMaxIndexWins, 'prop_FalseListFirstMaxIndexWins ])
   where
     prop_compare :: P (v a -> v a -> Ordering) = compare `eq` compare
     prop_maximum :: P (v a -> a) = not . V.null ===> V.maximum `eq` maximum
@@ -529,8 +529,8 @@ testOrdFunctions _ = $(testProperties
       not . V.null ===> V.minimumOn id `eq` minimum
     prop_maxIndexBy :: P (v a -> Int) =
       not . V.null ===> V.maxIndexBy compare `eq` maxIndex
-    prop_ListLastMaxIndexWins ::  P (v a -> Int) =
-        not . V.null ===> ( maxIndex . V.toList) `eq` listMaxIndexLMW
+    prop_ListFirstMaxIndexWins ::  P (v a -> Int) =
+        not . V.null ===> ( maxIndex . V.toList) `eq` listMaxIndexFMW
     prop_FalseListFirstMaxIndexWinsDesc ::  P (v a -> Int) =
         (\x -> not $ V.null x && (V.uniq x /= x ) )===> ( maxIndex . V.toList) `eq` listMaxIndexFMW
     prop_FalseListFirstMaxIndexWins :: Property
@@ -540,9 +540,6 @@ testOrdFunctions _ = $(testProperties
 
 listMaxIndexFMW :: Ord a => [a] -> Int
 listMaxIndexFMW  = ( fst  . extractFMW .  sconcat . DLE.fromList . fmap FMW . zip [0 :: Int ..])
-
-listMaxIndexLMW :: Ord a => [a] -> Int
-listMaxIndexLMW = ( fst  . extractLMW .  sconcat . DLE.fromList . fmap LMW . zip [0 :: Int ..])
 
 newtype LastMaxWith a i = LMW {extractLMW:: (i,a)}
     deriving(Eq,Show,Read)

--- a/tests/Utilities.hs
+++ b/tests/Utilities.hs
@@ -336,7 +336,7 @@ minIndex = fst . foldr1 imin . zip [0..]
 maxIndex :: Ord a => [a] -> Int
 maxIndex = fst . foldr1 imax . zip [0..]
   where
-    imax (i,x) (j,y) | x >  y    = (i,x)
+    imax (i,x) (j,y) | x >= y    = (i,x)
                      | otherwise = (j,y)
 
 iterateNM :: Monad m => Int -> (a -> m a) -> a -> m [a]


### PR DESCRIPTION
    Doctests assume current semantics as it's implemented in code. For minimum first tie
    wins, for maximum last one,
    
    I think most convincing reason to keep this semantics is that maximum/minimum
    pair works in exactly same way when equal values could be distinguished:
    
      >>> data F = F Int Char deriving Show
      >>> instance Eq F  where F i _ == F j _ = i == j
      >>> instance Ord F where compare = comparing (\(F i _) -> i)
      >>> V.maximum [F 1 'a', F 1 'b']
      F 1 'b'
      >>> V.minimum [F 1 'a', F 1 'b']
      F 1 'a'
    
    As a bonus it matches behavior of list functions

@lehins @Bodigrim what's your opinion on matter? 

Fixes #362

P.S. @lehins you may want to pick second commit for 0.12.2. 