### PR TITLE
Rebased and fixed #347

### DIFF
--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -245,7 +245,7 @@ infixl 9 !?
 -- | O(1) Safe indexing.
 (!?) :: Vector v a => v a -> Int -> Maybe a
 {-# INLINE_FUSED (!?) #-}
--- Use basicUnsafeIndexM @Maybe to perform the indexing eagerly.
+-- Use basicUnsafeIndexM @Box to perform the indexing eagerly.
 v !? i | i `inRange` length v = case basicUnsafeIndexM v i of Box a -> Just a
        | otherwise            = Nothing
 

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -245,8 +245,13 @@ infixl 9 !?
 -- | O(1) Safe indexing.
 (!?) :: Vector v a => v a -> Int -> Maybe a
 {-# INLINE_FUSED (!?) #-}
-v !? i | i < 0 || i >= length v = Nothing
-       | otherwise              = Just $ unsafeIndex v i
+-- Lengths are never negative, so we can check  0 <= i < length v
+-- using one unsigned comparison.
+v !? i | (fromIntegral i :: Word) >= fromIntegral (length v)
+       = Nothing
+       | otherwise
+         -- Use basicUnsafeIndexM @Maybe to perform the indexing eagerly.
+       = case basicUnsafeIndexM v i of Box a -> Just a
 
 -- | /O(1)/ First element.
 head :: Vector v a => v a -> a

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -245,13 +245,10 @@ infixl 9 !?
 -- | O(1) Safe indexing.
 (!?) :: Vector v a => v a -> Int -> Maybe a
 {-# INLINE_FUSED (!?) #-}
--- Lengths are never negative, so we can check  0 <= i < length v
--- using one unsigned comparison.
-v !? i | (fromIntegral i :: Word) >= fromIntegral (length v)
-       = Nothing
-       | otherwise
-         -- Use basicUnsafeIndexM @Maybe to perform the indexing eagerly.
-       = case basicUnsafeIndexM v i of Box a -> Just a
+-- Use basicUnsafeIndexM @Maybe to perform the indexing eagerly.
+v !? i | i `inRange` length v = case basicUnsafeIndexM v i of Box a -> Just a
+       | otherwise            = Nothing
+
 
 -- | /O(1)/ First element.
 head :: Vector v a => v a -> a

--- a/vector/src/Data/Vector/Internal/Check.hs
+++ b/vector/src/Data/Vector/Internal/Check.hs
@@ -142,7 +142,7 @@ checkSlice :: HasCallStack => Checks -> Int -> Int -> Int -> a -> a
 checkSlice kind i m n x
   = check kind (checkSlice_msg i m n) (i >= 0 && m >= 0 && m <= n - i) x
 
--- Lengths are never negative, so we can check  0 <= i < length v
+-- Lengths are never negative, so we can check @0 <= i < length v@
 -- using one unsigned comparison.
 inRange :: Int -> Int -> Bool
 {-# INLINE inRange #-}

--- a/vector/src/Data/Vector/Internal/Check.hs
+++ b/vector/src/Data/Vector/Internal/Check.hs
@@ -18,7 +18,8 @@ module Data.Vector.Internal.Check (
   Checks(..), doChecks,
 
   internalError,
-  check, checkIndex, checkLength, checkSlice
+  check, checkIndex, checkLength, checkSlice,
+  inRange
 ) where
 
 import GHC.Base( Int(..) )
@@ -112,7 +113,7 @@ checkIndex_msg# i# n# = "index out of bounds " ++ show (I# i#, I# n#)
 checkIndex :: HasCallStack => Checks -> Int -> Int -> a -> a
 {-# INLINE checkIndex #-}
 checkIndex kind i n x
-  = check kind (checkIndex_msg i n) (i >= 0 && i<n) x
+  = check kind (checkIndex_msg i n) (inRange i n) x
 
 
 checkLength_msg :: Int -> String
@@ -141,3 +142,8 @@ checkSlice :: HasCallStack => Checks -> Int -> Int -> Int -> a -> a
 checkSlice kind i m n x
   = check kind (checkSlice_msg i m n) (i >= 0 && m >= 0 && m <= n - i) x
 
+-- Lengths are never negative, so we can check  0 <= i < length v
+-- using one unsigned comparison.
+inRange :: Int -> Int -> Bool
+{-# INLINE inRange #-}
+inRange i n = (fromIntegral i :: Word) < (fromIntegral n :: Word)


### PR DESCRIPTION
This is rebased #347 updated to work with current master. 

 - Makes `indexM` strict in vector by using `basicIndexM`
 - Word trick is used to make single comparison for range checks instead of two for all range checks