### PR TITLE
Disable problematic tests with -boundschecks

### DIFF
--- a/vector/tests/Tests/Vector/UnitTests.hs
+++ b/vector/tests/Tests/Vector/UnitTests.hs
@@ -12,6 +12,7 @@ import Data.Typeable
 import qualified Data.List as List
 import qualified Data.Vector.Generic  as Generic
 import qualified Data.Vector as Boxed
+import qualified Data.Vector.Internal.Check as Check
 import qualified Data.Vector.Mutable as MBoxed
 import qualified Data.Vector.Primitive as Primitive
 import qualified Data.Vector.Storable as Storable
@@ -43,6 +44,12 @@ checkAddressAlignment xs = Storable.unsafeWith xs $ \ptr -> do
     dummy :: a
     dummy = undefined
 
+withBoundsChecksOnly :: [TestTree] -> [TestTree]
+withBoundsChecksOnly ts =
+  if Check.doChecks Check.Bounds
+     then ts
+     else []
+
 tests :: [TestTree]
 tests =
   [ testGroup "Data.Vector.Storable.Vector Alignment"
@@ -66,14 +73,15 @@ tests =
       , regression188 ([] :: [Char])
       ]
     ]
-  , testGroup "Negative tests"
-    [ testGroup "slice out of bounds #257"
+  , testGroup "Negative tests" $
+    withBoundsChecksOnly [ testGroup "slice out of bounds #257"
       [ testGroup "Boxed" $ testsSliceOutOfBounds Boxed.slice
       , testGroup "Primitive" $ testsSliceOutOfBounds Primitive.slice
       , testGroup "Storable" $ testsSliceOutOfBounds Storable.slice
       , testGroup "Unboxed" $ testsSliceOutOfBounds Unboxed.slice
-      ]
-    , testGroup "take #282"
+      ]]
+    ++
+    [ testGroup "take #282"
       [ testCase "Boxed" $ testTakeOutOfMemory Boxed.take
       , testCase "Primitive" $ testTakeOutOfMemory Primitive.take
       , testCase "Storable" $ testTakeOutOfMemory Storable.take


### PR DESCRIPTION
Some negative tests (namely, the `testsSliceOutOfBounds` ones in the test group `slice out of bounds #257`) crash the test suites `vector-tests-O0` and `vector-tests-O2` when running it without bounds checks. I used `cabal test -f -boundschecks` from inside the `vector` directory, but encountered this problem in a `nix-build` of our project first where I disabled said flag for version `0.12.3.0` of the library.

It feels like they should not be run at all without those checks.

If there is a better/alternative way to tackle and fix this problem, please let me know and I'll try to update this PR with it :)