### PR TITLE
Update CI badge

### DIFF
--- a/vector/README.md
+++ b/vector/README.md
@@ -1,4 +1,4 @@
-The `vector` package [![Build Status](https://travis-ci.org/haskell/vector.png?branch=master)](https://travis-ci.org/haskell/vector)
+The `vector` package [![Build Status](https://github.com/haskell/vector/workflows/CI/badge.svg)](https://github.com/haskell/vector/actions?query=branch%3Amaster)
 ====================
 
 An efficient implementation of `Int`-indexed arrays (both mutable and immutable), with a powerful loop optimisation framework.


### PR DESCRIPTION
Update the CI badge to show the status of the GitHub Actions CI instead of the old Travis CI.