### PR TITLE
Try to add GHC9.0 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,13 @@ jobs:
           # - { cabal: "3.4", os: windows-latest, ghc: "8.8.4"  }
           # - { cabal: "3.4", os: windows-latest, ghc: "8.10.4" }
           # No cabal 3.4 for Windows as of 2021.03.05
-          # - { cabal: "3.4", os: windows-latest,  ghc: "9.0.1"  }
+          - { cabal: "3.4", os: windows-latest,  ghc: "9.0.1"  }
           # MacOS
           - { cabal: "3.2", os: macOS-latest,   ghc: "8.4.4"  }
           - { cabal: "3.2", os: macOS-latest,   ghc: "8.6.5"  }
           - { cabal: "3.2", os: macOS-latest,   ghc: "8.8.4"  }
           - { cabal: "3.2", os: macOS-latest,   ghc: "8.10.4" }
-          # No cabal 3.4 for macOS as of 2021.03.05
-          # - { cabal: "3.4", os: macOS-latest,   ghc: "9.0.1"  }
+          - { cabal: "3.4", os: macOS-latest,   ghc: "9.0.1"  }
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Cabal 3.4 is now available on win/mac