### PR TITLE
Extract vector stream into its own package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
-packages: vector/vector.cabal
+packages:
+  vector
+  vector-stream

--- a/vector-stream/LICENSE
+++ b/vector-stream/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2008-2012, Roman Leshchinskiy
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+- Neither name of the University nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
+GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+UNIVERSITY COURT OF THE UNIVERSITY OF GLASGOW OR THE CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/vector-stream/README.md
+++ b/vector-stream/README.md
@@ -1,0 +1,6 @@
+The `vector` package [![Build Status](https://travis-ci.org/haskell/vector.png?branch=master)](https://travis-ci.org/haskell/vector)
+====================
+
+An efficient implementation monadic streams used for fusion in `vector` package
+
+See [`vector-stream` on Hackage](http://hackage.haskell.org/package/vector-stream) for more information.

--- a/vector-stream/README.md
+++ b/vector-stream/README.md
@@ -1,6 +1,6 @@
 The `vector` package [![Build Status](https://travis-ci.org/haskell/vector.png?branch=master)](https://travis-ci.org/haskell/vector)
 ====================
 
-An efficient implementation monadic streams used for fusion in `vector` package
+An efficient implementation of monadic streams used for fusion in `vector` package
 
 See [`vector-stream` on Hackage](http://hackage.haskell.org/package/vector-stream) for more information.

--- a/vector-stream/Setup.hs
+++ b/vector-stream/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+main = defaultMain
+

--- a/vector-stream/changelog.md
+++ b/vector-stream/changelog.md
@@ -1,0 +1,4 @@
+# Changes in version 0.1.0.0
+
+ * Initial move from `vector`, which will depend on this package starting with
+   `vector-0.13.0.0`

--- a/vector-stream/changelog.md
+++ b/vector-stream/changelog.md
@@ -1,4 +1,4 @@
 # Changes in version 0.1.0.0
 
- * Initial move from `vector`, which will depend on this package starting with
+ * Initial move from `vector`, which will depend on this package starting from
    `vector-0.13.0.0`

--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -1,0 +1,47 @@
+Name:           vector-stream
+Version:        0.1.0.0
+-- don't forget to update the changelog file!
+License:        BSD3
+License-File:   LICENSE
+Author:         Roman Leshchinskiy <rl@cse.unsw.edu.au>
+Maintainer:     Haskell Libraries Team <libraries@haskell.org>
+Copyright:      (c) Roman Leshchinskiy 2008-2012
+Homepage:       https://github.com/haskell/vector
+Bug-Reports:    https://github.com/haskell/vector/issues
+Category:       Data, Data Structures
+Synopsis:       Efficient Streams
+Description:
+        Simple yet powerful monadic streams that are used
+        as a backbone for vector package fusion functionality.
+
+Tested-With:
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.4,
+  GHC == 8.6.5,
+  GHC == 8.8.4,
+  GHC == 8.10.4
+  GHC == 9.0.1
+
+Cabal-Version:  >=1.10
+Build-Type:     Simple
+
+Extra-Source-Files:
+      changelog.md
+      README.md
+
+Library
+  Default-Language: Haskell2010
+
+  Exposed-Modules:
+        Data.Stream.Monadic
+
+  Hs-Source-Dirs:
+        src
+
+  Build-Depends: base >= 4.9 && < 4.16
+               , ghc-prim >= 0.2 && < 0.8
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell/vector.git

--- a/vector/src/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Stream/Monadic.hs
@@ -1,0 +1,17 @@
+-- |
+-- Module      : Data.Vector.Fusion.Stream.Monadic
+-- Copyright   : (c) Roman Leshchinskiy 2008-2010
+-- License     : BSD-style
+--
+-- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Stability   : experimental
+-- Portability : non-portable
+--
+-- Monadic stream combinators.
+--
+
+module Data.Vector.Fusion.Stream.Monadic
+  ( module Data.Stream.Monadic
+  ) where
+
+import Data.Stream.Monadic

--- a/vector/src/Data/Vector/Fusion/Util.hs
+++ b/vector/src/Data/Vector/Fusion/Util.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Data.Vector.Fusion.Util
 -- Copyright   : (c) Roman Leshchinskiy 2009
@@ -17,6 +16,8 @@ module Data.Vector.Fusion.Util (
   delay_inline, delayed_min
 ) where
 
+import Data.Stream.Monadic (Box(..), liftBox)
+
 -- | Identity monad
 newtype Id a = Id { unId :: a }
 
@@ -30,24 +31,6 @@ instance Applicative Id where
 instance Monad Id where
   return = pure
   Id x >>= f = f x
-
--- | Box monad
-data Box a = Box { unBox :: a }
-
-instance Functor Box where
-  fmap f (Box x) = Box (f x)
-
-instance Applicative Box where
-  pure = Box
-  Box f <*> Box x = Box (f x)
-
-instance Monad Box where
-  return = pure
-  Box x >>= f = f x
-
-liftBox :: Monad m => Box a -> m a
-liftBox (Box a) = return a
-{-# INLINE liftBox #-}
 
 -- | Delay inlining a function until late in the game (simplifier phase 0).
 delay_inline :: (a -> b) -> a -> b

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -138,6 +138,7 @@ Library
                , primitive >= 0.6.4.0 && < 0.8
                , ghc-prim >= 0.2 && < 0.8
                , deepseq >= 1.1 && < 1.5
+               , vector-stream >= 0.1 && < 0.2
 
   Ghc-Options: -O2 -Wall
 


### PR DESCRIPTION
As discussed in #355 this PR moves the streaming functionality into its own package.

Unfortunately github diff isn't smart enough,  but the actual git history is preserved in the moved `Monadic.hs` file. It is critical to have two separate commits for this to work, despite that one of them doesn't build.

There are no changes to the actual code, except that `Box` type was moved from `Utils.hs` into the new `vector-stream` package.

There are future plans of adding benchmarks and a test suite into the `vector-stream`, but for now to keep review as easy as possible this PR only moves the code.