### PR TITLE
Clarify kinds of As arguments explicitly

### DIFF
--- a/vector/src/Data/Vector/Generic/Base.hs
+++ b/vector/src/Data/Vector/Generic/Base.hs
@@ -27,10 +27,11 @@ import qualified Data.Vector.Generic.Mutable.Base as M
 import           Data.Vector.Fusion.Util (Box(..), liftBox)
 
 import Control.Monad.ST
+import Data.Kind (Type)
 
 -- | @Mutable v s a@ is the mutable version of the immutable vector type @v a@ with
 -- the state token @s@. It is injective on GHC 8 and newer.
-type family Mutable (v :: * -> *) = (mv :: * -> * -> *) | mv -> v
+type family Mutable (v :: Type -> Type) = (mv :: Type -> Type -> Type) | mv -> v
 
 -- | Class of immutable vectors. Every immutable vector is associated with its
 -- mutable version through the 'Mutable' type family. Methods of this class

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -54,6 +54,7 @@ import Data.Data     ( Data(..) )
 import GHC.Exts      ( Down(..) )
 import GHC.Generics
 import Data.Coerce
+import Data.Kind     (Type)
 
 -- Data.Vector.Internal.Check is unused
 #define NOT_VECTOR_MODULE
@@ -332,7 +333,7 @@ idU = id
 -- instance VU.Unbox a => VU.Unbox (Bar a)
 -- :}
 --
-newtype As a b = As a
+newtype As (a :: Type) (b :: Type) = As a
 
 newtype instance MVector s (As a b) = MV_UnboxAs (MVector s b)
 newtype instance Vector    (As a b) = V_UnboxAs  (Vector b)


### PR DESCRIPTION
Otherwise GHC HEAD cannot figure out that `b` is restricted to be of kind `Type` and complains 
```
src/Data/Vector/Unboxed/Base.hs:345:61: error:
    • Expected a type, but ‘b’ has kind ‘k’
      ‘k’ is a rigid type variable bound by
        the data constructor ‘MV_UnboxAs’
        at src/Data/Vector/Unboxed/Base.hs:345:1-62
    • In the second argument of ‘MVector’, namely ‘b’
      In the type ‘(MVector s b)’
      In the definition of data constructor ‘MV_UnboxAs’
    |
345 | newtype instance MVector s (As a b) = MV_UnboxAs (MVector s b)
    |
```

This is because 
> Kind inference for data/newtype instance declarations is slightly more restrictive than before. See the user manual Kind inference for data/newtype instance declarations. This is a breaking change, albeit a fairly obscure one that corrects a specification bug.
> http://downloads.haskell.org/ghc/9.2.1-rc1/docs/html/users_guide/9.2.1-notes.html#language