### PR TITLE
Remove redundant `Storable` constraints 

### DIFF
--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -42,7 +42,7 @@
    Prior to this change, applying an empty vector to any of those functions
    resulted in an error. This change was introduced in:
    [#382](https://github.com/haskell/vector/pull/382)
-
+* Remove redundant `Storable` constraints on to/from `ForeignPtr` conversions
 
 # Changes in version 0.12.3.0
 

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -1894,8 +1894,7 @@ unsafeFromForeignPtr fp i n = unsafeFromForeignPtr0 fp' n
 -- Use `unsafeFromForeignPtr` if you need to specify an offset.
 --
 -- The data may not be modified through the 'ForeignPtr' afterwards.
-unsafeFromForeignPtr0 :: Storable a
-                      => ForeignPtr a    -- ^ pointer
+unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
                       -> Int             -- ^ length
                       -> Vector a
 {-# INLINE unsafeFromForeignPtr0 #-}
@@ -1903,7 +1902,7 @@ unsafeFromForeignPtr0 fp n = Vector n fp
 
 -- | /O(1)/ Yield the underlying 'ForeignPtr' together with the offset to the
 -- data and its length. The data may not be modified through the 'ForeignPtr'.
-unsafeToForeignPtr :: Storable a => Vector a -> (ForeignPtr a, Int, Int)
+unsafeToForeignPtr :: Vector a -> (ForeignPtr a, Int, Int)
 {-# INLINE unsafeToForeignPtr #-}
 unsafeToForeignPtr (Vector n fp) = (fp, 0, n)
 
@@ -1912,7 +1911,7 @@ unsafeToForeignPtr (Vector n fp) = (fp, 0, n)
 -- You can assume the pointer points directly to the data (no offset).
 --
 -- The data may not be modified through the 'ForeignPtr'.
-unsafeToForeignPtr0 :: Storable a => Vector a -> (ForeignPtr a, Int)
+unsafeToForeignPtr0 :: Vector a -> (ForeignPtr a, Int)
 {-# INLINE unsafeToForeignPtr0 #-}
 unsafeToForeignPtr0 (Vector n fp) = (fp, n)
 

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -800,8 +800,7 @@ unsafeFromForeignPtr fp i n = unsafeFromForeignPtr0 fp' n
 --
 -- Modifying data through the 'ForeignPtr' afterwards is unsafe if the vector
 -- could have been frozen before the modification.
-unsafeFromForeignPtr0 :: Storable a
-                      => ForeignPtr a    -- ^ pointer
+unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
                       -> Int             -- ^ length
                       -> MVector s a
 {-# INLINE unsafeFromForeignPtr0 #-}
@@ -810,7 +809,7 @@ unsafeFromForeignPtr0 fp n = MVector n fp
 -- | Yield the underlying 'ForeignPtr' together with the offset to the data
 -- and its length. Modifying the data through the 'ForeignPtr' is
 -- unsafe if the vector could have frozen before the modification.
-unsafeToForeignPtr :: Storable a => MVector s a -> (ForeignPtr a, Int, Int)
+unsafeToForeignPtr :: MVector s a -> (ForeignPtr a, Int, Int)
 {-# INLINE unsafeToForeignPtr #-}
 unsafeToForeignPtr (MVector n fp) = (fp, 0, n)
 
@@ -820,7 +819,7 @@ unsafeToForeignPtr (MVector n fp) = (fp, 0, n)
 --
 -- Modifying the data through the 'ForeignPtr' is unsafe if the vector could
 -- have frozen before the modification.
-unsafeToForeignPtr0 :: Storable a => MVector s a -> (ForeignPtr a, Int)
+unsafeToForeignPtr0 :: MVector s a -> (ForeignPtr a, Int)
 {-# INLINE unsafeToForeignPtr0 #-}
 unsafeToForeignPtr0 (MVector n fp) = (fp, n)
 


### PR DESCRIPTION
These redundant constraints can get in a way on rare occasions. Consider

```haskell
data Buffer a = BA Int ByteArray | FP Int (ForeignPtr a)

toVector :: Buffer a -> Either (VP.Vector a) (VS.Vector a)
toVector (BA size ba) = Left (VP.Vector 0 size ba)
toVector (FP size fp) = Right (VS.unsafeFromForeignPtr0 fp size)
```

This function will not compile because it needs `Storable`, but it doesn't need `Prim`.