### PR TITLE
docs: Explain that `unsafeThaw` allows reuse of argument on read-only ops

### DIFF
--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -2075,7 +2075,7 @@ unsafeFreeze :: PrimMonad m => MVector (PrimState m) a -> m (Vector a)
 unsafeFreeze = G.unsafeFreeze
 
 -- | /O(1)/ Unsafely convert an immutable vector to a mutable one without
--- copying. The immutable vector may not be used after this operation.
+-- copying. The immutable vector may not be used after this operation if the thawed vector is mutated.
 unsafeThaw :: PrimMonad m => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -2246,7 +2246,7 @@ freeze :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m (v a)
 freeze mv = unsafeFreeze =<< M.clone mv
 
 -- | /O(1)/ Unsafely convert an immutable vector to a mutable one without
--- copying. The immutable vector may not be used after this operation.
+-- copying. The immutable vector may not be used after this operation if the thawed vector is mutated.
 unsafeThaw :: (PrimMonad m, Vector v a) => v a -> m (Mutable v (PrimState m) a)
 {-# INLINE_FUSED unsafeThaw #-}
 unsafeThaw = stToPrim . basicUnsafeThaw

--- a/vector/src/Data/Vector/Generic/Base.hs
+++ b/vector/src/Data/Vector/Generic/Base.hs
@@ -65,7 +65,7 @@ class MVector (Mutable v) a => Vector v a where
   -- | /Assumed complexity: O(1)/
   --
   -- Unsafely convert an immutable vector to its mutable version without
-  -- copying. The immutable vector may not be used after this operation.
+  -- copying. The immutable vector may not be used after this operation if the thawed vector is mutated.
   basicUnsafeThaw :: v a -> ST s (Mutable v s a)
 
   -- | /Assumed complexity: O(1)/

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -1717,7 +1717,7 @@ unsafeFreeze :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 unsafeFreeze = G.unsafeFreeze
 
 -- | /O(1)/ Unsafely convert an immutable vector to a mutable one without
--- copying. The immutable vector may not be used after this operation.
+-- copying. The immutable vector may not be used after this operation if the thawed vector is mutated.
 unsafeThaw :: (Prim a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -1780,7 +1780,7 @@ unsafeFreeze
 unsafeFreeze = G.unsafeFreeze
 
 -- | /O(1)/ Unsafely convert an immutable vector to a mutable one without
--- copying. The immutable vector may not be used after this operation.
+-- copying. The immutable vector may not be used after this operation if the thawed vector is mutated.
 unsafeThaw
         :: (Storable a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -1813,7 +1813,7 @@ unsafeFreeze :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a
 unsafeFreeze = G.unsafeFreeze
 
 -- | /O(1)/ Unsafely convert an immutable vector to a mutable one without
--- copying. The immutable vector may not be used after this operation.
+-- copying. The immutable vector may not be used after this operation if the thawed vector is mutated.
 unsafeThaw :: (Unbox a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw


### PR DESCRIPTION
This makes clear that usages such as

    unsafeCopy mutableTarget =<< unsafeThaw immutableSource

are safe.

Justification thanks to @lehins:

    It is safe to use it like that. unsafeThaw/unsafeFreeze only do
    a type cast for ByteArray/MutableByteArray.
    For boxed arrays it treats it a bit differently because GC needs
    to traverse mutable arrays, but that does not make this use case
    you mentioned unsafe in any way.