### PR TITLE
Fix CI for 7.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,16 @@ jobs:
         cd vector
         cabal -vnormal check
     # ----------------
+    # GHC 7.10 fails with PIE-related linker errors. Thus it needs extra
+    # encouragement for linker in form of flags.
     - name: Build
       run: |
-        cabal configure --haddock-all --enable-tests --enable-benchmarks --benchmark-option=-l
-        cabal build all --write-ghc-environment-files=always
+        if [ ${{matrix.ghc}} = 7.10.3 ]; then
+          EXTRA_FLAGS=--ghc-option="-optl-no-pie"
+        fi
+        echo $EXTRA_FLAGS
+        cabal $EXTRA_FLAGS configure --haddock-all --enable-tests --enable-benchmarks --benchmark-option=-l
+        cabal $EXTRA_FLAGS build all --write-ghc-environment-files=always
     # ----------------
     - name: Test
       run: |


### PR DESCRIPTION
At some moment GHC 7.10 started to fail with linker errors related to PIE. Turn
out could be made to work with some magic linker flags