### PR TITLE
Add `unsafeCast` to `Primitive` vectors

### DIFF
--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -43,6 +43,7 @@
    resulted in an error. This change was introduced in:
    [#382](https://github.com/haskell/vector/pull/382)
 * Remove redundant `Storable` constraints on to/from `ForeignPtr` conversions
+* Add `unsafeCast` to `Primitive` vectors
 
 # Changes in version 0.12.3.0
 

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -61,7 +61,7 @@ module Data.Vector.Primitive.Mutable (
   set, copy, move, unsafeCopy, unsafeMove,
 
   -- * Unsafe conversions
-  unsafeCoerceMVector,
+  unsafeCoerceMVector, unsafeCast,
   -- * Re-exports
   Prim, PrimMonad, PrimState, RealWorld
 ) where
@@ -69,6 +69,7 @@ module Data.Vector.Primitive.Mutable (
 import qualified Data.Vector.Generic.Mutable as G
 import           Data.Primitive.ByteArray
 import           Data.Primitive ( Prim, sizeOf )
+import           Data.Vector.Internal.Check
 import           Data.Word ( Word8 )
 import           Control.Monad.Primitive
 import           Control.Monad ( liftM )
@@ -656,3 +657,20 @@ ifoldrM = G.ifoldrM
 ifoldrM' :: (PrimMonad m, Prim a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM' #-}
 ifoldrM' = G.ifoldrM'
+
+
+-- Unsafe conversions
+-- ------------------
+
+-- | /O(1)/ Unsafely cast a vector from one element type to another.
+-- This operation just changes the type of the vector and does not
+-- modify the elements.
+--
+-- This function will throw an error if elements are of mismatching sizes.
+--
+-- | @since 0.13.0.0
+unsafeCast :: forall a b s. (HasCallStack, Prim a, Prim b) => MVector s a -> MVector s b
+{-# INLINE unsafeCast #-}
+unsafeCast (MVector o n ba)
+  | sizeOf (undefined :: a) == sizeOf (undefined :: b) = MVector o n ba
+  | otherwise = error "Element size mismatch"


### PR DESCRIPTION
While reviewing #398 I noticed that there is no `unsafeCast` for primitive vector.
 
We can't provide a cast that changes primitive vectors with elements of different sizes in the way that `Data.Vector.Storable.unsafeCast` does it. For example `Vector Word8` -> `Vector Word16` cast cannot be implemented with current `primitive`. However, this doesn't mean a cast like `Vector Word8` -> Word Int8` or a `Vector Float` -> `Vector Word32` cannot be useful for some reason.