### PR TITLE
Future-proof Eq instances

### DIFF
--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -293,9 +293,6 @@ instance Eq a => Eq (Vector a) where
   {-# INLINE (==) #-}
   xs == ys = Bundle.eq (G.stream xs) (G.stream ys)
 
-  {-# INLINE (/=) #-}
-  xs /= ys = not (Bundle.eq (G.stream xs) (G.stream ys))
-
 -- See http://trac.haskell.org/vector/ticket/12
 instance Ord a => Ord (Vector a) where
   {-# INLINE compare #-}

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -272,9 +272,6 @@ instance (Prim a, Eq a) => Eq (Vector a) where
   {-# INLINE (==) #-}
   xs == ys = Bundle.eq (G.stream xs) (G.stream ys)
 
-  {-# INLINE (/=) #-}
-  xs /= ys = not (Bundle.eq (G.stream xs) (G.stream ys))
-
 -- See http://trac.haskell.org/vector/ticket/12
 instance (Prim a, Ord a) => Ord (Vector a) where
   {-# INLINE compare #-}

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -284,9 +284,6 @@ instance (Storable a, Eq a) => Eq (Vector a) where
   {-# INLINE (==) #-}
   xs == ys = Bundle.eq (G.stream xs) (G.stream ys)
 
-  {-# INLINE (/=) #-}
-  xs /= ys = not (Bundle.eq (G.stream xs) (G.stream ys))
-
 -- See http://trac.haskell.org/vector/ticket/12
 instance (Storable a, Ord a) => Ord (Vector a) where
   {-# INLINE compare #-}

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -234,9 +234,6 @@ instance (Unbox a, Eq a) => Eq (Vector a) where
   {-# INLINE (==) #-}
   xs == ys = Bundle.eq (G.stream xs) (G.stream ys)
 
-  {-# INLINE (/=) #-}
-  xs /= ys = not (Bundle.eq (G.stream xs) (G.stream ys))
-
 -- See http://trac.haskell.org/vector/ticket/12
 instance (Unbox a, Ord a) => Ord (Vector a) where
   {-# INLINE compare #-}


### PR DESCRIPTION
CLC has approved the proposal to remove `(/=)` from `class Eq` (https://github.com/haskell/core-libraries-committee/issues/3). It means that `class Eq` will contain a single member `(==)` and `(/=)` will be just a normal function.

The implementation of the proposal is delayed at least to GHC 9.4 and likely to GHC 9.6, but one can already future-proof `Eq` instances to be compliant with this change in a backwards-compatible way. No CPP required.

Migration guide and more info: https://github.com/haskell/core-libraries-committee/pull/16/files?short_path=96261da#diff-96261daba6a7a6dc59441c8a9ae10ce5cbbeae9a5ad9b11d9b8cac0d3c01be5a