### PR TITLE
Add tests for munstream 

### DIFF
--- a/vector/tests/Tests/Bundle.hs
+++ b/vector/tests/Tests/Bundle.hs
@@ -14,13 +14,11 @@ import Test.Tasty.QuickCheck hiding (testProperties)
 import Text.Show.Functions ()
 import Data.List           (foldl', foldl1', unfoldr, find, findIndex)
 
--- migration from testframework to tasty
-type Test = TestTree
 
 type CommonContext a = ( Eq a, Show a, Arbitrary a, CoArbitrary a, TestData a
                        , Model a ~ a, EqTest a ~ Property)
 
-testSanity :: forall v a. (CommonContext a) => S.Bundle v a -> [Test]
+testSanity :: forall v a. (CommonContext a) => S.Bundle v a -> [TestTree]
 testSanity _ = [
         testProperty "fromList.toList == id" prop_fromList_toList,
         testProperty "toList.fromList == id" prop_toList_fromList
@@ -31,7 +29,7 @@ testSanity _ = [
     prop_toList_fromList :: P ([a] -> [a])
         = (S.toList . (S.fromList :: [a] -> S.Bundle v a)) `eq` id
 
-testPolymorphicFunctions :: forall v a. (CommonContext a) => S.Bundle v a -> [Test]
+testPolymorphicFunctions :: forall v a. (CommonContext a) => S.Bundle v a -> [TestTree]
 testPolymorphicFunctions _ = $(testProperties [
         'prop_eq,
 
@@ -149,7 +147,7 @@ testPolymorphicFunctions _ = $(testProperties [
          = (\n f a -> S.unfoldr (limitUnfolds f) (a, n))
            `eq` (\n f a -> unfoldr (limitUnfolds f) (a, n))
 
-testBoolFunctions :: forall v. S.Bundle v Bool -> [Test]
+testBoolFunctions :: forall v. S.Bundle v Bool -> [TestTree]
 testBoolFunctions _ = $(testProperties ['prop_and, 'prop_or ])
   where
     prop_and :: P (S.Bundle v Bool -> Bool) = S.and `eq` and

--- a/vector/tests/Tests/Bundle.hs
+++ b/vector/tests/Tests/Bundle.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 module Tests.Bundle ( tests ) where
 
 import Boilerplater
@@ -16,13 +17,10 @@ import Data.List           (foldl', foldl1', unfoldr, find, findIndex)
 -- migration from testframework to tasty
 type Test = TestTree
 
-#define COMMON_CONTEXT(a) \
- VANILLA_CONTEXT(a)
+type CommonContext a = ( Eq a, Show a, Arbitrary a, CoArbitrary a, TestData a
+                       , Model a ~ a, EqTest a ~ Property)
 
-#define VANILLA_CONTEXT(a) \
-  Eq a,     Show a,     Arbitrary a,     CoArbitrary a,     TestData a,     Model a ~ a,        EqTest a ~ Property
-
-testSanity :: forall v a. (COMMON_CONTEXT(a)) => S.Bundle v a -> [Test]
+testSanity :: forall v a. (CommonContext a) => S.Bundle v a -> [Test]
 testSanity _ = [
         testProperty "fromList.toList == id" prop_fromList_toList,
         testProperty "toList.fromList == id" prop_toList_fromList
@@ -33,7 +31,7 @@ testSanity _ = [
     prop_toList_fromList :: P ([a] -> [a])
         = (S.toList . (S.fromList :: [a] -> S.Bundle v a)) `eq` id
 
-testPolymorphicFunctions :: forall v a. (COMMON_CONTEXT(a)) => S.Bundle v a -> [Test]
+testPolymorphicFunctions :: forall v a. (CommonContext a) => S.Bundle v a -> [Test]
 testPolymorphicFunctions _ = $(testProperties [
         'prop_eq,
 

--- a/vector/tests/Tests/Vector/Boxed.hs
+++ b/vector/tests/Tests/Vector/Boxed.hs
@@ -48,4 +48,5 @@ tests =
     testBoolBoxedVector (undefined :: Data.Vector.Vector Bool)
   , testGroup "Int" $
     testNumericBoxedVector (undefined :: Data.Vector.Vector Int)
+  , testGroup "unstream" $ testUnstream (undefined :: Data.Vector.Vector Int)
   ]

--- a/vector/tests/Tests/Vector/Boxed.hs
+++ b/vector/tests/Tests/Vector/Boxed.hs
@@ -10,7 +10,7 @@ import GHC.Exts (inline)
 
 testGeneralBoxedVector
   :: forall a. (CommonContext a Data.Vector.Vector, Ord a, Data a)
-  => Data.Vector.Vector a -> [Test]
+  => Data.Vector.Vector a -> [TestTree]
 testGeneralBoxedVector dummy = concatMap ($ dummy)
   [
     testSanity
@@ -35,7 +35,7 @@ testBoolBoxedVector dummy = concatMap ($ dummy)
 
 testNumericBoxedVector
   :: forall a. (CommonContext a Data.Vector.Vector, Ord a, Num a, Enum a, Random a, Data a)
-  => Data.Vector.Vector a -> [Test]
+  => Data.Vector.Vector a -> [TestTree]
 testNumericBoxedVector dummy = concatMap ($ dummy)
   [
     testGeneralBoxedVector

--- a/vector/tests/Tests/Vector/Primitive.hs
+++ b/vector/tests/Tests/Vector/Primitive.hs
@@ -10,7 +10,7 @@ import GHC.Exts (inline)
 testGeneralPrimitiveVector
   :: forall a. ( CommonContext a Data.Vector.Primitive.Vector
                , Data.Vector.Primitive.Prim a, Ord a, Data a)
-  => Data.Vector.Primitive.Vector a -> [Test]
+  => Data.Vector.Primitive.Vector a -> [TestTree]
 testGeneralPrimitiveVector dummy = concatMap ($ dummy)
   [
     testSanity
@@ -23,7 +23,7 @@ testGeneralPrimitiveVector dummy = concatMap ($ dummy)
 testNumericPrimitiveVector
   :: forall a. ( CommonContext a Data.Vector.Primitive.Vector
                , Data.Vector.Primitive.Prim a, Ord a, Num a, Enum a, Random a, Data a)
-  => Data.Vector.Primitive.Vector a -> [Test]
+  => Data.Vector.Primitive.Vector a -> [TestTree]
 testNumericPrimitiveVector dummy = concatMap ($ dummy)
   [
     testGeneralPrimitiveVector

--- a/vector/tests/Tests/Vector/Primitive.hs
+++ b/vector/tests/Tests/Vector/Primitive.hs
@@ -37,4 +37,5 @@ tests =
   , testGroup "Double" $
     testNumericPrimitiveVector
       (undefined :: Data.Vector.Primitive.Vector Double)
+  , testGroup "unstream" $ testUnstream (undefined :: Data.Vector.Primitive.Vector Int)
   ]

--- a/vector/tests/Tests/Vector/Storable.hs
+++ b/vector/tests/Tests/Vector/Storable.hs
@@ -36,4 +36,5 @@ tests =
     testNumericStorableVector (undefined :: Data.Vector.Storable.Vector Int)
   , testGroup "Data.Vector.Storable.Vector (Double)" $
     testNumericStorableVector (undefined :: Data.Vector.Storable.Vector Double)
+  , testGroup "unstream" $ testUnstream (undefined :: Data.Vector.Storable.Vector Int)
   ]

--- a/vector/tests/Tests/Vector/Storable.hs
+++ b/vector/tests/Tests/Vector/Storable.hs
@@ -10,7 +10,7 @@ import GHC.Exts (inline)
 testGeneralStorableVector
   :: forall a. ( CommonContext a Data.Vector.Storable.Vector
                , Data.Vector.Storable.Storable a, Ord a, Data a)
-  => Data.Vector.Storable.Vector a -> [Test]
+  => Data.Vector.Storable.Vector a -> [TestTree]
 testGeneralStorableVector dummy = concatMap ($ dummy)
   [
     testSanity
@@ -23,7 +23,7 @@ testGeneralStorableVector dummy = concatMap ($ dummy)
 testNumericStorableVector
   :: forall a. ( CommonContext a Data.Vector.Storable.Vector
                , Data.Vector.Storable.Storable a, Ord a, Num a, Enum a, Random a, Data a)
-  => Data.Vector.Storable.Vector a -> [Test]
+  => Data.Vector.Storable.Vector a -> [TestTree]
 testNumericStorableVector dummy = concatMap ($ dummy)
   [
     testGeneralStorableVector

--- a/vector/tests/Tests/Vector/Unboxed.hs
+++ b/vector/tests/Tests/Vector/Unboxed.hs
@@ -66,4 +66,5 @@ tests =
   , testGroup "(Int,Bool,Int)" $
     testTupleUnboxedVector
       (undefined :: Data.Vector.Unboxed.Vector (Int, Bool, Int))
+  , testGroup "unstream" $ testUnstream (undefined :: Data.Vector.Unboxed.Vector Int)
   ]

--- a/vector/tests/Tests/Vector/Unboxed.hs
+++ b/vector/tests/Tests/Vector/Unboxed.hs
@@ -9,7 +9,7 @@ import Tests.Vector.Property
 
 testGeneralUnboxedVector
   :: forall a. (CommonContext a Data.Vector.Unboxed.Vector, Data.Vector.Unboxed.Unbox a, Ord a, Data a)
-  => Data.Vector.Unboxed.Vector a -> [Test]
+  => Data.Vector.Unboxed.Vector a -> [TestTree]
 testGeneralUnboxedVector dummy = concatMap ($ dummy)
   [
     testSanity
@@ -34,7 +34,7 @@ testBoolUnboxedVector dummy = concatMap ($ dummy)
 testNumericUnboxedVector
   :: forall a. ( CommonContext a Data.Vector.Unboxed.Vector
                , Data.Vector.Unboxed.Unbox a, Ord a, Num a, Enum a, Random a, Data a)
-  => Data.Vector.Unboxed.Vector a -> [Test]
+  => Data.Vector.Unboxed.Vector a -> [TestTree]
 testNumericUnboxedVector dummy = concatMap ($ dummy)
   [
     testGeneralUnboxedVector
@@ -44,7 +44,7 @@ testNumericUnboxedVector dummy = concatMap ($ dummy)
 
 testTupleUnboxedVector
   :: forall a. ( CommonContext a Data.Vector.Unboxed.Vector
-               , Data.Vector.Unboxed.Unbox a, Ord a, Data a) => Data.Vector.Unboxed.Vector a -> [Test]
+               , Data.Vector.Unboxed.Unbox a, Ord a, Data a) => Data.Vector.Unboxed.Vector a -> [TestTree]
 testTupleUnboxedVector dummy = concatMap ($ dummy)
   [
     testGeneralUnboxedVector


### PR DESCRIPTION
While working on unstreaming machinery (See #301, #388, #406 for context) I found out that we don't test `unstream` at all. One could replace its definition with undefined and tests will still pass. This PR fixes this situation by adding tests that `unstream`, `vunstream` and `unstreamR` produce identical results. 

There're few cleanups for the test suite.  