### PR TITLE
Use unsafeWithForeignPtr where possible

### DIFF
--- a/Data/Vector/Storable.hs
+++ b/Data/Vector/Storable.hs
@@ -261,14 +261,14 @@ instance Storable a => G.Vector Vector a where
   {-# INLINE basicUnsafeIndexM #-}
   basicUnsafeIndexM (Vector _ fp) i = return
                                     . unsafeInlineIO
-                                    $ withForeignPtr fp $ \p ->
+                                    $ unsafeWithForeignPtr fp $ \p ->
                                       peekElemOff p i
 
   {-# INLINE basicUnsafeCopy #-}
   basicUnsafeCopy (MVector n fp) (Vector _ fq)
     = unsafePrimToPrim
-    $ withForeignPtr fp $ \p ->
-      withForeignPtr fq $ \q ->
+    $ unsafeWithForeignPtr fp $ \p ->
+      unsafeWithForeignPtr fq $ \q ->
       copyArray p q n
 
   {-# INLINE elemseq #-}

--- a/Data/Vector/Storable/Internal.hs
+++ b/Data/Vector/Storable/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Module      : Data.Vector.Storable.Internal
 -- Copyright   : (c) Roman Leshchinskiy 2009-2010
@@ -11,12 +13,17 @@
 --
 
 module Data.Vector.Storable.Internal (
-  getPtr, setPtr, updPtr
+  getPtr, setPtr, updPtr, unsafeWithForeignPtr
 ) where
 
 import Foreign.ForeignPtr ()
 import Foreign.Ptr        ()
 import GHC.ForeignPtr   ( ForeignPtr(..) )
+#if MIN_VERSION_base(4,15,0)
+import GHC.ForeignPtr       ( unsafeWithForeignPtr )
+#else
+import Foreign.ForeignPtr   ( withForeignPtr )
+#endif
 import GHC.Ptr          ( Ptr(..) )
 
 getPtr :: ForeignPtr a -> Ptr a
@@ -31,3 +38,12 @@ updPtr :: (Ptr a -> Ptr a) -> ForeignPtr a -> ForeignPtr a
 {-# INLINE updPtr #-}
 updPtr f (ForeignPtr p c) = case f (Ptr p) of { Ptr q -> ForeignPtr q c }
 
+#if !MIN_VERSION_base(4,15,0)
+-- | A compatibility wrapper for 'GHC.ForeignPtr.unsafeWithForeignPtr' provided
+-- by GHC 9.0.1 and later.
+--
+-- Only to be used when the continuation is known not to
+-- unconditionally diverge lest unsoundness can result.
+unsafeWithForeignPtr :: ForeignPtr a -> (Ptr a -> IO b) -> IO b
+unsafeWithForeignPtr = withForeignPtr
+#endif


### PR DESCRIPTION
In GHC 9.0.1 `withForeignPtr` became (necessarily) considerably more
expensive. In GHC ticket #19474, it was noted that `Storable` `Vector`s
are affected by this regression. Fix this by using
`unsafeWithForeignPtr` when it is known that the continuation is
not divergent.

See also GHC #17760.