### PR TITLE
Add iso-deriving for Unboxed instances

### DIFF
--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -192,7 +192,9 @@ module Data.Vector.Unboxed (
   freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy,
 
   -- ** Deriving via
-  UnboxViaPrim(..)
+  UnboxViaPrim(..),
+  As(..),
+  Isomorphic(..)
 ) where
 
 import Data.Vector.Unboxed.Base

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -194,7 +194,7 @@ module Data.Vector.Unboxed (
   -- ** Deriving via
   UnboxViaPrim(..),
   As(..),
-  Isomorphic(..)
+  IsoUnbox(..)
 ) where
 
 import Data.Vector.Unboxed.Base

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -56,7 +56,7 @@
 -- >>> instance Unbox Foo
 module Data.Vector.Unboxed (
   -- * Unboxed vectors
-  Vector, MVector(..), Unbox,
+  Vector(V_UnboxAs), MVector(..), Unbox,
 
   -- * Accessors
 

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -17,7 +17,7 @@
 
 module Data.Vector.Unboxed.Base (
   MVector(..), IOVector, STVector, Vector(..), Unbox,
-  UnboxViaPrim(..), As(..), Isomorphic(..)
+  UnboxViaPrim(..), As(..), IsoUnbox(..)
 ) where
 
 import qualified Data.Vector.Generic         as G
@@ -256,7 +256,7 @@ instance P.Prim a => G.Vector Vector (UnboxViaPrim a) where
 
 -- | Isomorphism between type @a@ and its representation in unboxed
 -- vector @b@.
-class Isomorphic a b where
+class IsoUnbox a b where
   -- | Convert value into it representation in unboxed vector.
   toURepr   :: a -> b
   -- | Convert value representation in unboxed vector back to value.
@@ -265,7 +265,7 @@ class Isomorphic a b where
 -- | Newtype which allows to derive unbox instances for type @a@ which
 -- uses @b@ as underlying representation (usually tuple). Type @a@ and
 -- its representation @b@ are connected by type class
--- 'Isomorphic'. For example:
+-- 'IsoUnbox'. For example:
 --
 --
 -- >>> :set -XTypeFamilies -XStandaloneDeriving -XDerivingVia
@@ -276,7 +276,7 @@ class Isomorphic a b where
 -- >>> :{
 -- data Foo a = Foo Int a
 --   deriving Show
--- instance VU.Isomorphic (Foo a) (Int,a) where
+-- instance VU.IsoUnbox (Foo a) (Int,a) where
 --   toURepr (Foo i a) = (i,a)
 --   fromURepr (i,a) = Foo i a
 --   {-# INLINE toURepr #-}
@@ -292,7 +292,7 @@ newtype As a b = As a
 newtype instance MVector s (As a b) = MV_UnboxAs (MVector s b)
 newtype instance Vector    (As a b) = V_UnboxAs  (Vector b)
 
-instance (Isomorphic a b, Unbox b) => M.MVector MVector (As a b) where
+instance (IsoUnbox a b, Unbox b) => M.MVector MVector (As a b) where
   {-# INLINE basicLength #-}
   {-# INLINE basicUnsafeSlice #-}
   {-# INLINE basicOverlaps #-}
@@ -319,7 +319,7 @@ instance (Isomorphic a b, Unbox b) => M.MVector MVector (As a b) where
   basicUnsafeMove (MV_UnboxAs v1) (MV_UnboxAs v2) = M.basicUnsafeMove v1 v2
   basicUnsafeGrow (MV_UnboxAs v) n = MV_UnboxAs `liftM` M.basicUnsafeGrow v n
 
-instance (Isomorphic a b, Unbox b) => G.Vector Vector (As a b) where
+instance (IsoUnbox a b, Unbox b) => G.Vector Vector (As a b) where
   {-# INLINE basicUnsafeFreeze #-}
   {-# INLINE basicUnsafeThaw #-}
   {-# INLINE basicLength #-}

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -308,10 +308,10 @@ idU = id
 --   fromURepr (i,a) = Foo i a
 --   {-# INLINE toURepr #-}
 --   {-# INLINE fromURepr #-}
--- newtype instance VU.MVector s (Foo a) = MV_Int (VU.MVector s (Int, a))
--- newtype instance VU.Vector    (Foo a) = V_Int  (VU.Vector    (Int, a))
--- deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => M.MVector MVector (Foo a)
--- deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => G.Vector  Vector  (Foo a)
+-- newtype instance VU.MVector s (Foo a) = MV_Foo (VU.MVector s (Int, a))
+-- newtype instance VU.Vector    (Foo a) = V_Foo  (VU.Vector    (Int, a))
+-- deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => VGM.MVector MVector (Foo a)
+-- deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => VG.Vector  Vector  (Foo a)
 -- instance VU.Unbox a => VU.Unbox (Foo a)
 -- :}
 --
@@ -328,10 +328,10 @@ idU = id
 -- data Bar a = Bar Int a
 --   deriving (Show,Generic)
 -- instance VU.IsoUnbox (Bar a) (Int,a) where
--- newtype instance VU.MVector s (Bar a) = MV_Int (VU.MVector s (Int, a))
--- newtype instance VU.Vector    (Bar a) = V_Int  (VU.Vector    (Int, a))
--- deriving via (Bar a `VU.As` (Int, a)) instance VU.Unbox a => M.MVector MVector (Bar a)
--- deriving via (Bar a `VU.As` (Int, a)) instance VU.Unbox a => G.Vector  Vector  (Bar a)
+-- newtype instance VU.MVector s (Bar a) = MV_Bar (VU.MVector s (Int, a))
+-- newtype instance VU.Vector    (Bar a) = V_Bar  (VU.Vector    (Int, a))
+-- deriving via (Bar a `VU.As` (Int, a)) instance VU.Unbox a => VGM.MVector VU.MVector (Bar a)
+-- deriving via (Bar a `VU.As` (Int, a)) instance VU.Unbox a => VG.Vector  VU.Vector  (Bar a)
 -- instance VU.Unbox a => VU.Unbox (Bar a)
 -- :}
 --

--- a/vector/tests-inspect/Inspect/DerivingVia.hs
+++ b/vector/tests-inspect/Inspect/DerivingVia.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# OPTIONS_GHC -fplugin=Test.Tasty.Inspection.Plugin #-}
+{-# OPTIONS_GHC -dsuppress-all                        #-}
+{-# OPTIONS_GHC -dno-suppress-type-signatures         #-}
+-- | Most basic inspection tests
+module Inspect.DerivingVia where
+
+import Test.Tasty
+import Test.Tasty.Inspection
+import qualified Data.Vector.Generic         as VG
+import qualified Data.Vector.Generic.Mutable as VGM
+import qualified Data.Vector.Unboxed         as VU
+import GHC.Generics (Generic)
+
+import Inspect.DerivingVia.OtherFoo
+
+
+-- | Simple product data type for which we derive Unbox instances
+-- using generics and iso-deriving. This one is used in same module
+-- where it's defined. It's used to check that there's no difference
+-- between data type defined in same and different module (see
+-- 'OtherFoo').
+data Foo a = Foo Int a
+  deriving (Show,Generic)
+
+instance VU.IsoUnbox (Foo a) (Int,a) where
+
+newtype instance VU.MVector s (Foo a) = MV_Int (VU.MVector s (Int, a))
+newtype instance VU.Vector    (Foo a) = V_Int  (VU.Vector    (Int, a))
+
+instance VU.Unbox a => VU.Unbox (Foo a)
+deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => VGM.MVector VU.MVector (Foo a)
+deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => VG.Vector   VU.Vector  (Foo a)
+
+map_Foo :: VU.Vector (Foo Double) -> VU.Vector (Foo Double)
+map_Foo = VU.map (\(Foo a b) -> Foo (a*10) (b*100))
+
+pipeline_Foo :: Int -> Double
+pipeline_Foo n
+  = VU.foldl' (\acc (Foo a b) -> acc + b^^a) 0
+  $ VU.filter (\(Foo a _) -> a < 4)
+  $ VU.map (\(Foo a b) -> Foo (a + 2) (log b))
+  $ VU.generate n (\i -> Foo i (log (fromIntegral i)))
+
+map_OtherFoo :: VU.Vector (OtherFoo Double) -> VU.Vector (OtherFoo Double)
+map_OtherFoo = VU.map (\(OtherFoo a b) -> OtherFoo (a*10) (b*100))
+
+pipeline_OtherFoo :: Int -> Double
+pipeline_OtherFoo n
+  = VU.foldl' (\acc (OtherFoo a b) -> acc + b^^a) 0
+  $ VU.filter (\(OtherFoo a _) -> a < 4)
+  $ VU.map (\(OtherFoo a b) -> OtherFoo (a + 2) (log b))
+  $ VU.generate n (\i -> OtherFoo i (log (fromIntegral i)))
+
+
+-- | Here we test that optimizer successfully eliminated all generics
+-- and even mentions of Foo data type.
+tests :: TestTree
+tests = testGroup "iso-deriving"
+  [ $(inspectObligations [(`doesNotUse` 'Foo), hasNoGenerics, hasNoTypeClasses]
+       'map_Foo)
+  , $(inspectObligations [(`doesNotUse` 'OtherFoo), hasNoGenerics, hasNoTypeClasses]
+       'pipeline_Foo)
+  , $(inspectObligations [(`doesNotUse` 'OtherFoo), hasNoGenerics, hasNoTypeClasses]
+       'map_OtherFoo)
+  , $(inspectObligations [(`doesNotUse` 'OtherFoo), hasNoGenerics, hasNoTypeClasses]
+       'pipeline_OtherFoo)
+  ]

--- a/vector/tests-inspect/Inspect/DerivingVia/OtherFoo.hs
+++ b/vector/tests-inspect/Inspect/DerivingVia/OtherFoo.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+module Inspect.DerivingVia.OtherFoo where
+
+import qualified Data.Vector.Generic         as VG
+import qualified Data.Vector.Generic.Mutable as VGM
+import qualified Data.Vector.Unboxed         as VU
+import GHC.Generics (Generic)
+
+
+-- | Simple product data type for which we derive Unbox instances
+-- using generics and iso-deriving. It's defined in separate module in
+-- order to test that it doesn't impede optimizer
+data OtherFoo a = OtherFoo Int a
+  deriving (Show,Generic)
+
+instance VU.IsoUnbox (OtherFoo a) (Int,a) where
+
+newtype instance VU.MVector s (OtherFoo a) = MV_Int (VU.MVector s (Int, a))
+newtype instance VU.Vector    (OtherFoo a) = V_Int  (VU.Vector    (Int, a))
+
+instance VU.Unbox a => VU.Unbox (OtherFoo a)
+deriving via (OtherFoo a `VU.As` (Int, a)) instance VU.Unbox a => VGM.MVector VU.MVector (OtherFoo a)
+deriving via (OtherFoo a `VU.As` (Int, a)) instance VU.Unbox a => VG.Vector   VU.Vector  (OtherFoo a)

--- a/vector/tests-inspect/main.hs
+++ b/vector/tests-inspect/main.hs
@@ -1,10 +1,16 @@
+{-# LANGUAGE CPP #-}
 module Main (main) where
 
 import qualified Inspect
-
+#if MIN_VERSION_base(4,12,0)
+import qualified Inspect.DerivingVia
+#endif
 import Test.Tasty (defaultMain,testGroup)
 
 main :: IO ()
 main = defaultMain $ testGroup "tests"
   [ Inspect.tests
+#if MIN_VERSION_base(4,12,0)
+  , Inspect.DerivingVia.tests
+#endif
   ]

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -281,8 +281,11 @@ test-suite vector-inspection
   -- -as well
   Ghc-Options:      -Wall
   main-is:          main.hs
-  Other-modules:    Inspect
   default-language: Haskell2010
+  Other-modules:    Inspect
+  if impl(ghc >= 8.6)
+    Other-modules:  Inspect.DerivingVia
+                    Inspect.DerivingVia.OtherFoo
   -- GHC<8.0 doesn't support plugins
   if impl(ghc < 8.0)
     buildable: False


### PR DESCRIPTION
Another take on use of DerivingVia for defining Unbox instances. This should largely subsume TH-based deriving from th-vector-unbox. Verbosity is about same and there's no TH which is frequently breaks with each GHC release

P.S. It's still too verbose. I think use of data family was a mistake. They couldn't be derived and have to be defined for each type. On top of it we only have handful of possible representations. Type family + newtype wrapper for injectivity would've worked out much better.