### PR TITLE
Change allocation strategy for unfoldrN & add warning for fromListN

### DIFF
--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -2119,7 +2119,11 @@ fromList :: [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
+-- expected that the supplied list will be exactly @n@ elements long. As
+-- an optimization, this function allocates a buffer for @n@ elements, which
+-- could be used for DoS-attacks by exhausting the memory if an attacker controls
+-- that parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -664,7 +664,7 @@ unfoldrN n f = unfoldrNM n (return . f)
 -- | Unfold at most @n@ elements with a monadic function.
 unfoldrNM :: Monad m => Int -> (s -> m (Maybe (a, s))) -> s -> Bundle m u a
 {-# INLINE_FUSED unfoldrNM #-}
-unfoldrNM n f s = fromStream (S.unfoldrNM n f s) (Max (delay_inline max n 0))
+unfoldrNM n f s = fromStream (S.unfoldrNM n f s) Unknown
 
 -- | Unfold exactly @n@ elements
 --

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -2297,7 +2297,11 @@ fromList :: Vector v a => [a] -> v a
 {-# INLINE fromList #-}
 fromList = unstream . Bundle.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
+-- expected that supplied list will be exactly @n@ elements long. As
+-- optimization this function allocates buffer for @n@ elements and
+-- could be used to DoS by exhausting memory if attacker controls that
+-- parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -2298,10 +2298,10 @@ fromList :: Vector v a => [a] -> v a
 fromList = unstream . Bundle.fromList
 
 -- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
--- expected that supplied list will be exactly @n@ elements long. As
--- optimization this function allocates buffer for @n@ elements and
--- could be used to DoS by exhausting memory if attacker controls that
--- parameter.
+-- expected that the supplied list will be exactly @n@ elements long. As
+-- an optimization, this function allocates a buffer for @n@ elements, which
+-- could be used for DoS-attacks by exhausting the memory if an attacker controls
+-- that parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -1786,7 +1786,11 @@ fromList :: Prim a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
+-- expected that supplied list will be exactly @n@ elements long. As
+-- optimization this function allocates buffer for @n@ elements and
+-- could be used to DoS by exhausting memory if attacker controls that
+-- parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -1787,10 +1787,10 @@ fromList :: Prim a => [a] -> Vector a
 fromList = G.fromList
 
 -- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
--- expected that supplied list will be exactly @n@ elements long. As
--- optimization this function allocates buffer for @n@ elements and
--- could be used to DoS by exhausting memory if attacker controls that
--- parameter.
+-- expected that the supplied list will be exactly @n@ elements long. As
+-- an optimization, this function allocates a buffer for @n@ elements, which
+-- could be used for DoS-attacks by exhausting the memory if an attacker controls
+-- that parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -1833,10 +1833,10 @@ fromList :: Storable a => [a] -> Vector a
 fromList = G.fromList
 
 -- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
--- expected that supplied list will be exactly @n@ elements long. As
--- optimization this function allocates buffer for @n@ elements and
--- could be used to DoS by exhausting memory if attacker controls that
--- parameter.
+-- expected that the supplied list will be exactly @n@ elements long. As
+-- an optimization, this function allocates a buffer for @n@ elements, which
+-- could be used for DoS-attacks by exhausting the memory if an attacker controls
+-- that parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -1832,7 +1832,11 @@ fromList :: Storable a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
+-- expected that supplied list will be exactly @n@ elements long. As
+-- optimization this function allocates buffer for @n@ elements and
+-- could be used to DoS by exhausting memory if attacker controls that
+-- parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -1879,10 +1879,10 @@ fromList :: Unbox a => [a] -> Vector a
 fromList = G.fromList
 
 -- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
--- expected that supplied list will be exactly @n@ elements long. As
--- optimization this function allocates buffer for @n@ elements and
--- could be used to DoS by exhausting memory if attacker controls that
--- parameter.
+-- expected that the supplied list will be exactly @n@ elements long. As
+-- an optimization, this function allocates a buffer for @n@ elements, which
+-- could be used for DoS-attacks by exhausting the memory if an attacker controls
+-- that parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -1878,7 +1878,11 @@ fromList :: Unbox a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | /O(n)/ Convert the first @n@ elements of a list to a vector. It's
+-- expected that supplied list will be exactly @n@ elements long. As
+-- optimization this function allocates buffer for @n@ elements and
+-- could be used to DoS by exhausting memory if attacker controls that
+-- parameter.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)


### PR DESCRIPTION
This PR changes allocation strategy for `unfoldrN{,M}` to `Unknown` and adds warning about possible DoS for fromListN. Here is reasoning from #301

> I think that changing type hint from Max to Unknown for unfoldrN/unfoldrNM is right thing to do. In addition to possible heap overflow it's poor strategy in cases when upper limit is used as some sort of safeguard and vector is usually much smaller. It just wastes memory.
>
> On other hand such change for fromListN makes no sense. It's mostly an optimization for cases when vector size is known in advance. It allows avoid reallocation of buffers when growing vector. Yes. it allows to induce heap overflow if size if hands of attacker. Without such preallocation we could just drop fromListN or implement it as fromList . take n. I think it's better to leave function as it is and just update documentation explaining possible dangers

@lehins, what's you opinion? 

Fixes #301