### PR TITLE
Add safe read variant for mutable vectors

### DIFF
--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -635,7 +635,15 @@ clear = stToPrim . basicClear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position.
+-- | Yield the element at the given position. Will throw exception if
+-- index is out of range.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Mutable as MV
+-- >>> v <- MV.generate 10 (\x -> x*x)
+-- >>> MV.read v 3
+-- 9
 read :: (HasCallStack, PrimMonad m, MVector v a) => v (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read v i = checkIndex Bounds i (length v)

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -44,7 +44,7 @@ module Data.Vector.Generic.Mutable (
   clear,
 
   -- * Accessing individual elements
-  read, write, modify, modifyM, swap, exchange,
+  read, readMaybe, write, modify, modifyM, swap, exchange,
   unsafeRead, unsafeWrite, unsafeModify, unsafeModifyM, unsafeSwap, unsafeExchange,
 
   -- * Folds
@@ -635,8 +635,8 @@ clear = stToPrim . basicClear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position. Will throw exception if
--- index is out of range.
+-- | Yield the element at the given position. Will throw an exception if
+-- the index is out of range.
 --
 -- ==== __Examples__
 --
@@ -648,6 +648,24 @@ read :: (HasCallStack, PrimMonad m, MVector v a) => v (PrimState m) a -> Int -> 
 {-# INLINE read #-}
 read v i = checkIndex Bounds i (length v)
          $ unsafeRead v i
+
+-- | Yield the element at the given position. Returns 'Nothing' if
+-- the index is out of range.
+--
+-- @since 0.13
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Mutable as MV
+-- >>> v <- MV.generate 10 (\x -> x*x)
+-- >>> MV.readMaybe v 3
+-- Just 9
+-- >>> MV.readMaybe v 13
+-- Nothing
+readMaybe :: (PrimMonad m, MVector v a) => v (PrimState m) a -> Int -> m (Maybe a)
+{-# INLINE readMaybe #-}
+readMaybe v i | i `inRange` (length v) = Just <$> unsafeRead v i
+              | otherwise              = pure Nothing
 
 -- | Replace the element at the given position.
 write :: (HasCallStack, PrimMonad m, MVector v a) => v (PrimState m) a -> Int -> a -> m ()

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -424,7 +424,15 @@ clear = G.clear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position.
+-- | Yield the element at the given position. Will throw exception if
+-- index is out of range.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Mutable as MV
+-- >>> v <- MV.generate 10 (\x -> x*x)
+-- >>> MV.read v 3
+-- 9
 read :: PrimMonad m => MVector (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read = G.read

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -44,7 +44,7 @@ module Data.Vector.Mutable (
   clear,
 
   -- * Accessing individual elements
-  read, write, modify, modifyM, swap, exchange,
+  read, readMaybe, write, modify, modifyM, swap, exchange,
   unsafeRead, unsafeWrite, unsafeModify, unsafeModifyM, unsafeSwap, unsafeExchange,
 
   -- * Folds
@@ -424,8 +424,8 @@ clear = G.clear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position. Will throw exception if
--- index is out of range.
+-- | Yield the element at the given position. Will throw an exception if
+-- the index is out of range.
 --
 -- ==== __Examples__
 --
@@ -436,6 +436,23 @@ clear = G.clear
 read :: PrimMonad m => MVector (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read = G.read
+
+-- | Yield the element at the given position. Returns 'Nothing' if
+-- the index is out of range.
+--
+-- @since 0.13
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Mutable as MV
+-- >>> v <- MV.generate 10 (\x -> x*x)
+-- >>> MV.readMaybe v 3
+-- Just 9
+-- >>> MV.readMaybe v 13
+-- Nothing
+readMaybe :: (PrimMonad m) => MVector (PrimState m) a -> Int -> m (Maybe a)
+{-# INLINE readMaybe #-}
+readMaybe = G.readMaybe
 
 -- | Replace the element at the given position.
 write :: PrimMonad m => MVector (PrimState m) a -> Int -> a -> m ()

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -386,7 +386,15 @@ clear = G.clear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position.
+-- | Yield the element at the given position. Will throw exception if
+-- index is out of range.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Primitive.Mutable as MVP
+-- >>> v <- MV.generate 10 (\x -> x*x)
+-- >>> MV.read v 3
+-- 9
 read :: (PrimMonad m, Prim a) => MVector (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read = G.read

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -43,7 +43,7 @@ module Data.Vector.Primitive.Mutable (
   clear,
 
   -- * Accessing individual elements
-  read, write, modify, modifyM, swap, exchange,
+  read, readMaybe, write, modify, modifyM, swap, exchange,
   unsafeRead, unsafeWrite, unsafeModify, unsafeModifyM, unsafeSwap, unsafeExchange,
 
   -- * Folds
@@ -386,18 +386,35 @@ clear = G.clear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position. Will throw exception if
--- index is out of range.
+-- | Yield the element at the given position. Will throw an exception if
+-- the index is out of range.
 --
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Primitive.Mutable as MVP
--- >>> v <- MV.generate 10 (\x -> x*x)
--- >>> MV.read v 3
+-- >>> v <- MVP.generate 10 (\x -> x*x)
+-- >>> MVP.read v 3
 -- 9
 read :: (PrimMonad m, Prim a) => MVector (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read = G.read
+
+-- | Yield the element at the given position. Returns 'Nothing' if
+-- the index is out of range.
+--
+-- @since 0.13
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Primitive.Mutable as MVP
+-- >>> v <- MVP.generate 10 (\x -> x*x)
+-- >>> MVP.readMaybe v 3
+-- Just 9
+-- >>> MVP.readMaybe v 13
+-- Nothing
+readMaybe :: (PrimMonad m, Prim a) => MVector (PrimState m) a -> Int -> m (Maybe a)
+{-# INLINE readMaybe #-}
+readMaybe = G.readMaybe
 
 -- | Replace the element at the given position.
 write :: (PrimMonad m, Prim a) => MVector (PrimState m) a -> Int -> a -> m ()

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -44,7 +44,7 @@ module Data.Vector.Storable.Mutable(
   clear,
 
   -- * Accessing individual elements
-  read, write, modify, modifyM, swap, exchange,
+  read, readMaybe, write, modify, modifyM, swap, exchange,
   unsafeRead, unsafeWrite, unsafeModify, unsafeModifyM, unsafeSwap, unsafeExchange,
 
   -- * Folds
@@ -485,18 +485,35 @@ clear = G.clear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position. Will throw exception if
--- index is out of range.
+-- | Yield the element at the given position. Will throw an exception if
+-- the index is out of range.
 --
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Storable.Mutable as MVS
--- >>> v <- MV.generate 10 (\x -> x*x)
--- >>> MV.read v 3
+-- >>> v <- MVS.generate 10 (\x -> x*x)
+-- >>> MVS.read v 3
 -- 9
 read :: (PrimMonad m, Storable a) => MVector (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read = G.read
+
+-- | Yield the element at the given position. Returns 'Nothing' if
+-- the index is out of range.
+--
+-- @since 0.13
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Storable.Mutable as MVS
+-- >>> v <- MVS.generate 10 (\x -> x*x)
+-- >>> MVS.readMaybe v 3
+-- Just 9
+-- >>> MVS.readMaybe v 13
+-- Nothing
+readMaybe :: (PrimMonad m, Storable a) => MVector (PrimState m) a -> Int -> m (Maybe a)
+{-# INLINE readMaybe #-}
+readMaybe = G.readMaybe
 
 -- | Replace the element at the given position.
 write

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -485,7 +485,15 @@ clear = G.clear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position.
+-- | Yield the element at the given position. Will throw exception if
+-- index is out of range.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Storable.Mutable as MVS
+-- >>> v <- MV.generate 10 (\x -> x*x)
+-- >>> MV.read v 3
+-- 9
 read :: (PrimMonad m, Storable a) => MVector (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read = G.read

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -43,7 +43,7 @@ module Data.Vector.Unboxed.Mutable (
   unzip, unzip3, unzip4, unzip5, unzip6,
 
   -- * Accessing individual elements
-  read, write, modify, modifyM, swap, exchange,
+  read, readMaybe, write, modify, modifyM, swap, exchange,
   unsafeRead, unsafeWrite, unsafeModify, unsafeModifyM, unsafeSwap, unsafeExchange,
 
   -- * Folds
@@ -293,18 +293,35 @@ clear = G.clear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position. Will throw exception if
--- index is out of range.
+-- | Yield the element at the given position. Will throw an exception if
+-- the index is out of range.
 --
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Unboxed.Mutable as MVU
--- >>> v <- MV.generate 10 (\x -> x*x)
--- >>> MV.read v 3
+-- >>> v <- MVU.generate 10 (\x -> x*x)
+-- >>> MVU.read v 3
 -- 9
 read :: (PrimMonad m, Unbox a) => MVector (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read = G.read
+
+-- | Yield the element at the given position. Returns 'Nothing' if
+-- the index is out of range.
+--
+-- @since 0.13
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Unboxed.Mutable as MVU
+-- >>> v <- MVU.generate 10 (\x -> x*x)
+-- >>> MVU.readMaybe v 3
+-- Just 9
+-- >>> MVU.readMaybe v 13
+-- Nothing
+readMaybe :: (PrimMonad m, Unbox a) => MVector (PrimState m) a -> Int -> m (Maybe a)
+{-# INLINE readMaybe #-}
+readMaybe = G.readMaybe
 
 -- | Replace the element at the given position.
 write :: (PrimMonad m, Unbox a) => MVector (PrimState m) a -> Int -> a -> m ()

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -293,7 +293,15 @@ clear = G.clear
 -- Accessing individual elements
 -- -----------------------------
 
--- | Yield the element at the given position.
+-- | Yield the element at the given position. Will throw exception if
+-- index is out of range.
+--
+-- ==== __Examples__
+--
+-- >>> import qualified Data.Vector.Unboxed.Mutable as MVU
+-- >>> v <- MV.generate 10 (\x -> x*x)
+-- >>> MV.read v 3
+-- 9
 read :: (PrimMonad m, Unbox a) => MVector (PrimState m) a -> Int -> m a
 {-# INLINE read #-}
 read = G.read

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -266,7 +266,7 @@ test-suite vector-doctest
     buildable: False
   build-depends:
         base      -any
-      , doctest   >=0.15 && <0.20
+      , doctest   >=0.15 && <0.21
       , primitive >= 0.6.4.0 && < 0.8
       , vector    -any
 


### PR DESCRIPTION
Also add doctests for read along the way and bump doctest's upper bound (0.21) is on hackage

Fixes #341 