### PR TITLE
Use MathJax format for complexity annotations

### DIFF
--- a/vector-stream/src/Data/Stream/Monadic.hs
+++ b/vector-stream/src/Data/Stream/Monadic.hs
@@ -1171,7 +1171,7 @@ unfoldrExactNM m f t = Stream step (t,m)
                | otherwise = do (x,s') <- f s
                                 return $ Yield x (s',n-1)
 
--- | /O(n)/ Apply monadic function \(\max(n - 1, 0)\) times to an initial value,
+-- | \(O(n)\) Apply monadic function \(\max(n - 1, 0)\) times to an initial value,
 -- producing a stream of \(\max(n, 0)\) values.
 iterateNM :: Monad m => Int -> (a -> m a) -> a -> Stream m a
 {-# INLINE_FUSED iterateNM #-}
@@ -1183,7 +1183,7 @@ iterateNM n f x0 = Stream step (x0,n)
                | otherwise = do a <- f x
                                 return $ Yield a (a,i-1)
 
--- | /O(n)/ Apply function \(\max(n - 1, 0)\) times to an initial value,
+-- | \(O(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value,
 -- producing a stream of \(\max(n, 0)\) values.
 iterateN :: Monad m => Int -> (a -> a) -> a -> Stream m a
 {-# INLINE_FUSED iterateN #-}

--- a/vector-stream/src/Data/Stream/Monadic.hs
+++ b/vector-stream/src/Data/Stream/Monadic.hs
@@ -1171,7 +1171,7 @@ unfoldrExactNM m f t = Stream step (t,m)
                | otherwise = do (x,s') <- f s
                                 return $ Yield x (s',n-1)
 
--- | \(O(n)\) Apply monadic function \(\max(n - 1, 0)\) times to an initial value,
+-- | \(\mathcal{O}(n)\) Apply monadic function \(\max(n - 1, 0)\) times to an initial value,
 -- producing a stream of \(\max(n, 0)\) values.
 iterateNM :: Monad m => Int -> (a -> m a) -> a -> Stream m a
 {-# INLINE_FUSED iterateNM #-}
@@ -1183,7 +1183,7 @@ iterateNM n f x0 = Stream step (x0,n)
                | otherwise = do a <- f x
                                 return $ Yield a (a,i-1)
 
--- | \(O(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value,
+-- | \(\mathcal{O}(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value,
 -- producing a stream of \(\max(n, 0)\) values.
 iterateN :: Monad m => Int -> (a -> a) -> a -> Stream m a
 {-# INLINE_FUSED iterateN #-}

--- a/vector/internal/GenUnboxTuple.hs
+++ b/vector/internal/GenUnboxTuple.hs
@@ -53,7 +53,7 @@ generate n =
 
 
     define_zip ty c
-      = sep [text "-- | \(O(1)\) Zip" <+> int n <+> text "vectors."
+      = sep [text "-- | \(\mathcal{O}(1)\) Zip" <+> int n <+> text "vectors."
             ,name <+> text "::"
                   <+> vtuple [text "Unbox" <+> v | v <- vars]
                   <+> text "=>"
@@ -94,7 +94,7 @@ generate n =
 
 
     define_unzip ty c
-      = sep [text "-- | \(O(1)\) Unzip" <+> int n <+> text "vectors."
+      = sep [text "-- | \(\mathcal{O}(1)\) Unzip" <+> int n <+> text "vectors."
             ,name <+> text "::"
                   <+> vtuple [text "Unbox" <+> v | v <- vars]
                   <+> text "=>"

--- a/vector/internal/GenUnboxTuple.hs
+++ b/vector/internal/GenUnboxTuple.hs
@@ -53,7 +53,7 @@ generate n =
 
 
     define_zip ty c
-      = sep [text "-- | /O(1)/ Zip" <+> int n <+> text "vectors."
+      = sep [text "-- | \(O(1)\) Zip" <+> int n <+> text "vectors."
             ,name <+> text "::"
                   <+> vtuple [text "Unbox" <+> v | v <- vars]
                   <+> text "=>"
@@ -94,7 +94,7 @@ generate n =
 
 
     define_unzip ty c
-      = sep [text "-- | /O(1)/ Unzip" <+> int n <+> text "vectors."
+      = sep [text "-- | \(O(1)\) Unzip" <+> int n <+> text "vectors."
             ,name <+> text "::"
                   <+> vtuple [text "Unbox" <+> v | v <- vars]
                   <+> text "=>"

--- a/vector/internal/unbox-tuple-instances
+++ b/vector/internal/unbox-tuple-instances
@@ -107,20 +107,20 @@ instance (Unbox a, Unbox b) => G.Vector Vector (a, b) where
         . G.elemseq (undefined :: Vector b) b
 #endif
 #ifdef DEFINE_MUTABLE
--- | \(O(1)\) Zip 2 vectors.
+-- | \(\mathcal{O}(1)\) Zip 2 vectors.
 zip :: (Unbox a, Unbox b) => MVector s a ->
                              MVector s b -> MVector s (a, b)
 {-# INLINE_FUSED zip #-}
 zip as bs = MV_2 len (unsafeSlice 0 len as) (unsafeSlice 0 len bs)
   where len = length as `delayed_min` length bs
--- | \(O(1)\) Unzip 2 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 2 vectors.
 unzip :: (Unbox a, Unbox b) => MVector s (a, b) -> (MVector s a,
                                                     MVector s b)
 {-# INLINE unzip #-}
 unzip (MV_2 _ as bs) = (as, bs)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | \(O(1)\) Zip 2 vectors.
+-- | \(\mathcal{O}(1)\) Zip 2 vectors.
 zip :: (Unbox a, Unbox b) => Vector a -> Vector b -> Vector (a, b)
 {-# INLINE_FUSED zip #-}
 zip as bs = V_2 len (unsafeSlice 0 len as) (unsafeSlice 0 len bs)
@@ -129,7 +129,7 @@ zip as bs = V_2 len (unsafeSlice 0 len as) (unsafeSlice 0 len bs)
   G.stream (zip as bs) = Bundle.zipWith (,) (G.stream as)
                                             (G.stream bs)   #-}
 
--- | \(O(1)\) Unzip 2 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 2 vectors.
 unzip :: (Unbox a, Unbox b) => Vector (a, b) -> (Vector a,
                                                  Vector b)
 {-# INLINE unzip #-}
@@ -268,7 +268,7 @@ instance (Unbox a,
         . G.elemseq (undefined :: Vector c) c
 #endif
 #ifdef DEFINE_MUTABLE
--- | \(O(1)\) Zip 3 vectors.
+-- | \(\mathcal{O}(1)\) Zip 3 vectors.
 zip3 :: (Unbox a, Unbox b, Unbox c) => MVector s a ->
                                        MVector s b ->
                                        MVector s c -> MVector s (a, b, c)
@@ -278,7 +278,7 @@ zip3 as bs cs = MV_3 len (unsafeSlice 0 len as)
                          (unsafeSlice 0 len cs)
   where
     len = length as `delayed_min` length bs `delayed_min` length cs
--- | \(O(1)\) Unzip 3 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 3 vectors.
 unzip3 :: (Unbox a,
            Unbox b,
            Unbox c) => MVector s (a, b, c) -> (MVector s a,
@@ -288,7 +288,7 @@ unzip3 :: (Unbox a,
 unzip3 (MV_3 _ as bs cs) = (as, bs, cs)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | \(O(1)\) Zip 3 vectors.
+-- | \(\mathcal{O}(1)\) Zip 3 vectors.
 zip3 :: (Unbox a, Unbox b, Unbox c) => Vector a ->
                                        Vector b ->
                                        Vector c -> Vector (a, b, c)
@@ -303,7 +303,7 @@ zip3 as bs cs = V_3 len (unsafeSlice 0 len as)
                                                    (G.stream bs)
                                                    (G.stream cs)   #-}
 
--- | \(O(1)\) Unzip 3 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 3 vectors.
 unzip3 :: (Unbox a,
            Unbox b,
            Unbox c) => Vector (a, b, c) -> (Vector a, Vector b, Vector c)
@@ -474,7 +474,7 @@ instance (Unbox a,
         . G.elemseq (undefined :: Vector d) d
 #endif
 #ifdef DEFINE_MUTABLE
--- | \(O(1)\) Zip 4 vectors.
+-- | \(\mathcal{O}(1)\) Zip 4 vectors.
 zip4 :: (Unbox a, Unbox b, Unbox c, Unbox d) => MVector s a ->
                                                 MVector s b ->
                                                 MVector s c ->
@@ -489,7 +489,7 @@ zip4 as bs cs ds = MV_4 len (unsafeSlice 0 len as)
           length bs `delayed_min`
           length cs `delayed_min`
           length ds
--- | \(O(1)\) Unzip 4 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 4 vectors.
 unzip4 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -501,7 +501,7 @@ unzip4 :: (Unbox a,
 unzip4 (MV_4 _ as bs cs ds) = (as, bs, cs, ds)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | \(O(1)\) Zip 4 vectors.
+-- | \(\mathcal{O}(1)\) Zip 4 vectors.
 zip4 :: (Unbox a, Unbox b, Unbox c, Unbox d) => Vector a ->
                                                 Vector b ->
                                                 Vector c ->
@@ -522,7 +522,7 @@ zip4 as bs cs ds = V_4 len (unsafeSlice 0 len as)
                                                         (G.stream cs)
                                                         (G.stream ds)   #-}
 
--- | \(O(1)\) Unzip 4 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 4 vectors.
 unzip4 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -730,7 +730,7 @@ instance (Unbox a,
         . G.elemseq (undefined :: Vector e) e
 #endif
 #ifdef DEFINE_MUTABLE
--- | \(O(1)\) Zip 5 vectors.
+-- | \(\mathcal{O}(1)\) Zip 5 vectors.
 zip5 :: (Unbox a,
          Unbox b,
          Unbox c,
@@ -752,7 +752,7 @@ zip5 as bs cs ds es = MV_5 len (unsafeSlice 0 len as)
           length cs `delayed_min`
           length ds `delayed_min`
           length es
--- | \(O(1)\) Unzip 5 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 5 vectors.
 unzip5 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -766,7 +766,7 @@ unzip5 :: (Unbox a,
 unzip5 (MV_5 _ as bs cs ds es) = (as, bs, cs, ds, es)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | \(O(1)\) Zip 5 vectors.
+-- | \(\mathcal{O}(1)\) Zip 5 vectors.
 zip5 :: (Unbox a,
          Unbox b,
          Unbox c,
@@ -799,7 +799,7 @@ zip5 as bs cs ds es = V_5 len (unsafeSlice 0 len as)
                                                  (G.stream ds)
                                                  (G.stream es)   #-}
 
--- | \(O(1)\) Unzip 5 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 5 vectors.
 unzip5 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -1036,7 +1036,7 @@ instance (Unbox a,
         . G.elemseq (undefined :: Vector f) f
 #endif
 #ifdef DEFINE_MUTABLE
--- | \(O(1)\) Zip 6 vectors.
+-- | \(\mathcal{O}(1)\) Zip 6 vectors.
 zip6 :: (Unbox a,
          Unbox b,
          Unbox c,
@@ -1062,7 +1062,7 @@ zip6 as bs cs ds es fs = MV_6 len (unsafeSlice 0 len as)
           length ds `delayed_min`
           length es `delayed_min`
           length fs
--- | \(O(1)\) Unzip 6 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 6 vectors.
 unzip6 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -1078,7 +1078,7 @@ unzip6 :: (Unbox a,
 unzip6 (MV_6 _ as bs cs ds es fs) = (as, bs, cs, ds, es, fs)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | \(O(1)\) Zip 6 vectors.
+-- | \(\mathcal{O}(1)\) Zip 6 vectors.
 zip6 :: (Unbox a,
          Unbox b,
          Unbox c,
@@ -1117,7 +1117,7 @@ zip6 as bs cs ds es fs = V_6 len (unsafeSlice 0 len as)
                                                    (G.stream es)
                                                    (G.stream fs)   #-}
 
--- | \(O(1)\) Unzip 6 vectors.
+-- | \(\mathcal{O}(1)\) Unzip 6 vectors.
 unzip6 :: (Unbox a,
            Unbox b,
            Unbox c,

--- a/vector/internal/unbox-tuple-instances
+++ b/vector/internal/unbox-tuple-instances
@@ -107,20 +107,20 @@ instance (Unbox a, Unbox b) => G.Vector Vector (a, b) where
         . G.elemseq (undefined :: Vector b) b
 #endif
 #ifdef DEFINE_MUTABLE
--- | /O(1)/ Zip 2 vectors.
+-- | \(O(1)\) Zip 2 vectors.
 zip :: (Unbox a, Unbox b) => MVector s a ->
                              MVector s b -> MVector s (a, b)
 {-# INLINE_FUSED zip #-}
 zip as bs = MV_2 len (unsafeSlice 0 len as) (unsafeSlice 0 len bs)
   where len = length as `delayed_min` length bs
--- | /O(1)/ Unzip 2 vectors.
+-- | \(O(1)\) Unzip 2 vectors.
 unzip :: (Unbox a, Unbox b) => MVector s (a, b) -> (MVector s a,
                                                     MVector s b)
 {-# INLINE unzip #-}
 unzip (MV_2 _ as bs) = (as, bs)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | /O(1)/ Zip 2 vectors.
+-- | \(O(1)\) Zip 2 vectors.
 zip :: (Unbox a, Unbox b) => Vector a -> Vector b -> Vector (a, b)
 {-# INLINE_FUSED zip #-}
 zip as bs = V_2 len (unsafeSlice 0 len as) (unsafeSlice 0 len bs)
@@ -129,7 +129,7 @@ zip as bs = V_2 len (unsafeSlice 0 len as) (unsafeSlice 0 len bs)
   G.stream (zip as bs) = Bundle.zipWith (,) (G.stream as)
                                             (G.stream bs)   #-}
 
--- | /O(1)/ Unzip 2 vectors.
+-- | \(O(1)\) Unzip 2 vectors.
 unzip :: (Unbox a, Unbox b) => Vector (a, b) -> (Vector a,
                                                  Vector b)
 {-# INLINE unzip #-}
@@ -268,7 +268,7 @@ instance (Unbox a,
         . G.elemseq (undefined :: Vector c) c
 #endif
 #ifdef DEFINE_MUTABLE
--- | /O(1)/ Zip 3 vectors.
+-- | \(O(1)\) Zip 3 vectors.
 zip3 :: (Unbox a, Unbox b, Unbox c) => MVector s a ->
                                        MVector s b ->
                                        MVector s c -> MVector s (a, b, c)
@@ -278,7 +278,7 @@ zip3 as bs cs = MV_3 len (unsafeSlice 0 len as)
                          (unsafeSlice 0 len cs)
   where
     len = length as `delayed_min` length bs `delayed_min` length cs
--- | /O(1)/ Unzip 3 vectors.
+-- | \(O(1)\) Unzip 3 vectors.
 unzip3 :: (Unbox a,
            Unbox b,
            Unbox c) => MVector s (a, b, c) -> (MVector s a,
@@ -288,7 +288,7 @@ unzip3 :: (Unbox a,
 unzip3 (MV_3 _ as bs cs) = (as, bs, cs)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | /O(1)/ Zip 3 vectors.
+-- | \(O(1)\) Zip 3 vectors.
 zip3 :: (Unbox a, Unbox b, Unbox c) => Vector a ->
                                        Vector b ->
                                        Vector c -> Vector (a, b, c)
@@ -303,7 +303,7 @@ zip3 as bs cs = V_3 len (unsafeSlice 0 len as)
                                                    (G.stream bs)
                                                    (G.stream cs)   #-}
 
--- | /O(1)/ Unzip 3 vectors.
+-- | \(O(1)\) Unzip 3 vectors.
 unzip3 :: (Unbox a,
            Unbox b,
            Unbox c) => Vector (a, b, c) -> (Vector a, Vector b, Vector c)
@@ -474,7 +474,7 @@ instance (Unbox a,
         . G.elemseq (undefined :: Vector d) d
 #endif
 #ifdef DEFINE_MUTABLE
--- | /O(1)/ Zip 4 vectors.
+-- | \(O(1)\) Zip 4 vectors.
 zip4 :: (Unbox a, Unbox b, Unbox c, Unbox d) => MVector s a ->
                                                 MVector s b ->
                                                 MVector s c ->
@@ -489,7 +489,7 @@ zip4 as bs cs ds = MV_4 len (unsafeSlice 0 len as)
           length bs `delayed_min`
           length cs `delayed_min`
           length ds
--- | /O(1)/ Unzip 4 vectors.
+-- | \(O(1)\) Unzip 4 vectors.
 unzip4 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -501,7 +501,7 @@ unzip4 :: (Unbox a,
 unzip4 (MV_4 _ as bs cs ds) = (as, bs, cs, ds)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | /O(1)/ Zip 4 vectors.
+-- | \(O(1)\) Zip 4 vectors.
 zip4 :: (Unbox a, Unbox b, Unbox c, Unbox d) => Vector a ->
                                                 Vector b ->
                                                 Vector c ->
@@ -522,7 +522,7 @@ zip4 as bs cs ds = V_4 len (unsafeSlice 0 len as)
                                                         (G.stream cs)
                                                         (G.stream ds)   #-}
 
--- | /O(1)/ Unzip 4 vectors.
+-- | \(O(1)\) Unzip 4 vectors.
 unzip4 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -730,7 +730,7 @@ instance (Unbox a,
         . G.elemseq (undefined :: Vector e) e
 #endif
 #ifdef DEFINE_MUTABLE
--- | /O(1)/ Zip 5 vectors.
+-- | \(O(1)\) Zip 5 vectors.
 zip5 :: (Unbox a,
          Unbox b,
          Unbox c,
@@ -752,7 +752,7 @@ zip5 as bs cs ds es = MV_5 len (unsafeSlice 0 len as)
           length cs `delayed_min`
           length ds `delayed_min`
           length es
--- | /O(1)/ Unzip 5 vectors.
+-- | \(O(1)\) Unzip 5 vectors.
 unzip5 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -766,7 +766,7 @@ unzip5 :: (Unbox a,
 unzip5 (MV_5 _ as bs cs ds es) = (as, bs, cs, ds, es)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | /O(1)/ Zip 5 vectors.
+-- | \(O(1)\) Zip 5 vectors.
 zip5 :: (Unbox a,
          Unbox b,
          Unbox c,
@@ -799,7 +799,7 @@ zip5 as bs cs ds es = V_5 len (unsafeSlice 0 len as)
                                                  (G.stream ds)
                                                  (G.stream es)   #-}
 
--- | /O(1)/ Unzip 5 vectors.
+-- | \(O(1)\) Unzip 5 vectors.
 unzip5 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -1036,7 +1036,7 @@ instance (Unbox a,
         . G.elemseq (undefined :: Vector f) f
 #endif
 #ifdef DEFINE_MUTABLE
--- | /O(1)/ Zip 6 vectors.
+-- | \(O(1)\) Zip 6 vectors.
 zip6 :: (Unbox a,
          Unbox b,
          Unbox c,
@@ -1062,7 +1062,7 @@ zip6 as bs cs ds es fs = MV_6 len (unsafeSlice 0 len as)
           length ds `delayed_min`
           length es `delayed_min`
           length fs
--- | /O(1)/ Unzip 6 vectors.
+-- | \(O(1)\) Unzip 6 vectors.
 unzip6 :: (Unbox a,
            Unbox b,
            Unbox c,
@@ -1078,7 +1078,7 @@ unzip6 :: (Unbox a,
 unzip6 (MV_6 _ as bs cs ds es fs) = (as, bs, cs, ds, es, fs)
 #endif
 #ifdef DEFINE_IMMUTABLE
--- | /O(1)/ Zip 6 vectors.
+-- | \(O(1)\) Zip 6 vectors.
 zip6 :: (Unbox a,
          Unbox b,
          Unbox c,
@@ -1117,7 +1117,7 @@ zip6 as bs cs ds es fs = V_6 len (unsafeSlice 0 len as)
                                                    (G.stream es)
                                                    (G.stream fs)   #-}
 
--- | /O(1)/ Unzip 6 vectors.
+-- | \(O(1)\) Unzip 6 vectors.
 unzip6 :: (Unbox a,
            Unbox b,
            Unbox c,

--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -458,7 +458,7 @@ instance Foldable.Foldable Vector where
 instance Traversable.Traversable Vector where
   {-# INLINE traverse #-}
   traverse f xs =
-      -- Get the length of the vector in \(O(1)\) time
+      -- Get the length of the vector in \(\mathcal{O}(1)\) time
       let !n = G.length xs
       -- Use fromListN to be more efficient in construction of resulting vector
       -- Also behaves better with compact regions, preventing runtime exceptions
@@ -473,12 +473,12 @@ instance Traversable.Traversable Vector where
 -- Length information
 -- ------------------
 
--- | \(O(1)\) Yield the length of the vector.
+-- | \(\mathcal{O}(1)\) Yield the length of the vector.
 length :: Vector a -> Int
 {-# INLINE length #-}
 length = G.length
 
--- | \(O(1)\) Test whether a vector is empty.
+-- | \(\mathcal{O}(1)\) Test whether a vector is empty.
 null :: Vector a -> Bool
 {-# INLINE null #-}
 null = G.null
@@ -486,37 +486,37 @@ null = G.null
 -- Indexing
 -- --------
 
--- | \(O(1)\) Indexing.
+-- | \(\mathcal{O}(1)\) Indexing.
 (!) :: Vector a -> Int -> a
 {-# INLINE (!) #-}
 (!) = (G.!)
 
--- | \(O(1)\) Safe indexing.
+-- | \(\mathcal{O}(1)\) Safe indexing.
 (!?) :: Vector a -> Int -> Maybe a
 {-# INLINE (!?) #-}
 (!?) = (G.!?)
 
--- | \(O(1)\) First element.
+-- | \(\mathcal{O}(1)\) First element.
 head :: Vector a -> a
 {-# INLINE head #-}
 head = G.head
 
--- | \(O(1)\) Last element.
+-- | \(\mathcal{O}(1)\) Last element.
 last :: Vector a -> a
 {-# INLINE last #-}
 last = G.last
 
--- | \(O(1)\) Unsafe indexing without bounds checking.
+-- | \(\mathcal{O}(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Vector a -> Int -> a
 {-# INLINE unsafeIndex #-}
 unsafeIndex = G.unsafeIndex
 
--- | \(O(1)\) First element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Vector a -> a
 {-# INLINE unsafeHead #-}
 unsafeHead = G.unsafeHead
 
--- | \(O(1)\) Last element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Vector a -> a
 {-# INLINE unsafeLast #-}
 unsafeLast = G.unsafeLast
@@ -524,7 +524,7 @@ unsafeLast = G.unsafeLast
 -- Monadic indexing
 -- ----------------
 
--- | \(O(1)\) Indexing in a monad.
+-- | \(\mathcal{O}(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -546,31 +546,31 @@ indexM :: Monad m => Vector a -> Int -> m a
 {-# INLINE indexM #-}
 indexM = G.indexM
 
--- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: Monad m => Vector a -> m a
 {-# INLINE headM #-}
 headM = G.headM
 
--- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: Monad m => Vector a -> m a
 {-# INLINE lastM #-}
 lastM = G.lastM
 
--- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: Monad m => Vector a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
 unsafeIndexM = G.unsafeIndexM
 
--- | \(O(1)\) First element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: Monad m => Vector a -> m a
 {-# INLINE unsafeHeadM #-}
 unsafeHeadM = G.unsafeHeadM
 
--- | \(O(1)\) Last element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: Monad m => Vector a -> m a
 {-# INLINE unsafeLastM #-}
@@ -579,7 +579,7 @@ unsafeLastM = G.unsafeLastM
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: Int   -- ^ @i@ starting index
                  -> Int   -- ^ @n@ length
@@ -588,31 +588,31 @@ slice :: Int   -- ^ @i@ starting index
 {-# INLINE slice #-}
 slice = G.slice
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Vector a -> Vector a
 {-# INLINE init #-}
 init = G.init
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Vector a -> Vector a
 {-# INLINE tail #-}
 tail = G.tail
 
--- | \(O(1)\) Yield at the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield at the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Int -> Vector a -> Vector a
 {-# INLINE take #-}
 take = G.take
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Int -> Vector a -> Vector a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -622,7 +622,7 @@ splitAt :: Int -> Vector a -> (Vector a, Vector a)
 {-# INLINE splitAt #-}
 splitAt = G.splitAt
 
--- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -630,7 +630,7 @@ uncons :: Vector a -> Maybe (a, Vector a)
 {-# INLINE uncons #-}
 uncons = G.uncons
 
--- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -638,7 +638,7 @@ unsnoc :: Vector a -> Maybe (Vector a, a)
 {-# INLINE unsnoc #-}
 unsnoc = G.unsnoc
 
--- | \(O(1)\) Yield a slice of the vector without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Int   -- ^ @i@ starting index
                        -> Int   -- ^ @n@ length
@@ -647,25 +647,25 @@ unsafeSlice :: Int   -- ^ @i@ starting index
 {-# INLINE unsafeSlice #-}
 unsafeSlice = G.unsafeSlice
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Vector a -> Vector a
 {-# INLINE unsafeInit #-}
 unsafeInit = G.unsafeInit
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Vector a -> Vector a
 {-# INLINE unsafeTail #-}
 unsafeTail = G.unsafeTail
 
--- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Int -> Vector a -> Vector a
 {-# INLINE unsafeTake #-}
 unsafeTake = G.unsafeTake
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Int -> Vector a -> Vector a
 {-# INLINE unsafeDrop #-}
@@ -674,28 +674,28 @@ unsafeDrop = G.unsafeDrop
 -- Initialisation
 -- --------------
 
--- | \(O(1)\) The empty vector.
+-- | \(\mathcal{O}(1)\) The empty vector.
 empty :: Vector a
 {-# INLINE empty #-}
 empty = G.empty
 
--- | \(O(1)\) A vector with exactly one element.
+-- | \(\mathcal{O}(1)\) A vector with exactly one element.
 singleton :: a -> Vector a
 {-# INLINE singleton #-}
 singleton = G.singleton
 
--- | \(O(n)\) A vector of the given length with the same value in each position.
+-- | \(\mathcal{O}(n)\) A vector of the given length with the same value in each position.
 replicate :: Int -> a -> Vector a
 {-# INLINE replicate #-}
 replicate = G.replicate
 
--- | \(O(n)\) Construct a vector of the given length by applying the function to
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Int -> (Int -> a) -> Vector a
 {-# INLINE generate #-}
 generate = G.generate
 
--- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -717,7 +717,7 @@ iterateN = G.iterateN
 -- Unfolding
 -- ---------
 
--- | \(O(n)\) Construct a vector by repeatedly applying the generator function
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -727,7 +727,7 @@ unfoldr :: (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldr #-}
 unfoldr = G.unfoldr
 
--- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -736,7 +736,7 @@ unfoldrN :: Int -> (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldrN #-}
 unfoldrN = G.unfoldrN
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -747,7 +747,7 @@ unfoldrExactN  :: Int -> (b -> (a, b)) -> b -> Vector a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = G.unfoldrExactN
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -755,7 +755,7 @@ unfoldrM :: (Monad m) => (b -> m (Maybe (a, b))) -> b -> m (Vector a)
 {-# INLINE unfoldrM #-}
 unfoldrM = G.unfoldrM
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -763,7 +763,7 @@ unfoldrNM :: (Monad m) => Int -> (b -> m (Maybe (a, b))) -> b -> m (Vector a)
 {-# INLINE unfoldrNM #-}
 unfoldrNM = G.unfoldrNM
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -772,7 +772,7 @@ unfoldrExactNM :: (Monad m) => Int -> (b -> m (a, b)) -> b -> m (Vector a)
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM = G.unfoldrExactNM
 
--- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -780,7 +780,7 @@ constructN :: Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
 constructN = G.constructN
 
--- | \(O(n)\) Construct a vector with @n@ elements from right to left by
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -792,7 +792,7 @@ constructrN = G.constructrN
 -- Enumeration
 -- -----------
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -800,7 +800,7 @@ enumFromN :: Num a => a -> Int -> Vector a
 {-# INLINE enumFromN #-}
 enumFromN = G.enumFromN
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -808,7 +808,7 @@ enumFromStepN :: Num a => a -> a -> Int -> Vector a
 {-# INLINE enumFromStepN #-}
 enumFromStepN = G.enumFromStepN
 
--- | \(O(n)\) Enumerate values from @x@ to @y@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -816,7 +816,7 @@ enumFromTo :: Enum a => a -> a -> Vector a
 {-# INLINE enumFromTo #-}
 enumFromTo = G.enumFromTo
 
--- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -827,23 +827,23 @@ enumFromThenTo = G.enumFromThenTo
 -- Concatenation
 -- -------------
 
--- | \(O(n)\) Prepend an element.
+-- | \(\mathcal{O}(n)\) Prepend an element.
 cons :: a -> Vector a -> Vector a
 {-# INLINE cons #-}
 cons = G.cons
 
--- | \(O(n)\) Append an element.
+-- | \(\mathcal{O}(n)\) Append an element.
 snoc :: Vector a -> a -> Vector a
 {-# INLINE snoc #-}
 snoc = G.snoc
 
 infixr 5 ++
--- | \(O(m+n)\) Concatenate two vectors.
+-- | \(\mathcal{O}(m+n)\) Concatenate two vectors.
 (++) :: Vector a -> Vector a -> Vector a
 {-# INLINE (++) #-}
 (++) = (G.++)
 
--- | \(O(n)\) Concatenate all vectors in the list.
+-- | \(\mathcal{O}(n)\) Concatenate all vectors in the list.
 concat :: [Vector a] -> Vector a
 {-# INLINE concat #-}
 concat = G.concat
@@ -851,19 +851,19 @@ concat = G.concat
 -- Monadic initialisation
 -- ----------------------
 
--- | \(O(n)\) Execute the monadic action the given number of times and store the
+-- | \(\mathcal{O}(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: Monad m => Int -> m a -> m (Vector a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | \(O(n)\) Construct a vector of the given length by applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: Monad m => Int -> (Int -> m a) -> m (Vector a)
 {-# INLINE generateM #-}
 generateM = G.generateM
 
--- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -894,7 +894,7 @@ createT p = G.createT p
 -- Restricting memory usage
 -- ------------------------
 
--- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
+-- | \(\mathcal{O}(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -911,7 +911,7 @@ force = G.force
 -- Bulk updates
 -- ------------
 
--- | \(O(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -922,7 +922,7 @@ force = G.force
 {-# INLINE (//) #-}
 (//) = (G.//)
 
--- | \(O(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > update <5,9,2,7> <(2,1),(0,3),(2,8)> = <3,9,8,7>
@@ -933,7 +933,7 @@ update :: Vector a        -- ^ initial vector (of length @m@)
 {-# INLINE update #-}
 update = G.update
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -970,7 +970,7 @@ unsafeUpdate_ = G.unsafeUpdate_
 -- Accumulations
 -- -------------
 
--- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -985,7 +985,7 @@ accum :: (a -> b -> a) -- ^ accumulating function @f@
 {-# INLINE accum #-}
 accum = G.accum
 
--- | \(O(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
 -- element @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -1000,7 +1000,7 @@ accumulate :: (a -> b -> a)  -- ^ accumulating function @f@
 {-# INLINE accumulate #-}
 accumulate = G.accumulate
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -1040,12 +1040,12 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- Permutations
 -- ------------
 
--- | \(O(n)\) Reverse a vector.
+-- | \(\mathcal{O}(n)\) Reverse a vector.
 reverse :: Vector a -> Vector a
 {-# INLINE reverse #-}
 reverse = G.reverse
 
--- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
+-- | \(\mathcal{O}(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -1076,7 +1076,7 @@ modify p = G.modify p
 -- Indexing
 -- --------
 
--- | \(O(n)\) Pair each element in a vector with its index.
+-- | \(\mathcal{O}(n)\) Pair each element in a vector with its index.
 indexed :: Vector a -> Vector (Int,a)
 {-# INLINE indexed #-}
 indexed = G.indexed
@@ -1084,12 +1084,12 @@ indexed = G.indexed
 -- Mapping
 -- -------
 
--- | \(O(n)\) Map a function over a vector.
+-- | \(\mathcal{O}(n)\) Map a function over a vector.
 map :: (a -> b) -> Vector a -> Vector b
 {-# INLINE map #-}
 map = G.map
 
--- | \(O(n)\) Apply a function to every element of a vector and its index.
+-- | \(\mathcal{O}(n)\) Apply a function to every element of a vector and its index.
 imap :: (Int -> a -> b) -> Vector a -> Vector b
 {-# INLINE imap #-}
 imap = G.imap
@@ -1102,43 +1102,43 @@ concatMap = G.concatMap
 -- Monadic mapping
 -- ---------------
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: Monad m => (a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE mapM #-}
 mapM = G.mapM
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 imapM :: Monad m => (Int -> a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE imapM #-}
 imapM = G.imapM
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: Monad m => (a -> m b) -> Vector a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 imapM_ :: Monad m => (Int -> a -> m b) -> Vector a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: Monad m => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: Monad m => Vector a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -1146,7 +1146,7 @@ iforM :: Monad m => Vector a -> (Int -> a -> m b) -> m (Vector b)
 {-# INLINE iforM #-}
 iforM = G.iforM
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -1157,7 +1157,7 @@ iforM_ = G.iforM_
 -- Zipping
 -- -------
 
--- | \(O(\min(m,n))\) Zip two vectors with the given function.
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE zipWith #-}
 zipWith = G.zipWith
@@ -1184,7 +1184,7 @@ zipWith6 :: (a -> b -> c -> d -> e -> f -> g)
 {-# INLINE zipWith6 #-}
 zipWith6 = G.zipWith6
 
--- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Int -> a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE izipWith #-}
@@ -1213,7 +1213,7 @@ izipWith6 :: (Int -> a -> b -> c -> d -> e -> f -> g)
 {-# INLINE izipWith6 #-}
 izipWith6 = G.izipWith6
 
--- | \(O(\min(m,n))\) Zip two vectors.
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors.
 zip :: Vector a -> Vector b -> Vector (a, b)
 {-# INLINE zip #-}
 zip = G.zip
@@ -1241,7 +1241,7 @@ zip6 = G.zip6
 -- Unzipping
 -- ---------
 
--- | \(O(\min(m,n))\) Unzip a vector of pairs.
+-- | \(\mathcal{O}(\min(m,n))\) Unzip a vector of pairs.
 unzip :: Vector (a, b) -> (Vector a, Vector b)
 {-# INLINE unzip #-}
 unzip = G.unzip
@@ -1267,25 +1267,25 @@ unzip6 = G.unzip6
 -- Monadic zipping
 -- ---------------
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: Monad m => (a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE zipWithM #-}
 zipWithM = G.zipWithM
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 izipWithM :: Monad m => (Int -> a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE izipWithM #-}
 izipWithM = G.izipWithM
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: Monad m => (a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ = G.zipWithM_
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 izipWithM_ :: Monad m => (Int -> a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE izipWithM_ #-}
@@ -1294,18 +1294,18 @@ izipWithM_ = G.izipWithM_
 -- Filtering
 -- ---------
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate.
 filter :: (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(\mathcal{O}(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1319,29 +1319,29 @@ uniq :: (Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq
 
--- | \(O(n)\) Map the values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
--- | \(O(n)\) Map the indices/values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
 
--- | \(O(n)\) Return a Vector of all the 'Just' values.
+-- | \(\mathcal{O}(n)\) Return a Vector of all the 'Just' values.
 --
 -- @since 0.12.2.0
 catMaybes :: Vector (Maybe a) -> Vector a
 {-# INLINE catMaybes #-}
 catMaybes = mapMaybe id
 
--- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: Monad m => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1349,7 +1349,7 @@ mapMaybeM :: Monad m => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
 {-# INLINE mapMaybeM #-}
 mapMaybeM = G.mapMaybeM
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1357,14 +1357,14 @@ imapMaybeM :: Monad m => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
 {-# INLINE imapMaybeM #-}
 imapMaybeM = G.imapMaybeM
 
--- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
+-- | \(\mathcal{O}(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: (a -> Bool) -> Vector a -> Vector a
 {-# INLINE takeWhile #-}
 takeWhile = G.takeWhile
 
--- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
+-- | \(\mathcal{O}(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
@@ -1373,7 +1373,7 @@ dropWhile = G.dropWhile
 -- Parititioning
 -- -------------
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1381,7 +1381,7 @@ partition :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE partition #-}
 partition = G.partition
 
--- | \(O(n)\) Split the vector into two parts, the first one containing the
+-- | \(\mathcal{O}(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1390,7 +1390,7 @@ partitionWith :: (a -> Either b c) -> Vector a -> (Vector b, Vector c)
 {-# INLINE partitionWith #-}
 partitionWith = G.partitionWith
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1398,19 +1398,19 @@ unstablePartition :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE unstablePartition #-}
 unstablePartition = G.unstablePartition
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE span #-}
 span = G.span
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that do not
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE break #-}
 break = G.break
 
--- | \(O(n)\) Split a vector into a list of slices, using a predicate function.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices, using a predicate function.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1430,7 +1430,7 @@ groupBy :: (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
 
--- | \(O(n)\) Split a vector into a list of slices of the input vector.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices of the input vector.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1454,43 +1454,43 @@ group = G.groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | \(O(n)\) Check if the vector contains an element.
+-- | \(\mathcal{O}(n)\) Check if the vector contains an element.
 elem :: Eq a => a -> Vector a -> Bool
 {-# INLINE elem #-}
 elem = G.elem
 
 infix 4 `notElem`
--- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
+-- | \(\mathcal{O}(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: Eq a => a -> Vector a -> Bool
 {-# INLINE notElem #-}
 notElem = G.notElem
 
--- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(\mathcal{O}(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: (a -> Bool) -> Vector a -> Maybe a
 {-# INLINE find #-}
 find = G.find
 
--- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
 
--- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
+-- | \(\mathcal{O}(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: (a -> Bool) -> Vector a -> Vector Int
 {-# INLINE findIndices #-}
 findIndices = G.findIndices
 
--- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: Eq a => a -> Vector a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex = G.elemIndex
 
--- | \(O(n)\) Yield the indices of all occurrences of the given element in
+-- | \(\mathcal{O}(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: Eq a => a -> Vector a -> Vector Int
 {-# INLINE elemIndices #-}
@@ -1499,69 +1499,69 @@ elemIndices = G.elemIndices
 -- Folding
 -- -------
 
--- | \(O(n)\) Left fold.
+-- | \(\mathcal{O}(n)\) Left fold.
 foldl :: (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | \(O(n)\) Left fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors.
 foldl1 :: (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1 #-}
 foldl1 = G.foldl1
 
--- | \(O(n)\) Left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator.
 foldl' :: (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1' #-}
 foldl1' = G.foldl1'
 
--- | \(O(n)\) Right fold.
+-- | \(\mathcal{O}(n)\) Right fold.
 foldr :: (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | \(O(n)\) Right fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors.
 foldr1 :: (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1 #-}
 foldr1 = G.foldr1
 
--- | \(O(n)\) Right fold with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold with a strict accumulator.
 foldr' :: (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1' #-}
 foldr1' = G.foldr1'
 
--- | \(O(n)\) Left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | \(O(n)\) Right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | \(O(n)\) Right fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | \(O(n)\) Map each element of the structure to a monoid and combine
+-- | \(\mathcal{O}(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type class. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1572,7 +1572,7 @@ foldMap :: (Monoid m) => (a -> m) -> Vector a -> m
 {-# INLINE foldMap #-}
 foldMap = G.foldMap
 
--- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(\mathcal{O}(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1586,7 +1586,7 @@ foldMap' = G.foldMap'
 -- Specialised folds
 -- -----------------
 
--- | \(O(n)\) Check if all elements satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1601,7 +1601,7 @@ all :: (a -> Bool) -> Vector a -> Bool
 {-# INLINE all #-}
 all = G.all
 
--- | \(O(n)\) Check if any element satisfies the predicate.
+-- | \(\mathcal{O}(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1616,7 +1616,7 @@ any :: (a -> Bool) -> Vector a -> Bool
 {-# INLINE any #-}
 any = G.any
 
--- | \(O(n)\) Check if all elements are 'True'.
+-- | \(\mathcal{O}(n)\) Check if all elements are 'True'.
 --
 -- ==== __Examples__
 --
@@ -1629,7 +1629,7 @@ and :: Vector Bool -> Bool
 {-# INLINE and #-}
 and = G.and
 
--- | \(O(n)\) Check if any element is 'True'.
+-- | \(\mathcal{O}(n)\) Check if any element is 'True'.
 --
 -- ==== __Examples__
 --
@@ -1642,7 +1642,7 @@ or :: Vector Bool -> Bool
 {-# INLINE or #-}
 or = G.or
 
--- | \(O(n)\) Compute the sum of the elements.
+-- | \(\mathcal{O}(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1655,7 +1655,7 @@ sum :: Num a => Vector a -> a
 {-# INLINE sum #-}
 sum = G.sum
 
--- | \(O(n)\) Compute the product of the elements.
+-- | \(\mathcal{O}(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1668,7 +1668,7 @@ product :: Num a => Vector a -> a
 {-# INLINE product #-}
 product = G.product
 
--- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1685,7 +1685,7 @@ maximum :: Ord a => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | \(O(n)\) Yield the maximum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1702,7 +1702,7 @@ maximumBy :: (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
--- | \(O(n)\) Yield the maximum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1717,7 +1717,7 @@ maximumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
 
--- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1734,7 +1734,7 @@ minimum :: Ord a => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | \(O(n)\) Yield the minimum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 --
@@ -1750,7 +1750,7 @@ minimumBy :: (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
 
--- | \(O(n)\) Yield the minimum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1765,13 +1765,13 @@ minimumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
 
--- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: Ord a => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | \(O(n)\) Yield the index of the maximum element of the vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
@@ -1787,13 +1787,13 @@ maxIndexBy :: (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
 
--- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: Ord a => Vector a -> Int
 {-# INLINE minIndex #-}
 minIndex = G.minIndex
 
--- | \(O(n)\) Yield the index of the minimum element of the vector according to
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1811,65 +1811,65 @@ minIndexBy = G.minIndexBy
 -- Monadic folds
 -- -------------
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 foldM :: Monad m => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 ifoldM :: Monad m => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | \(O(n)\) Monadic fold over non-empty vectors.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors.
 fold1M :: Monad m => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M #-}
 fold1M = G.fold1M
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 foldM' :: Monad m => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldM' :: Monad m => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: Monad m => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M' #-}
 fold1M' = G.fold1M'
 
--- | \(O(n)\) Monadic fold that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result.
 foldM_ :: Monad m => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ = G.foldM_
 
--- | \(O(n)\) Monadic fold that discards the result using a function applied to
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 ifoldM_ :: Monad m => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM_ #-}
 ifoldM_ = G.ifoldM_
 
--- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: Monad m => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ = G.fold1M_
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: Monad m => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ = G.foldM'_
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 ifoldM'_ :: Monad m => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ = G.ifoldM'_
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: Monad m => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -1891,7 +1891,7 @@ sequence_ = G.sequence_
 -- Scans
 -- -----
 
--- | \(O(n)\) Left-to-right prescan.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -1906,12 +1906,12 @@ prescanl :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl #-}
 prescanl = G.prescanl
 
--- | \(O(n)\) Left-to-right prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl' #-}
 prescanl' = G.prescanl'
 
--- | \(O(n)\) Left-to-right postscan.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -1926,12 +1926,12 @@ postscanl :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl #-}
 postscanl = G.postscanl
 
--- | \(O(n)\) Left-to-right postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl' #-}
 postscanl' = G.postscanl'
 
--- | \(O(n)\) Left-to-right scan.
+-- | \(\mathcal{O}(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -1946,26 +1946,26 @@ scanl :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl #-}
 scanl = G.scanl
 
--- | \(O(n)\) Left-to-right scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl' #-}
 scanl' = G.scanl'
 
--- | \(O(n)\) Left-to-right scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector with its index.
 --
 -- @since 0.12.0.0
 iscanl :: (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl #-}
 iscanl = G.iscanl
 
--- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector (strictly) with its index.
 --
 -- @since 0.12.0.0
 iscanl' :: (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl' #-}
 iscanl' = G.iscanl'
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -1986,7 +1986,7 @@ scanl1 :: (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1 #-}
 scanl1 = G.scanl1
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -2003,7 +2003,7 @@ scanl1' :: (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1' #-}
 scanl1' = G.scanl1'
 
--- | \(O(n)\) Right-to-left prescan.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -2012,46 +2012,46 @@ prescanr :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr #-}
 prescanr = G.prescanr
 
--- | \(O(n)\) Right-to-left prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr' #-}
 prescanr' = G.prescanr'
 
--- | \(O(n)\) Right-to-left postscan.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan.
 postscanr :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr #-}
 postscanr = G.postscanr
 
--- | \(O(n)\) Right-to-left postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr' #-}
 postscanr' = G.postscanr'
 
--- | \(O(n)\) Right-to-left scan.
+-- | \(\mathcal{O}(n)\) Right-to-left scan.
 scanr :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr #-}
 scanr = G.scanr
 
--- | \(O(n)\) Right-to-left scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr' #-}
 scanr' = G.scanr'
 
--- | \(O(n)\) Right-to-left scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector with its index.
 --
 -- @since 0.12.0.0
 iscanr :: (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr #-}
 iscanr = G.iscanr
 
--- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector (strictly) with its index.
 --
 -- @since 0.12.0.0
 iscanr' :: (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr' #-}
 iscanr' = G.iscanr'
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -2068,7 +2068,7 @@ scanr1 :: (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanr1 #-}
 scanr1 = G.scanr1
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -2089,7 +2089,7 @@ scanr1' = G.scanr1'
 -- Comparisons
 -- ------------------------
 
--- | \(O(n)\) Check if two vectors are equal using the supplied equality
+-- | \(\mathcal{O}(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 --
 -- @since 0.12.2.0
@@ -2097,7 +2097,7 @@ eqBy :: (a -> b -> Bool) -> Vector a -> Vector b -> Bool
 {-# INLINE eqBy #-}
 eqBy = G.eqBy
 
--- | \(O(n)\) Compare two vectors using the supplied comparison function for
+-- | \(\mathcal{O}(n)\) Compare two vectors using the supplied comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == compare
@@ -2109,17 +2109,17 @@ cmpBy = G.cmpBy
 -- Conversions - Lists
 -- ------------------------
 
--- | \(O(n)\) Convert a vector to a list.
+-- | \(\mathcal{O}(n)\) Convert a vector to a list.
 toList :: Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | \(O(n)\) Convert a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert a list to a vector.
 fromList :: [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -2131,14 +2131,14 @@ fromListN = G.fromListN
 -- Conversions - Arrays
 -- -----------------------------
 
--- | \(O(1)\) Convert an array to a vector.
+-- | \(\mathcal{O}(1)\) Convert an array to a vector.
 --
 -- @since 0.12.2.0
 fromArray :: Array a -> Vector a
 {-# INLINE fromArray #-}
 fromArray x = Vector 0 (sizeofArray x) x
 
--- | \(O(n)\) Convert a vector to an array.
+-- | \(\mathcal{O}(n)\) Convert a vector to an array.
 --
 -- @since 0.12.2.0
 toArray :: Vector a -> Array a
@@ -2150,18 +2150,18 @@ toArray (Vector offset size arr)
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
+-- | \(\mathcal{O}(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze :: PrimMonad m => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = G.unsafeFreeze
 
--- | \(O(n)\) Yield an immutable copy of the mutable vector.
+-- | \(\mathcal{O}(n)\) Yield an immutable copy of the mutable vector.
 freeze :: PrimMonad m => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE freeze #-}
 freeze = G.freeze
 
--- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
+-- | \(\mathcal{O}(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -2190,18 +2190,18 @@ unsafeThaw :: PrimMonad m => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw
 
--- | \(O(n)\) Yield a mutable copy of an immutable vector.
+-- | \(\mathcal{O}(n)\) Yield a mutable copy of an immutable vector.
 thaw :: PrimMonad m => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE thaw #-}
 thaw = G.thaw
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy :: PrimMonad m => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy = G.unsafeCopy
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: PrimMonad m => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}

--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -458,7 +458,7 @@ instance Foldable.Foldable Vector where
 instance Traversable.Traversable Vector where
   {-# INLINE traverse #-}
   traverse f xs =
-      -- Get the length of the vector in /O(1)/ time
+      -- Get the length of the vector in \(O(1)\) time
       let !n = G.length xs
       -- Use fromListN to be more efficient in construction of resulting vector
       -- Also behaves better with compact regions, preventing runtime exceptions
@@ -473,12 +473,12 @@ instance Traversable.Traversable Vector where
 -- Length information
 -- ------------------
 
--- | /O(1)/ Yield the length of the vector.
+-- | \(O(1)\) Yield the length of the vector.
 length :: Vector a -> Int
 {-# INLINE length #-}
 length = G.length
 
--- | /O(1)/ Test whether a vector is empty.
+-- | \(O(1)\) Test whether a vector is empty.
 null :: Vector a -> Bool
 {-# INLINE null #-}
 null = G.null
@@ -496,27 +496,27 @@ null = G.null
 {-# INLINE (!?) #-}
 (!?) = (G.!?)
 
--- | /O(1)/ First element.
+-- | \(O(1)\) First element.
 head :: Vector a -> a
 {-# INLINE head #-}
 head = G.head
 
--- | /O(1)/ Last element.
+-- | \(O(1)\) Last element.
 last :: Vector a -> a
 {-# INLINE last #-}
 last = G.last
 
--- | /O(1)/ Unsafe indexing without bounds checking.
+-- | \(O(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Vector a -> Int -> a
 {-# INLINE unsafeIndex #-}
 unsafeIndex = G.unsafeIndex
 
--- | /O(1)/ First element, without checking if the vector is empty.
+-- | \(O(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Vector a -> a
 {-# INLINE unsafeHead #-}
 unsafeHead = G.unsafeHead
 
--- | /O(1)/ Last element, without checking if the vector is empty.
+-- | \(O(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Vector a -> a
 {-# INLINE unsafeLast #-}
 unsafeLast = G.unsafeLast
@@ -524,7 +524,7 @@ unsafeLast = G.unsafeLast
 -- Monadic indexing
 -- ----------------
 
--- | /O(1)/ Indexing in a monad.
+-- | \(O(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -546,31 +546,31 @@ indexM :: Monad m => Vector a -> Int -> m a
 {-# INLINE indexM #-}
 indexM = G.indexM
 
--- | /O(1)/ First element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: Monad m => Vector a -> m a
 {-# INLINE headM #-}
 headM = G.headM
 
--- | /O(1)/ Last element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: Monad m => Vector a -> m a
 {-# INLINE lastM #-}
 lastM = G.lastM
 
--- | /O(1)/ Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: Monad m => Vector a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
 unsafeIndexM = G.unsafeIndexM
 
--- | /O(1)/ First element in a monad, without checking for empty vectors.
+-- | \(O(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: Monad m => Vector a -> m a
 {-# INLINE unsafeHeadM #-}
 unsafeHeadM = G.unsafeHeadM
 
--- | /O(1)/ Last element in a monad, without checking for empty vectors.
+-- | \(O(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: Monad m => Vector a -> m a
 {-# INLINE unsafeLastM #-}
@@ -579,7 +579,7 @@ unsafeLastM = G.unsafeLastM
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | /O(1)/ Yield a slice of the vector without copying it. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: Int   -- ^ @i@ starting index
                  -> Int   -- ^ @n@ length
@@ -588,31 +588,31 @@ slice :: Int   -- ^ @i@ starting index
 {-# INLINE slice #-}
 slice = G.slice
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Vector a -> Vector a
 {-# INLINE init #-}
 init = G.init
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Vector a -> Vector a
 {-# INLINE tail #-}
 tail = G.tail
 
--- | /O(1)/ Yield at the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield at the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Int -> Vector a -> Vector a
 {-# INLINE take #-}
 take = G.take
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Int -> Vector a -> Vector a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | /O(1)/ Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -622,7 +622,7 @@ splitAt :: Int -> Vector a -> (Vector a, Vector a)
 {-# INLINE splitAt #-}
 splitAt = G.splitAt
 
--- | /O(1)/ Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -630,7 +630,7 @@ uncons :: Vector a -> Maybe (a, Vector a)
 {-# INLINE uncons #-}
 uncons = G.uncons
 
--- | /O(1)/ Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -638,7 +638,7 @@ unsnoc :: Vector a -> Maybe (Vector a, a)
 {-# INLINE unsnoc #-}
 unsnoc = G.unsnoc
 
--- | /O(1)/ Yield a slice of the vector without copying. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Int   -- ^ @i@ starting index
                        -> Int   -- ^ @n@ length
@@ -647,25 +647,25 @@ unsafeSlice :: Int   -- ^ @i@ starting index
 {-# INLINE unsafeSlice #-}
 unsafeSlice = G.unsafeSlice
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Vector a -> Vector a
 {-# INLINE unsafeInit #-}
 unsafeInit = G.unsafeInit
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Vector a -> Vector a
 {-# INLINE unsafeTail #-}
 unsafeTail = G.unsafeTail
 
--- | /O(1)/ Yield the first @n@ elements without copying. The vector must
+-- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Int -> Vector a -> Vector a
 {-# INLINE unsafeTake #-}
 unsafeTake = G.unsafeTake
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Int -> Vector a -> Vector a
 {-# INLINE unsafeDrop #-}
@@ -674,28 +674,28 @@ unsafeDrop = G.unsafeDrop
 -- Initialisation
 -- --------------
 
--- | /O(1)/ The empty vector.
+-- | \(O(1)\) The empty vector.
 empty :: Vector a
 {-# INLINE empty #-}
 empty = G.empty
 
--- | /O(1)/ A vector with exactly one element.
+-- | \(O(1)\) A vector with exactly one element.
 singleton :: a -> Vector a
 {-# INLINE singleton #-}
 singleton = G.singleton
 
--- | /O(n)/ A vector of the given length with the same value in each position.
+-- | \(O(n)\) A vector of the given length with the same value in each position.
 replicate :: Int -> a -> Vector a
 {-# INLINE replicate #-}
 replicate = G.replicate
 
--- | /O(n)/ Construct a vector of the given length by applying the function to
+-- | \(O(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Int -> (Int -> a) -> Vector a
 {-# INLINE generate #-}
 generate = G.generate
 
--- | /O(n)/ Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -717,7 +717,7 @@ iterateN = G.iterateN
 -- Unfolding
 -- ---------
 
--- | /O(n)/ Construct a vector by repeatedly applying the generator function
+-- | \(O(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -727,7 +727,7 @@ unfoldr :: (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldr #-}
 unfoldr = G.unfoldr
 
--- | /O(n)/ Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -736,7 +736,7 @@ unfoldrN :: Int -> (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldrN #-}
 unfoldrN = G.unfoldrN
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -747,7 +747,7 @@ unfoldrExactN  :: Int -> (b -> (a, b)) -> b -> Vector a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = G.unfoldrExactN
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -755,7 +755,7 @@ unfoldrM :: (Monad m) => (b -> m (Maybe (a, b))) -> b -> m (Vector a)
 {-# INLINE unfoldrM #-}
 unfoldrM = G.unfoldrM
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -763,7 +763,7 @@ unfoldrNM :: (Monad m) => Int -> (b -> m (Maybe (a, b))) -> b -> m (Vector a)
 {-# INLINE unfoldrNM #-}
 unfoldrNM = G.unfoldrNM
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -772,7 +772,7 @@ unfoldrExactNM :: (Monad m) => Int -> (b -> m (a, b)) -> b -> m (Vector a)
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM = G.unfoldrExactNM
 
--- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
+-- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -780,7 +780,7 @@ constructN :: Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
 constructN = G.constructN
 
--- | /O(n)/ Construct a vector with @n@ elements from right to left by
+-- | \(O(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -792,7 +792,7 @@ constructrN = G.constructrN
 -- Enumeration
 -- -----------
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -800,7 +800,7 @@ enumFromN :: Num a => a -> Int -> Vector a
 {-# INLINE enumFromN #-}
 enumFromN = G.enumFromN
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -808,7 +808,7 @@ enumFromStepN :: Num a => a -> a -> Int -> Vector a
 {-# INLINE enumFromStepN #-}
 enumFromStepN = G.enumFromStepN
 
--- | /O(n)/ Enumerate values from @x@ to @y@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -816,7 +816,7 @@ enumFromTo :: Enum a => a -> a -> Vector a
 {-# INLINE enumFromTo #-}
 enumFromTo = G.enumFromTo
 
--- | /O(n)/ Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -827,23 +827,23 @@ enumFromThenTo = G.enumFromThenTo
 -- Concatenation
 -- -------------
 
--- | /O(n)/ Prepend an element.
+-- | \(O(n)\) Prepend an element.
 cons :: a -> Vector a -> Vector a
 {-# INLINE cons #-}
 cons = G.cons
 
--- | /O(n)/ Append an element.
+-- | \(O(n)\) Append an element.
 snoc :: Vector a -> a -> Vector a
 {-# INLINE snoc #-}
 snoc = G.snoc
 
 infixr 5 ++
--- | /O(m+n)/ Concatenate two vectors.
+-- | \(O(m+n)\) Concatenate two vectors.
 (++) :: Vector a -> Vector a -> Vector a
 {-# INLINE (++) #-}
 (++) = (G.++)
 
--- | /O(n)/ Concatenate all vectors in the list.
+-- | \(O(n)\) Concatenate all vectors in the list.
 concat :: [Vector a] -> Vector a
 {-# INLINE concat #-}
 concat = G.concat
@@ -851,19 +851,19 @@ concat = G.concat
 -- Monadic initialisation
 -- ----------------------
 
--- | /O(n)/ Execute the monadic action the given number of times and store the
+-- | \(O(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: Monad m => Int -> m a -> m (Vector a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | /O(n)/ Construct a vector of the given length by applying the monadic
+-- | \(O(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: Monad m => Int -> (Int -> m a) -> m (Vector a)
 {-# INLINE generateM #-}
 generateM = G.generateM
 
--- | /O(n)/ Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -894,7 +894,7 @@ createT p = G.createT p
 -- Restricting memory usage
 -- ------------------------
 
--- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
+-- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -911,7 +911,7 @@ force = G.force
 -- Bulk updates
 -- ------------
 
--- | /O(m+n)/ For each pair @(i,a)@ from the list of index/value pairs,
+-- | \(O(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -922,7 +922,7 @@ force = G.force
 {-# INLINE (//) #-}
 (//) = (G.//)
 
--- | /O(m+n)/ For each pair @(i,a)@ from the vector of index/value pairs,
+-- | \(O(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > update <5,9,2,7> <(2,1),(0,3),(2,8)> = <3,9,8,7>
@@ -933,7 +933,7 @@ update :: Vector a        -- ^ initial vector (of length @m@)
 {-# INLINE update #-}
 update = G.update
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -970,7 +970,7 @@ unsafeUpdate_ = G.unsafeUpdate_
 -- Accumulations
 -- -------------
 
--- | /O(m+n)/ For each pair @(i,b)@ from the list, replace the vector element
+-- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -985,7 +985,7 @@ accum :: (a -> b -> a) -- ^ accumulating function @f@
 {-# INLINE accum #-}
 accum = G.accum
 
--- | /O(m+n)/ For each pair @(i,b)@ from the vector of pairs, replace the vector
+-- | \(O(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
 -- element @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -1000,7 +1000,7 @@ accumulate :: (a -> b -> a)  -- ^ accumulating function @f@
 {-# INLINE accumulate #-}
 accumulate = G.accumulate
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -1040,12 +1040,12 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- Permutations
 -- ------------
 
--- | /O(n)/ Reverse a vector.
+-- | \(O(n)\) Reverse a vector.
 reverse :: Vector a -> Vector a
 {-# INLINE reverse #-}
 reverse = G.reverse
 
--- | /O(n)/ Yield the vector obtained by replacing each element @i@ of the
+-- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -1076,7 +1076,7 @@ modify p = G.modify p
 -- Indexing
 -- --------
 
--- | /O(n)/ Pair each element in a vector with its index.
+-- | \(O(n)\) Pair each element in a vector with its index.
 indexed :: Vector a -> Vector (Int,a)
 {-# INLINE indexed #-}
 indexed = G.indexed
@@ -1084,12 +1084,12 @@ indexed = G.indexed
 -- Mapping
 -- -------
 
--- | /O(n)/ Map a function over a vector.
+-- | \(O(n)\) Map a function over a vector.
 map :: (a -> b) -> Vector a -> Vector b
 {-# INLINE map #-}
 map = G.map
 
--- | /O(n)/ Apply a function to every element of a vector and its index.
+-- | \(O(n)\) Apply a function to every element of a vector and its index.
 imap :: (Int -> a -> b) -> Vector a -> Vector b
 {-# INLINE imap #-}
 imap = G.imap
@@ -1102,43 +1102,43 @@ concatMap = G.concatMap
 -- Monadic mapping
 -- ---------------
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: Monad m => (a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE mapM #-}
 mapM = G.mapM
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 imapM :: Monad m => (Int -> a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE imapM #-}
 imapM = G.imapM
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: Monad m => (a -> m b) -> Vector a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 imapM_ :: Monad m => (Int -> a -> m b) -> Vector a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: Monad m => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: Monad m => Vector a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -1146,7 +1146,7 @@ iforM :: Monad m => Vector a -> (Int -> a -> m b) -> m (Vector b)
 {-# INLINE iforM #-}
 iforM = G.iforM
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -1157,7 +1157,7 @@ iforM_ = G.iforM_
 -- Zipping
 -- -------
 
--- | /O(min(m,n))/ Zip two vectors with the given function.
+-- | \(O(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE zipWith #-}
 zipWith = G.zipWith
@@ -1184,7 +1184,7 @@ zipWith6 :: (a -> b -> c -> d -> e -> f -> g)
 {-# INLINE zipWith6 #-}
 zipWith6 = G.zipWith6
 
--- | /O(min(m,n))/ Zip two vectors with a function that also takes the
+-- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Int -> a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE izipWith #-}
@@ -1213,7 +1213,7 @@ izipWith6 :: (Int -> a -> b -> c -> d -> e -> f -> g)
 {-# INLINE izipWith6 #-}
 izipWith6 = G.izipWith6
 
--- | /O(min(m,n))/ Zip two vectors.
+-- | \(O(\min(m,n))\) Zip two vectors.
 zip :: Vector a -> Vector b -> Vector (a, b)
 {-# INLINE zip #-}
 zip = G.zip
@@ -1241,7 +1241,7 @@ zip6 = G.zip6
 -- Unzipping
 -- ---------
 
--- | /O(min(m,n))/ Unzip a vector of pairs.
+-- | \(O(\min(m,n))\) Unzip a vector of pairs.
 unzip :: Vector (a, b) -> (Vector a, Vector b)
 {-# INLINE unzip #-}
 unzip = G.unzip
@@ -1267,25 +1267,25 @@ unzip6 = G.unzip6
 -- Monadic zipping
 -- ---------------
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and yield a
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: Monad m => (a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE zipWithM #-}
 zipWithM = G.zipWithM
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 izipWithM :: Monad m => (Int -> a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE izipWithM #-}
 izipWithM = G.izipWithM
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and ignore the
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: Monad m => (a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ = G.zipWithM_
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 izipWithM_ :: Monad m => (Int -> a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE izipWithM_ #-}
@@ -1294,18 +1294,18 @@ izipWithM_ = G.izipWithM_
 -- Filtering
 -- ---------
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate.
 filter :: (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate which is applied to
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | /O(n)/ Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1319,29 +1319,29 @@ uniq :: (Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq
 
--- | /O(n)/ Map the values and collect the 'Just' results.
+-- | \(O(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
--- | /O(n)/ Map the indices/values and collect the 'Just' results.
+-- | \(O(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
 
--- | /O(n)/ Return a Vector of all the 'Just' values.
+-- | \(O(n)\) Return a Vector of all the 'Just' values.
 --
 -- @since 0.12.2.0
 catMaybes :: Vector (Maybe a) -> Vector a
 {-# INLINE catMaybes #-}
 catMaybes = mapMaybe id
 
--- | /O(n)/ Drop all elements that do not satisfy the monadic predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: Monad m => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
 
--- | /O(n)/ Apply the monadic function to each element of the vector and
+-- | \(O(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1349,7 +1349,7 @@ mapMaybeM :: Monad m => (a -> m (Maybe b)) -> Vector a -> m (Vector b)
 {-# INLINE mapMaybeM #-}
 mapMaybeM = G.mapMaybeM
 
--- | /O(n)/ Apply the monadic function to each element of the vector and its index.
+-- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1357,14 +1357,14 @@ imapMaybeM :: Monad m => (Int -> a -> m (Maybe b)) -> Vector a -> m (Vector b)
 {-# INLINE imapMaybeM #-}
 imapMaybeM = G.imapMaybeM
 
--- | /O(n)/ Yield the longest prefix of elements satisfying the predicate.
+-- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: (a -> Bool) -> Vector a -> Vector a
 {-# INLINE takeWhile #-}
 takeWhile = G.takeWhile
 
--- | /O(n)/ Drop the longest prefix of elements that satisfy the predicate
+-- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
@@ -1373,7 +1373,7 @@ dropWhile = G.dropWhile
 -- Parititioning
 -- -------------
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1381,7 +1381,7 @@ partition :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE partition #-}
 partition = G.partition
 
--- | /O(n)/ Split the vector into two parts, the first one containing the
+-- | \(O(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1390,7 +1390,7 @@ partitionWith :: (a -> Either b c) -> Vector a -> (Vector b, Vector c)
 {-# INLINE partitionWith #-}
 partitionWith = G.partitionWith
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1398,19 +1398,19 @@ unstablePartition :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE unstablePartition #-}
 unstablePartition = G.unstablePartition
 
--- | /O(n)/ Split the vector into the longest prefix of elements that satisfy
+-- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE span #-}
 span = G.span
 
--- | /O(n)/ Split the vector into the longest prefix of elements that do not
+-- | \(O(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE break #-}
 break = G.break
 
--- | /O(n)/ Split a vector into a list of slices, using a predicate function.
+-- | \(O(n)\) Split a vector into a list of slices, using a predicate function.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1430,7 +1430,7 @@ groupBy :: (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
 
--- | /O(n)/ Split a vector into a list of slices of the input vector.
+-- | \(O(n)\) Split a vector into a list of slices of the input vector.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1454,43 +1454,43 @@ group = G.groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | /O(n)/ Check if the vector contains an element.
+-- | \(O(n)\) Check if the vector contains an element.
 elem :: Eq a => a -> Vector a -> Bool
 {-# INLINE elem #-}
 elem = G.elem
 
 infix 4 `notElem`
--- | /O(n)/ Check if the vector does not contain an element (inverse of 'elem').
+-- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: Eq a => a -> Vector a -> Bool
 {-# INLINE notElem #-}
 notElem = G.notElem
 
--- | /O(n)/ Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: (a -> Bool) -> Vector a -> Maybe a
 {-# INLINE find #-}
 find = G.find
 
--- | /O(n)/ Yield 'Just' the index of the first element matching the predicate
+-- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
 
--- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
+-- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: (a -> Bool) -> Vector a -> Vector Int
 {-# INLINE findIndices #-}
 findIndices = G.findIndices
 
--- | /O(n)/ Yield 'Just' the index of the first occurrence of the given element or
+-- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: Eq a => a -> Vector a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex = G.elemIndex
 
--- | /O(n)/ Yield the indices of all occurrences of the given element in
+-- | \(O(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: Eq a => a -> Vector a -> Vector Int
 {-# INLINE elemIndices #-}
@@ -1499,69 +1499,69 @@ elemIndices = G.elemIndices
 -- Folding
 -- -------
 
--- | /O(n)/ Left fold.
+-- | \(O(n)\) Left fold.
 foldl :: (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | /O(n)/ Left fold on non-empty vectors.
+-- | \(O(n)\) Left fold on non-empty vectors.
 foldl1 :: (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1 #-}
 foldl1 = G.foldl1
 
--- | /O(n)/ Left fold with strict accumulator.
+-- | \(O(n)\) Left fold with strict accumulator.
 foldl' :: (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | /O(n)/ Left fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1' #-}
 foldl1' = G.foldl1'
 
--- | /O(n)/ Right fold.
+-- | \(O(n)\) Right fold.
 foldr :: (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | /O(n)/ Right fold on non-empty vectors.
+-- | \(O(n)\) Right fold on non-empty vectors.
 foldr1 :: (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1 #-}
 foldr1 = G.foldr1
 
--- | /O(n)/ Right fold with a strict accumulator.
+-- | \(O(n)\) Right fold with a strict accumulator.
 foldr' :: (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | /O(n)/ Right fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1' #-}
 foldr1' = G.foldr1'
 
--- | /O(n)/ Left fold using a function applied to each element and its index.
+-- | \(O(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | /O(n)/ Left fold with strict accumulator using a function applied to each element
+-- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | /O(n)/ Right fold using a function applied to each element and its index.
+-- | \(O(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | /O(n)/ Right fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | /O(n)/ Map each element of the structure to a monoid and combine
+-- | \(O(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type class. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1572,7 +1572,7 @@ foldMap :: (Monoid m) => (a -> m) -> Vector a -> m
 {-# INLINE foldMap #-}
 foldMap = G.foldMap
 
--- | /O(n)/ Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1586,7 +1586,7 @@ foldMap' = G.foldMap'
 -- Specialised folds
 -- -----------------
 
--- | /O(n)/ Check if all elements satisfy the predicate.
+-- | \(O(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1601,7 +1601,7 @@ all :: (a -> Bool) -> Vector a -> Bool
 {-# INLINE all #-}
 all = G.all
 
--- | /O(n)/ Check if any element satisfies the predicate.
+-- | \(O(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1616,7 +1616,7 @@ any :: (a -> Bool) -> Vector a -> Bool
 {-# INLINE any #-}
 any = G.any
 
--- | /O(n)/ Check if all elements are 'True'.
+-- | \(O(n)\) Check if all elements are 'True'.
 --
 -- ==== __Examples__
 --
@@ -1629,7 +1629,7 @@ and :: Vector Bool -> Bool
 {-# INLINE and #-}
 and = G.and
 
--- | /O(n)/ Check if any element is 'True'.
+-- | \(O(n)\) Check if any element is 'True'.
 --
 -- ==== __Examples__
 --
@@ -1642,7 +1642,7 @@ or :: Vector Bool -> Bool
 {-# INLINE or #-}
 or = G.or
 
--- | /O(n)/ Compute the sum of the elements.
+-- | \(O(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1655,7 +1655,7 @@ sum :: Num a => Vector a -> a
 {-# INLINE sum #-}
 sum = G.sum
 
--- | /O(n)/ Compute the product of the elements.
+-- | \(O(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1668,7 +1668,7 @@ product :: Num a => Vector a -> a
 {-# INLINE product #-}
 product = G.product
 
--- | /O(n)/ Yield the maximum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1685,7 +1685,7 @@ maximum :: Ord a => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | /O(n)/ Yield the maximum element of the vector according to the
+-- | \(O(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1702,7 +1702,7 @@ maximumBy :: (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
--- | /O(n)/ Yield the maximum element of the vector by comparing the results
+-- | \(O(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1717,7 +1717,7 @@ maximumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
 
--- | /O(n)/ Yield the minimum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1734,7 +1734,7 @@ minimum :: Ord a => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | /O(n)/ Yield the minimum element of the vector according to the
+-- | \(O(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 --
@@ -1750,7 +1750,7 @@ minimumBy :: (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
 
--- | /O(n)/ Yield the minimum element of the vector by comparing the results
+-- | \(O(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1765,13 +1765,13 @@ minimumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
 
--- | /O(n)/ Yield the index of the maximum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: Ord a => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | /O(n)/ Yield the index of the maximum element of the vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
@@ -1787,13 +1787,13 @@ maxIndexBy :: (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
 
--- | /O(n)/ Yield the index of the minimum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: Ord a => Vector a -> Int
 {-# INLINE minIndex #-}
 minIndex = G.minIndex
 
--- | /O(n)/ Yield the index of the minimum element of the vector according to
+-- | \(O(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1811,65 +1811,65 @@ minIndexBy = G.minIndexBy
 -- Monadic folds
 -- -------------
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 foldM :: Monad m => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 ifoldM :: Monad m => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | /O(n)/ Monadic fold over non-empty vectors.
+-- | \(O(n)\) Monadic fold over non-empty vectors.
 fold1M :: Monad m => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M #-}
 fold1M = G.fold1M
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 foldM' :: Monad m => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldM' :: Monad m => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator.
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: Monad m => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M' #-}
 fold1M' = G.fold1M'
 
--- | /O(n)/ Monadic fold that discards the result.
+-- | \(O(n)\) Monadic fold that discards the result.
 foldM_ :: Monad m => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ = G.foldM_
 
--- | /O(n)/ Monadic fold that discards the result using a function applied to
+-- | \(O(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 ifoldM_ :: Monad m => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM_ #-}
 ifoldM_ = G.ifoldM_
 
--- | /O(n)/ Monadic fold over non-empty vectors that discards the result.
+-- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: Monad m => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ = G.fold1M_
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result.
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: Monad m => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ = G.foldM'_
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 ifoldM'_ :: Monad m => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ = G.ifoldM'_
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: Monad m => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -1891,7 +1891,7 @@ sequence_ = G.sequence_
 -- Scans
 -- -----
 
--- | /O(n)/ Left-to-right prescan.
+-- | \(O(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -1906,12 +1906,12 @@ prescanl :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl #-}
 prescanl = G.prescanl
 
--- | /O(n)/ Left-to-right prescan with strict accumulator.
+-- | \(O(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl' #-}
 prescanl' = G.prescanl'
 
--- | /O(n)/ Left-to-right postscan.
+-- | \(O(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -1926,12 +1926,12 @@ postscanl :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl #-}
 postscanl = G.postscanl
 
--- | /O(n)/ Left-to-right postscan with strict accumulator.
+-- | \(O(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl' #-}
 postscanl' = G.postscanl'
 
--- | /O(n)/ Left-to-right scan.
+-- | \(O(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -1946,26 +1946,26 @@ scanl :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl #-}
 scanl = G.scanl
 
--- | /O(n)/ Left-to-right scan with strict accumulator.
+-- | \(O(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl' #-}
 scanl' = G.scanl'
 
--- | /O(n)/ Left-to-right scan over a vector with its index.
+-- | \(O(n)\) Left-to-right scan over a vector with its index.
 --
 -- @since 0.12.0.0
 iscanl :: (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl #-}
 iscanl = G.iscanl
 
--- | /O(n)/ Left-to-right scan over a vector (strictly) with its index.
+-- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
 --
 -- @since 0.12.0.0
 iscanl' :: (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl' #-}
 iscanl' = G.iscanl'
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -1986,7 +1986,7 @@ scanl1 :: (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1 #-}
 scanl1 = G.scanl1
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -2003,7 +2003,7 @@ scanl1' :: (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1' #-}
 scanl1' = G.scanl1'
 
--- | /O(n)/ Right-to-left prescan.
+-- | \(O(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -2012,46 +2012,46 @@ prescanr :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr #-}
 prescanr = G.prescanr
 
--- | /O(n)/ Right-to-left prescan with strict accumulator.
+-- | \(O(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr' #-}
 prescanr' = G.prescanr'
 
--- | /O(n)/ Right-to-left postscan.
+-- | \(O(n)\) Right-to-left postscan.
 postscanr :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr #-}
 postscanr = G.postscanr
 
--- | /O(n)/ Right-to-left postscan with strict accumulator.
+-- | \(O(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr' #-}
 postscanr' = G.postscanr'
 
--- | /O(n)/ Right-to-left scan.
+-- | \(O(n)\) Right-to-left scan.
 scanr :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr #-}
 scanr = G.scanr
 
--- | /O(n)/ Right-to-left scan with strict accumulator.
+-- | \(O(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr' #-}
 scanr' = G.scanr'
 
--- | /O(n)/ Right-to-left scan over a vector with its index.
+-- | \(O(n)\) Right-to-left scan over a vector with its index.
 --
 -- @since 0.12.0.0
 iscanr :: (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr #-}
 iscanr = G.iscanr
 
--- | /O(n)/ Right-to-left scan over a vector (strictly) with its index.
+-- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
 --
 -- @since 0.12.0.0
 iscanr' :: (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr' #-}
 iscanr' = G.iscanr'
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector.
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -2068,7 +2068,7 @@ scanr1 :: (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanr1 #-}
 scanr1 = G.scanr1
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector with a strict
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -2089,7 +2089,7 @@ scanr1' = G.scanr1'
 -- Comparisons
 -- ------------------------
 
--- | /O(n)/ Check if two vectors are equal using the supplied equality
+-- | \(O(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 --
 -- @since 0.12.2.0
@@ -2097,7 +2097,7 @@ eqBy :: (a -> b -> Bool) -> Vector a -> Vector b -> Bool
 {-# INLINE eqBy #-}
 eqBy = G.eqBy
 
--- | /O(n)/ Compare two vectors using the supplied comparison function for
+-- | \(O(n)\) Compare two vectors using the supplied comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == compare
@@ -2109,17 +2109,17 @@ cmpBy = G.cmpBy
 -- Conversions - Lists
 -- ------------------------
 
--- | /O(n)/ Convert a vector to a list.
+-- | \(O(n)\) Convert a vector to a list.
 toList :: Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | /O(n)/ Convert a list to a vector.
+-- | \(O(n)\) Convert a list to a vector.
 fromList :: [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -2131,14 +2131,14 @@ fromListN = G.fromListN
 -- Conversions - Arrays
 -- -----------------------------
 
--- | /O(1)/ Convert an array to a vector.
+-- | \(O(1)\) Convert an array to a vector.
 --
 -- @since 0.12.2.0
 fromArray :: Array a -> Vector a
 {-# INLINE fromArray #-}
 fromArray x = Vector 0 (sizeofArray x) x
 
--- | /O(n)/ Convert a vector to an array.
+-- | \(O(n)\) Convert a vector to an array.
 --
 -- @since 0.12.2.0
 toArray :: Vector a -> Array a
@@ -2150,18 +2150,18 @@ toArray (Vector offset size arr)
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | /O(1)/ Unsafely convert a mutable vector to an immutable one without
+-- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze :: PrimMonad m => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = G.unsafeFreeze
 
--- | /O(n)/ Yield an immutable copy of the mutable vector.
+-- | \(O(n)\) Yield an immutable copy of the mutable vector.
 freeze :: PrimMonad m => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE freeze #-}
 freeze = G.freeze
 
--- | /O(1)/ Unsafely convert an immutable vector to a mutable one
+-- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -2190,18 +2190,18 @@ unsafeThaw :: PrimMonad m => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw
 
--- | /O(n)/ Yield a mutable copy of an immutable vector.
+-- | \(O(n)\) Yield a mutable copy of an immutable vector.
 thaw :: PrimMonad m => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE thaw #-}
 thaw = G.thaw
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy :: PrimMonad m => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy = G.unsafeCopy
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: PrimMonad m => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}

--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -486,12 +486,12 @@ null = G.null
 -- Indexing
 -- --------
 
--- | O(1) Indexing.
+-- | \(O(1)\) Indexing.
 (!) :: Vector a -> Int -> a
 {-# INLINE (!) #-}
 (!) = (G.!)
 
--- | O(1) Safe indexing.
+-- | \(O(1)\) Safe indexing.
 (!?) :: Vector a -> Int -> Maybe a
 {-# INLINE (!?) #-}
 (!?) = (G.!?)

--- a/vector/src/Data/Vector/Fusion/Bundle.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle.hs
@@ -435,7 +435,7 @@ unfoldrExactN :: Int -> (s -> (a, s)) -> s -> Bundle v a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = M.unfoldrExactN
 
--- | /O(n)/ Apply function \(\max(n - 1, 0)\) times to an initial value, producing a pure
+-- | \(O(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value, producing a pure
 -- bundle of exact length \(\max(n, 0)\). Zeroth element will contain the initial value.
 iterateN :: Int -> (a -> a) -> a -> Bundle v a
 {-# INLINE iterateN #-}
@@ -549,7 +549,7 @@ filterM :: Monad m => (a -> m Bool) -> Bundle v a -> M.Bundle m v a
 {-# INLINE filterM #-}
 filterM f = M.filterM f . lift
 
--- | /O(n)/ Apply monadic function to each element of a bundle and
+-- | \(O(n)\) Apply monadic function to each element of a bundle and
 -- discard elements returning Nothing.
 --
 -- @since 0.12.2.0

--- a/vector/src/Data/Vector/Fusion/Bundle.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle.hs
@@ -435,7 +435,7 @@ unfoldrExactN :: Int -> (s -> (a, s)) -> s -> Bundle v a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = M.unfoldrExactN
 
--- | \(O(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value, producing a pure
+-- | \(\mathcal{O}(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value, producing a pure
 -- bundle of exact length \(\max(n, 0)\). Zeroth element will contain the initial value.
 iterateN :: Int -> (a -> a) -> a -> Bundle v a
 {-# INLINE iterateN #-}
@@ -549,7 +549,7 @@ filterM :: Monad m => (a -> m Bool) -> Bundle v a -> M.Bundle m v a
 {-# INLINE filterM #-}
 filterM f = M.filterM f . lift
 
--- | \(O(n)\) Apply monadic function to each element of a bundle and
+-- | \(\mathcal{O}(n)\) Apply monadic function to each element of a bundle and
 -- discard elements returning Nothing.
 --
 -- @since 0.12.2.0

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -680,14 +680,14 @@ unfoldrExactNM :: Monad m => Int -> (s -> m (a, s)) -> s -> Bundle m u a
 {-# INLINE_FUSED unfoldrExactNM #-}
 unfoldrExactNM n f s = fromStream (S.unfoldrExactNM n f s) (Max (delay_inline max n 0))
 
--- | \(O(n)\) Apply monadic function \(\max(n - 1, 0)\) times to an initial value, producing
+-- | \(\mathcal{O}(n)\) Apply monadic function \(\max(n - 1, 0)\) times to an initial value, producing
 -- a monadic bundle of exact length \(\max(n, 0)\). Zeroth element will contain the initial
 -- value.
 iterateNM :: Monad m => Int -> (a -> m a) -> a -> Bundle m u a
 {-# INLINE_FUSED iterateNM #-}
 iterateNM n f x0 = fromStream (S.iterateNM n f x0) (Exact (delay_inline max n 0))
 
--- | \(O(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value, producing a
+-- | \(\mathcal{O}(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value, producing a
 -- monadic bundle of exact length \(\max(n, 0)\). Zeroth element will contain the initial
 -- value.
 iterateN :: Monad m => Int -> (a -> a) -> a -> Bundle m u a

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -680,14 +680,14 @@ unfoldrExactNM :: Monad m => Int -> (s -> m (a, s)) -> s -> Bundle m u a
 {-# INLINE_FUSED unfoldrExactNM #-}
 unfoldrExactNM n f s = fromStream (S.unfoldrExactNM n f s) (Max (delay_inline max n 0))
 
--- | /O(n)/ Apply monadic function \(\max(n - 1, 0)\) times to an initial value, producing
+-- | \(O(n)\) Apply monadic function \(\max(n - 1, 0)\) times to an initial value, producing
 -- a monadic bundle of exact length \(\max(n, 0)\). Zeroth element will contain the initial
 -- value.
 iterateNM :: Monad m => Int -> (a -> m a) -> a -> Bundle m u a
 {-# INLINE_FUSED iterateNM #-}
 iterateNM n f x0 = fromStream (S.iterateNM n f x0) (Exact (delay_inline max n 0))
 
--- | /O(n)/ Apply function \(\max(n - 1, 0)\) times to an initial value, producing a
+-- | \(O(n)\) Apply function \(\max(n - 1, 0)\) times to an initial value, producing a
 -- monadic bundle of exact length \(\max(n, 0)\). Zeroth element will contain the initial
 -- value.
 iterateN :: Monad m => Int -> (a -> a) -> a -> Bundle m u a

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -236,13 +236,13 @@ null = Bundle.null . stream
 -- --------
 
 infixl 9 !
--- | O(1) Indexing.
+-- | \(O(1)\) Indexing.
 (!) :: (HasCallStack, Vector v a) => v a -> Int -> a
 {-# INLINE_FUSED (!) #-}
 (!) v i = checkIndex Bounds i (length v) $ unBox (basicUnsafeIndexM v i)
 
 infixl 9 !?
--- | O(1) Safe indexing.
+-- | \(O(1)\) Safe indexing.
 (!?) :: Vector v a => v a -> Int -> Maybe a
 {-# INLINE_FUSED (!?) #-}
 -- Use basicUnsafeIndexM @Box to perform the indexing eagerly.

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -222,12 +222,12 @@ import qualified Data.Traversable as T (Traversable(mapM))
 -- Length information
 -- ------------------
 
--- | \(O(1)\) Yield the length of the vector.
+-- | \(\mathcal{O}(1)\) Yield the length of the vector.
 length :: Vector v a => v a -> Int
 {-# INLINE length #-}
 length = Bundle.length . stream
 
--- | \(O(1)\) Test whether a vector is empty.
+-- | \(\mathcal{O}(1)\) Test whether a vector is empty.
 null :: Vector v a => v a -> Bool
 {-# INLINE null #-}
 null = Bundle.null . stream
@@ -236,13 +236,13 @@ null = Bundle.null . stream
 -- --------
 
 infixl 9 !
--- | \(O(1)\) Indexing.
+-- | \(\mathcal{O}(1)\) Indexing.
 (!) :: (HasCallStack, Vector v a) => v a -> Int -> a
 {-# INLINE_FUSED (!) #-}
 (!) v i = checkIndex Bounds i (length v) $ unBox (basicUnsafeIndexM v i)
 
 infixl 9 !?
--- | \(O(1)\) Safe indexing.
+-- | \(\mathcal{O}(1)\) Safe indexing.
 (!?) :: Vector v a => v a -> Int -> Maybe a
 {-# INLINE_FUSED (!?) #-}
 -- Use basicUnsafeIndexM @Box to perform the indexing eagerly.
@@ -250,27 +250,27 @@ v !? i | i `inRange` length v = case basicUnsafeIndexM v i of Box a -> Just a
        | otherwise            = Nothing
 
 
--- | \(O(1)\) First element.
+-- | \(\mathcal{O}(1)\) First element.
 head :: Vector v a => v a -> a
 {-# INLINE_FUSED head #-}
 head v = v ! 0
 
--- | \(O(1)\) Last element.
+-- | \(\mathcal{O}(1)\) Last element.
 last :: Vector v a => v a -> a
 {-# INLINE_FUSED last #-}
 last v = v ! (length v - 1)
 
--- | \(O(1)\) Unsafe indexing without bounds checking.
+-- | \(\mathcal{O}(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Vector v a => v a -> Int -> a
 {-# INLINE_FUSED unsafeIndex #-}
 unsafeIndex v i = checkIndex Unsafe i (length v) $ unBox (basicUnsafeIndexM v i)
 
--- | \(O(1)\) First element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Vector v a => v a -> a
 {-# INLINE_FUSED unsafeHead #-}
 unsafeHead v = unsafeIndex v 0
 
--- | \(O(1)\) Last element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Vector v a => v a -> a
 {-# INLINE_FUSED unsafeLast #-}
 unsafeLast v = unsafeIndex v (length v - 1)
@@ -303,7 +303,7 @@ unsafeLast v = unsafeIndex v (length v - 1)
 -- Monadic indexing
 -- ----------------
 
--- | \(O(1)\) Indexing in a monad.
+-- | \(\mathcal{O}(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -325,19 +325,19 @@ indexM :: (HasCallStack, Vector v a, Monad m) => v a -> Int -> m a
 {-# INLINE_FUSED indexM #-}
 indexM v i = checkIndex Bounds i (length v) $ liftBox $ basicUnsafeIndexM v i
 
--- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (Vector v a, Monad m) => v a -> m a
 {-# INLINE_FUSED headM #-}
 headM v = indexM v 0
 
--- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (Vector v a, Monad m) => v a -> m a
 {-# INLINE_FUSED lastM #-}
 lastM v = indexM v (length v - 1)
 
--- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (Vector v a, Monad m) => v a -> Int -> m a
 {-# INLINE_FUSED unsafeIndexM #-}
@@ -345,13 +345,13 @@ unsafeIndexM v i = checkIndex Unsafe i (length v)
                  $ liftBox
                  $ basicUnsafeIndexM v i
 
--- | \(O(1)\) First element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (Vector v a, Monad m) => v a -> m a
 {-# INLINE_FUSED unsafeHeadM #-}
 unsafeHeadM v = unsafeIndexM v 0
 
--- | \(O(1)\) Last element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (Vector v a, Monad m) => v a -> m a
 {-# INLINE_FUSED unsafeLastM #-}
@@ -382,7 +382,7 @@ unsafeLastM v = unsafeIndexM v (length v - 1)
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: (HasCallStack, Vector v a)
       => Int   -- ^ @i@ starting index
@@ -392,26 +392,26 @@ slice :: (HasCallStack, Vector v a)
 {-# INLINE_FUSED slice #-}
 slice i n v = checkSlice Bounds i n (length v) $ basicUnsafeSlice i n v
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Vector v a => v a -> v a
 {-# INLINE_FUSED init #-}
 init v = slice 0 (length v - 1) v
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Vector v a => v a -> v a
 {-# INLINE_FUSED tail #-}
 tail v = slice 1 (length v - 1) v
 
--- | \(O(1)\) Yield the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Vector v a => Int -> v a -> v a
 {-# INLINE_FUSED take #-}
 take n v = unsafeSlice 0 (delay_inline min n' (length v)) v
   where n' = max n 0
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Vector v a => Int -> v a -> v a
 {-# INLINE_FUSED drop #-}
@@ -420,7 +420,7 @@ drop n v = unsafeSlice (delay_inline min n' len)
   where n' = max n 0
         len = length v
 
--- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -436,7 +436,7 @@ splitAt n v = ( unsafeSlice 0 m v
       n'  = max n 0
       len = length v
 
--- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -444,7 +444,7 @@ uncons :: Vector v a => v a -> Maybe (a, v a)
 {-# INLINE_FUSED uncons #-}
 uncons xs = flip (,) (unsafeTail xs) <$> xs !? 0
 
--- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -452,7 +452,7 @@ unsnoc :: Vector v a => v a -> Maybe (v a, a)
 {-# INLINE_FUSED unsnoc #-}
 unsnoc xs = (,) (unsafeInit xs) <$> xs !? (length xs - 1)
 
--- | \(O(1)\) Yield a slice of the vector without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Vector v a => Int   -- ^ @i@ starting index
                           -> Int   -- ^ @n@ length
@@ -461,25 +461,25 @@ unsafeSlice :: Vector v a => Int   -- ^ @i@ starting index
 {-# INLINE_FUSED unsafeSlice #-}
 unsafeSlice i n v = checkSlice Unsafe i n (length v) $ basicUnsafeSlice i n v
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Vector v a => v a -> v a
 {-# INLINE_FUSED unsafeInit #-}
 unsafeInit v = unsafeSlice 0 (length v - 1) v
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Vector v a => v a -> v a
 {-# INLINE_FUSED unsafeTail #-}
 unsafeTail v = unsafeSlice 1 (length v - 1) v
 
--- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Vector v a => Int -> v a -> v a
 {-# INLINE unsafeTake #-}
 unsafeTake n v = unsafeSlice 0 n v
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Vector v a => Int -> v a -> v a
 {-# INLINE unsafeDrop #-}
@@ -518,31 +518,31 @@ unsafeDrop n v = unsafeSlice n (length v - n) v
 -- Initialisation
 -- --------------
 
--- | \(O(1)\) The empty vector.
+-- | \(\mathcal{O}(1)\) The empty vector.
 empty :: Vector v a => v a
 {-# INLINE empty #-}
 empty = unstream Bundle.empty
 
--- | \(O(1)\) A vector with exactly one element.
+-- | \(\mathcal{O}(1)\) A vector with exactly one element.
 singleton :: forall v a. Vector v a => a -> v a
 {-# INLINE singleton #-}
 singleton x = elemseq (undefined :: v a) x
             $ unstream (Bundle.singleton x)
 
--- | \(O(n)\) A vector of the given length with the same value in each position.
+-- | \(\mathcal{O}(n)\) A vector of the given length with the same value in each position.
 replicate :: forall v a. Vector v a => Int -> a -> v a
 {-# INLINE replicate #-}
 replicate n x = elemseq (undefined :: v a) x
               $ unstream
               $ Bundle.replicate n x
 
--- | \(O(n)\) Construct a vector of the given length by applying the function to
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Vector v a => Int -> (Int -> a) -> v a
 {-# INLINE generate #-}
 generate n f = unstream (Bundle.generate n f)
 
--- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -556,7 +556,7 @@ iterateN n f x = unstream (Bundle.iterateN n f x)
 -- Unfolding
 -- ---------
 
--- | \(O(n)\) Construct a vector by repeatedly applying the generator function
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -566,7 +566,7 @@ unfoldr :: Vector v a => (b -> Maybe (a, b)) -> b -> v a
 {-# INLINE unfoldr #-}
 unfoldr f = unstream . Bundle.unfoldr f
 
--- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -575,7 +575,7 @@ unfoldrN  :: Vector v a => Int -> (b -> Maybe (a, b)) -> b -> v a
 {-# INLINE unfoldrN #-}
 unfoldrN n f = unstream . Bundle.unfoldrN n f
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -586,7 +586,7 @@ unfoldrExactN  :: Vector v a => Int -> (b -> (a, b)) -> b -> v a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN n f = unstream . Bundle.unfoldrExactN n f
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -594,7 +594,7 @@ unfoldrM :: (Monad m, Vector v a) => (b -> m (Maybe (a, b))) -> b -> m (v a)
 {-# INLINE unfoldrM #-}
 unfoldrM f = unstreamM . MBundle.unfoldrM f
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -602,7 +602,7 @@ unfoldrNM :: (Monad m, Vector v a) => Int -> (b -> m (Maybe (a, b))) -> b -> m (
 {-# INLINE unfoldrNM #-}
 unfoldrNM n f = unstreamM . MBundle.unfoldrNM n f
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -611,7 +611,7 @@ unfoldrExactNM :: (Monad m, Vector v a) => Int -> (b -> m (a, b)) -> b -> m (v a
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM n f = unstreamM . MBundle.unfoldrExactNM n f
 
--- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -635,7 +635,7 @@ constructN !n f = runST (
                           fill v'' (i+1)
     fill v _ = return v
 
--- | \(O(n)\) Construct a vector with @n@ elements from right to left by
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -664,7 +664,7 @@ constructrN !n f = runST (
 -- Enumeration
 -- -----------
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -672,7 +672,7 @@ enumFromN :: (Vector v a, Num a) => a -> Int -> v a
 {-# INLINE enumFromN #-}
 enumFromN x n = enumFromStepN x 1 n
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -683,7 +683,7 @@ enumFromStepN x y n = elemseq (undefined :: v a) x
                     $ unstream
                     $ Bundle.enumFromStepN  x y n
 
--- | \(O(n)\) Enumerate values from @x@ to @y@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -691,7 +691,7 @@ enumFromTo :: (Vector v a, Enum a) => a -> a -> v a
 {-# INLINE enumFromTo #-}
 enumFromTo x y = unstream (Bundle.enumFromTo x y)
 
--- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -702,7 +702,7 @@ enumFromThenTo x y z = unstream (Bundle.enumFromThenTo x y z)
 -- Concatenation
 -- -------------
 
--- | \(O(n)\) Prepend an element.
+-- | \(\mathcal{O}(n)\) Prepend an element.
 cons :: forall v a. Vector v a => a -> v a -> v a
 {-# INLINE cons #-}
 cons x v = elemseq (undefined :: v a) x
@@ -710,7 +710,7 @@ cons x v = elemseq (undefined :: v a) x
          $ Bundle.cons x
          $ stream v
 
--- | \(O(n)\) Append an element.
+-- | \(\mathcal{O}(n)\) Append an element.
 snoc :: forall v a. Vector v a => v a -> a -> v a
 {-# INLINE snoc #-}
 snoc v x = elemseq (undefined :: v a) x
@@ -718,12 +718,12 @@ snoc v x = elemseq (undefined :: v a) x
          $ Bundle.snoc (stream v) x
 
 infixr 5 ++
--- | \(O(m+n)\) Concatenate two vectors.
+-- | \(\mathcal{O}(m+n)\) Concatenate two vectors.
 (++) :: Vector v a => v a -> v a -> v a
 {-# INLINE (++) #-}
 v ++ w = unstream (stream v Bundle.++ stream w)
 
--- | \(O(n)\) Concatenate all vectors in the list.
+-- | \(\mathcal{O}(n)\) Concatenate all vectors in the list.
 concat :: Vector v a => [v a] -> v a
 {-# INLINE concat #-}
 concat = unstream . Bundle.fromVectors
@@ -744,26 +744,26 @@ concat vs = unstream (Bundle.flatten mk step (Exact n) (Bundle.fromList vs))
            k `seq` (v,0,k)
 -}
 
--- | \(O(n)\) Concatenate all vectors in the non-empty list.
+-- | \(\mathcal{O}(n)\) Concatenate all vectors in the non-empty list.
 concatNE :: Vector v a => NonEmpty.NonEmpty (v a) -> v a
 concatNE = concat . NonEmpty.toList
 
 -- Monadic initialisation
 -- ----------------------
 
--- | \(O(n)\) Execute the monadic action the given number of times and store the
+-- | \(\mathcal{O}(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: (Monad m, Vector v a) => Int -> m a -> m (v a)
 {-# INLINE replicateM #-}
 replicateM n m = unstreamM (MBundle.replicateM n m)
 
--- | \(O(n)\) Construct a vector of the given length by applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: (Monad m, Vector v a) => Int -> (Int -> m a) -> m (v a)
 {-# INLINE generateM #-}
 generateM n f = unstreamM (MBundle.generateM n f)
 
--- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -793,7 +793,7 @@ createT p = runST (p >>= T.mapM unsafeFreeze)
 -- Restricting memory usage
 -- ------------------------
 
--- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
+-- | \(\mathcal{O}(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -812,7 +812,7 @@ force v = new (clone v)
 -- Bulk updates
 -- ------------
 
--- | \(O(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -823,7 +823,7 @@ force v = new (clone v)
 {-# INLINE (//) #-}
 v // us = update_stream v (Bundle.fromList us)
 
--- | \(O(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > update <5,9,2,7> <(2,1),(0,3),(2,8)> = <3,9,8,7>
@@ -835,7 +835,7 @@ update :: (Vector v a, Vector v (Int, a))
 {-# INLINE update #-}
 update v w = update_stream v (stream w)
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -882,7 +882,7 @@ unsafeUpdate_stream = modifyWithBundle M.unsafeUpdate
 -- Accumulations
 -- -------------
 
--- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -898,7 +898,7 @@ accum :: Vector v a
 {-# INLINE accum #-}
 accum f v us = accum_stream f v (Bundle.fromList us)
 
--- | \(O(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
 -- element @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -914,7 +914,7 @@ accumulate :: (Vector v a, Vector v (Int, b))
 {-# INLINE accumulate #-}
 accumulate f v us = accum_stream f v (stream us)
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -968,13 +968,13 @@ unsafeAccum_stream f = modifyWithBundle (M.unsafeAccum f)
 -- Permutations
 -- ------------
 
--- | \(O(n)\) Reverse a vector.
+-- | \(\mathcal{O}(n)\) Reverse a vector.
 reverse :: (Vector v a) => v a -> v a
 {-# INLINE reverse #-}
 -- FIXME: make this fuse better, add support for recycling
 reverse = unstream . streamR
 
--- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
+-- | \(\mathcal{O}(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -1044,7 +1044,7 @@ modifyWithBundle p v s = new (New.modifyWithBundle p (clone v) s)
 -- Indexing
 -- --------
 
--- | \(O(n)\) Pair each element in a vector with its index.
+-- | \(\mathcal{O}(n)\) Pair each element in a vector with its index.
 indexed :: (Vector v a, Vector v (Int,a)) => v a -> v (Int,a)
 {-# INLINE indexed #-}
 indexed = unstream . Bundle.indexed . stream
@@ -1052,12 +1052,12 @@ indexed = unstream . Bundle.indexed . stream
 -- Mapping
 -- -------
 
--- | \(O(n)\) Map a function over a vector.
+-- | \(\mathcal{O}(n)\) Map a function over a vector.
 map :: (Vector v a, Vector v b) => (a -> b) -> v a -> v b
 {-# INLINE map #-}
 map f = unstream . inplace (S.map f) id . stream
 
--- | \(O(n)\) Apply a function to every element of a vector and its index.
+-- | \(\mathcal{O}(n)\) Apply a function to every element of a vector and its index.
 imap :: (Vector v a, Vector v b) => (Int -> a -> b) -> v a -> v b
 {-# INLINE imap #-}
 imap f = unstream . inplace (S.map (uncurry f) . S.indexed) id
@@ -1101,43 +1101,43 @@ concatMap f = unstream
 -- Monadic mapping
 -- ---------------
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: (Monad m, Vector v a, Vector v b) => (a -> m b) -> v a -> m (v b)
 {-# INLINE mapM #-}
 mapM f = unstreamM . Bundle.mapM f . stream
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 imapM :: (Monad m, Vector v a, Vector v b)
       => (Int -> a -> m b) -> v a -> m (v b)
 imapM f = unstreamM . Bundle.mapM (uncurry f) . Bundle.indexed . stream
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: (Monad m, Vector v a) => (a -> m b) -> v a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ f = Bundle.mapM_ f . stream
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 imapM_ :: (Monad m, Vector v a) => (Int -> a -> m b) -> v a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ f = Bundle.mapM_ (uncurry f) . Bundle.indexed . stream
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Vector v a, Vector v b) => v a -> (a -> m b) -> m (v b)
 {-# INLINE forM #-}
 forM as f = mapM f as
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, Vector v a) => v a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ as f = mapM_ f as
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -1145,7 +1145,7 @@ iforM :: (Monad m, Vector v a, Vector v b) => v a -> (Int -> a -> m b) -> m (v b
 {-# INLINE iforM #-}
 iforM as f = imapM f as
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -1156,7 +1156,7 @@ iforM_ as f = imapM_ f as
 -- Zipping
 -- -------
 
--- | \(O(\min(m,n))\) Zip two vectors with the given function.
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (Vector v a, Vector v b, Vector v c)
         => (a -> b -> c) -> v a -> v b -> v c
 {-# INLINE zipWith #-}
@@ -1204,7 +1204,7 @@ zipWith6 f = \as bs cs ds es fs ->
                                 (stream es)
                                 (stream fs))
 
--- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Vector v a, Vector v b, Vector v c)
         => (Int -> a -> b -> c) -> v a -> v b -> v c
@@ -1256,7 +1256,7 @@ izipWith6 f = \as bs cs ds es fs ->
                                                           (stream es)
                                                           (stream fs))
 
--- | \(O(\min(m,n))\) Zip two vectors.
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors.
 zip :: (Vector v a, Vector v b, Vector v (a,b)) => v a -> v b -> v (a, b)
 {-# INLINE zip #-}
 zip = zipWith (,)
@@ -1287,7 +1287,7 @@ zip6 = zipWith6 (,,,,,)
 -- Monadic zipping
 -- ---------------
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: (Monad m, Vector v a, Vector v b, Vector v c)
          => (a -> b -> m c) -> v a -> v b -> m (v c)
@@ -1295,7 +1295,7 @@ zipWithM :: (Monad m, Vector v a, Vector v b, Vector v c)
 {-# INLINE zipWithM #-}
 zipWithM f = \as bs -> unstreamM $ Bundle.zipWithM f (stream as) (stream bs)
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 izipWithM :: (Monad m, Vector v a, Vector v b, Vector v c)
          => (Int -> a -> b -> m c) -> v a -> v b -> m (v c)
@@ -1304,14 +1304,14 @@ izipWithM m as bs = unstreamM . Bundle.zipWithM (uncurry m)
                                 (Bundle.indexed (stream as))
                                 $ stream bs
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: (Monad m, Vector v a, Vector v b)
           => (a -> b -> m c) -> v a -> v b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ f = \as bs -> Bundle.zipWithM_ f (stream as) (stream bs)
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 izipWithM_ :: (Monad m, Vector v a, Vector v b)
           => (Int -> a -> b -> m c) -> v a -> v b -> m ()
@@ -1323,7 +1323,7 @@ izipWithM_ m as bs = Bundle.zipWithM_ (uncurry m)
 -- Unzipping
 -- ---------
 
--- | \(O(\min(m,n))\) Unzip a vector of pairs.
+-- | \(\mathcal{O}(\min(m,n))\) Unzip a vector of pairs.
 unzip :: (Vector v a, Vector v b, Vector v (a,b)) => v (a, b) -> (v a, v b)
 {-# INLINE unzip #-}
 unzip xs = (map fst xs, map snd xs)
@@ -1368,12 +1368,12 @@ unzip6 xs = (map (\(a, _, _, _, _, _) -> a) xs,
 -- Filtering
 -- ---------
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate.
 filter :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE filter #-}
 filter f = unstream . inplace (S.filter f) toMax . stream
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: Vector v a => (Int -> a -> Bool) -> v a -> v a
 {-# INLINE ifilter #-}
@@ -1381,7 +1381,7 @@ ifilter f = unstream
           . inplace (S.map snd . S.filter (uncurry f) . S.indexed) toMax
           . stream
 
--- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(\mathcal{O}(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1395,12 +1395,12 @@ uniq :: (Vector v a, Eq a) => v a -> v a
 {-# INLINE uniq #-}
 uniq = unstream . inplace S.uniq toMax . stream
 
--- | \(O(n)\) Map the values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (Vector v a, Vector v b) => (a -> Maybe b) -> v a -> v b
 {-# INLINE mapMaybe #-}
 mapMaybe f = unstream . inplace (S.mapMaybe f) toMax . stream
 
--- | \(O(n)\) Map the indices/values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Vector v a, Vector v b) => (Int -> a -> Maybe b) -> v a -> v b
 {-# INLINE imapMaybe #-}
 imapMaybe f = unstream
@@ -1408,12 +1408,12 @@ imapMaybe f = unstream
           . stream
 
 
--- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: (Monad m, Vector v a) => (a -> m Bool) -> v a -> m (v a)
 {-# INLINE filterM #-}
 filterM f = unstreamM . Bundle.filterM f . stream
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1421,7 +1421,7 @@ mapMaybeM :: (Monad m, Vector v a, Vector v b) => (a -> m (Maybe b)) -> v a -> m
 {-# INLINE mapMaybeM #-}
 mapMaybeM f = unstreamM . Bundle.mapMaybeM f . stream
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1430,14 +1430,14 @@ imapMaybeM :: (Monad m, Vector v a, Vector v b)
 {-# INLINE imapMaybeM #-}
 imapMaybeM f = unstreamM . Bundle.mapMaybeM (\(i, a) -> f i a) . Bundle.indexed . stream
 
--- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
+-- | \(\mathcal{O}(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE takeWhile #-}
 takeWhile f = unstream . Bundle.takeWhile f . stream
 
--- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
+-- | \(\mathcal{O}(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE_FUSED dropWhile #-}
@@ -1462,7 +1462,7 @@ dropWhile f xs = case findIndex (not . f) xs of
 -- Parititioning
 -- -------------
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1482,7 +1482,7 @@ partition_stream f s = s `seq` runST (
     v2 <- unsafeFreeze mv2
     return (v1,v2))
 
--- | \(O(n)\) Split the vector into two parts, the first one containing the
+-- | \(\mathcal{O}(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1500,7 +1500,7 @@ partition_with_stream f s = s `seq` runST (
     v2 <- unsafeFreeze mv2
     return (v1,v2))
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1538,13 +1538,13 @@ unstablePartition_new f (New.New p) = runST (
 
 -- FIXME: make span and break fusible
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: Vector v a => (a -> Bool) -> v a -> (v a, v a)
 {-# INLINE span #-}
 span f = break (not . f)
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that do not
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: Vector v a => (a -> Bool) -> v a -> (v a, v a)
 {-# INLINE break #-}
@@ -1552,7 +1552,7 @@ break f xs = case findIndex f xs of
                Just i  -> (unsafeSlice 0 i xs, unsafeSlice i (length xs - i) xs)
                Nothing -> (xs, empty)
 
--- | \(O(n)\) Split a vector into a list of slices.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1576,7 +1576,7 @@ groupBy f v =
       Nothing -> [v]
       Just n -> unsafeTake (n + 1) v : groupBy f (unsafeDrop (n + 1) v)
 
--- | \(O(n)\) Split a vector into a list of slices.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1598,30 +1598,30 @@ group = groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | \(O(n)\) Check if the vector contains an element.
+-- | \(\mathcal{O}(n)\) Check if the vector contains an element.
 elem :: (Vector v a, Eq a) => a -> v a -> Bool
 {-# INLINE elem #-}
 elem x = Bundle.elem x . stream
 
 infix 4 `notElem`
--- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
+-- | \(\mathcal{O}(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: (Vector v a, Eq a) => a -> v a -> Bool
 {-# INLINE notElem #-}
 notElem x = Bundle.notElem x . stream
 
--- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(\mathcal{O}(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: Vector v a => (a -> Bool) -> v a -> Maybe a
 {-# INLINE find #-}
 find f = Bundle.find f . stream
 
--- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: Vector v a => (a -> Bool) -> v a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex f = Bundle.findIndex f . stream
 
--- | \(O(n)\) Yield 'Just' the index of the /last/ element matching the predicate
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the /last/ element matching the predicate
 -- or 'Nothing' if no such element exists.
 --
 -- @since 0.12.2.0
@@ -1629,7 +1629,7 @@ findIndexR :: Vector v a => (a -> Bool) -> v a -> Maybe Int
 {-# INLINE findIndexR #-}
 findIndexR f v = fmap (length v - 1 -) . Bundle.findIndex f $ streamR v
 
--- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
+-- | \(\mathcal{O}(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: (Vector v a, Vector v Int) => (a -> Bool) -> v a -> v Int
 {-# INLINE findIndices #-}
@@ -1637,14 +1637,14 @@ findIndices f = unstream
               . inplace (S.map fst . S.filter (f . snd) . S.indexed) toMax
               . stream
 
--- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: (Vector v a, Eq a) => a -> v a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex x = findIndex (x ==)
 
--- | \(O(n)\) Yield the indices of all occurrences of the given element in
+-- | \(\mathcal{O}(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: (Vector v a, Vector v Int, Eq a) => a -> v a -> v Int
 {-# INLINE elemIndices #-}
@@ -1653,70 +1653,70 @@ elemIndices x = findIndices (x ==)
 -- Folding
 -- -------
 
--- | \(O(n)\) Left fold.
+-- | \(\mathcal{O}(n)\) Left fold.
 foldl :: Vector v b => (a -> b -> a) -> a -> v b -> a
 {-# INLINE foldl #-}
 foldl f z = Bundle.foldl f z . stream
 
--- | \(O(n)\) Left fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors.
 foldl1 :: Vector v a => (a -> a -> a) -> v a -> a
 {-# INLINE foldl1 #-}
 foldl1 f = Bundle.foldl1 f . stream
 
--- | \(O(n)\) Left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator.
 foldl' :: Vector v b => (a -> b -> a) -> a -> v b -> a
 {-# INLINE foldl' #-}
 foldl' f z = Bundle.foldl' f z . stream
 
--- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: Vector v a => (a -> a -> a) -> v a -> a
 {-# INLINE foldl1' #-}
 foldl1' f = Bundle.foldl1' f . stream
 
--- | \(O(n)\) Right fold.
+-- | \(\mathcal{O}(n)\) Right fold.
 foldr :: Vector v a => (a -> b -> b) -> b -> v a -> b
 {-# INLINE foldr #-}
 foldr f z = Bundle.foldr f z . stream
 
--- | \(O(n)\) Right fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors.
 foldr1 :: Vector v a => (a -> a -> a) -> v a -> a
 {-# INLINE foldr1 #-}
 foldr1 f = Bundle.foldr1 f . stream
 
--- | \(O(n)\) Right fold with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold with a strict accumulator.
 foldr' :: Vector v a => (a -> b -> b) -> b -> v a -> b
 {-# INLINE foldr' #-}
 foldr' f z = Bundle.foldl' (flip f) z . streamR
 
--- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: Vector v a => (a -> a -> a) -> v a -> a
 {-# INLINE foldr1' #-}
 foldr1' f = Bundle.foldl1' (flip f) . streamR
 
--- | \(O(n)\) Left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: Vector v b => (a -> Int -> b -> a) -> a -> v b -> a
 {-# INLINE ifoldl #-}
 ifoldl f z = Bundle.foldl (uncurry . f) z . Bundle.indexed . stream
 
--- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: Vector v b => (a -> Int -> b -> a) -> a -> v b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' f z = Bundle.foldl' (uncurry . f) z . Bundle.indexed . stream
 
--- | \(O(n)\) Right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: Vector v a => (Int -> a -> b -> b) -> b -> v a -> b
 {-# INLINE ifoldr #-}
 ifoldr f z = Bundle.foldr (uncurry f) z . Bundle.indexed . stream
 
--- | \(O(n)\) Right fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: Vector v a => (Int -> a -> b -> b) -> b -> v a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' f z xs = Bundle.foldl' (flip (uncurry f)) z
                $ Bundle.indexedR (length xs) $ streamR xs
 
--- | \(O(n)\) Map each element of the structure to a monoid and combine
+-- | \(\mathcal{O}(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type cless. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1727,7 +1727,7 @@ foldMap :: (Monoid m, Vector v a) => (a -> m) -> v a -> m
 {-# INLINE foldMap #-}
 foldMap f = foldr (mappend . f) mempty
 
--- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(\mathcal{O}(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1741,7 +1741,7 @@ foldMap' f = foldl' (\acc a -> acc `mappend` f a) mempty
 -- Specialised folds
 -- -----------------
 
--- | \(O(n)\) Check if all elements satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1756,7 +1756,7 @@ all :: Vector v a => (a -> Bool) -> v a -> Bool
 {-# INLINE all #-}
 all f = Bundle.and . Bundle.map f . stream
 
--- | \(O(n)\) Check if any element satisfies the predicate.
+-- | \(\mathcal{O}(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1771,7 +1771,7 @@ any :: Vector v a => (a -> Bool) -> v a -> Bool
 {-# INLINE any #-}
 any f = Bundle.or . Bundle.map f . stream
 
--- | \(O(n)\) Check if all elements are 'True'.
+-- | \(\mathcal{O}(n)\) Check if all elements are 'True'.
 --
 -- ==== __Examples__
 --
@@ -1784,7 +1784,7 @@ and :: Vector v Bool => v Bool -> Bool
 {-# INLINE and #-}
 and = Bundle.and . stream
 
--- | \(O(n)\) Check if any element is 'True'.
+-- | \(\mathcal{O}(n)\) Check if any element is 'True'.
 --
 -- ==== __Examples__
 --
@@ -1797,7 +1797,7 @@ or :: Vector v Bool => v Bool -> Bool
 {-# INLINE or #-}
 or = Bundle.or . stream
 
--- | \(O(n)\) Compute the sum of the elements.
+-- | \(\mathcal{O}(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1810,7 +1810,7 @@ sum :: (Vector v a, Num a) => v a -> a
 {-# INLINE sum #-}
 sum = Bundle.foldl' (+) 0 . stream
 
--- | \(O(n)\) Compute the product of the elements.
+-- | \(\mathcal{O}(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1823,7 +1823,7 @@ product :: (Vector v a, Num a) => v a -> a
 {-# INLINE product #-}
 product = Bundle.foldl' (*) 1 . stream
 
--- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1840,7 +1840,7 @@ maximum :: (Vector v a, Ord a) => v a -> a
 {-# INLINE maximum #-}
 maximum = Bundle.foldl1' max . stream
 
--- | \(O(n)\) Yield the maximum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1862,7 +1862,7 @@ maximumBy cmpr = Bundle.foldl1' maxBy . stream
                   LT -> y
                   _  -> x
 
--- | \(O(n)\) Yield the maximum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1882,7 +1882,7 @@ maximumOn f = fst . Bundle.foldl1' maxBy . Bundle.map (\a -> (a, f a)) . stream
                   LT -> y
                   _  -> x
 
--- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1899,7 +1899,7 @@ minimum :: (Vector v a, Ord a) => v a -> a
 {-# INLINE minimum #-}
 minimum = Bundle.foldl1' min . stream
 
--- | \(O(n)\) Yield the minimum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 --
@@ -1920,7 +1920,7 @@ minimumBy cmpr = Bundle.foldl1' minBy . stream
                   GT -> y
                   _  -> x
 
--- | \(O(n)\) Yield the minimum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1940,13 +1940,13 @@ minimumOn f = fst . Bundle.foldl1' minBy . Bundle.map (\a -> (a, f a)) . stream
                   GT -> y
                   _  -> x
 
--- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (Vector v a, Ord a) => v a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = maxIndexBy compare
 
--- | \(O(n)\) Yield the index of the maximum element of the vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
@@ -1967,13 +1967,13 @@ maxIndexBy cmpr = fst . Bundle.foldl1' imax . Bundle.indexed . stream
                          LT -> (j,y)
                          _  -> (i,x)
 
--- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (Vector v a, Ord a) => v a -> Int
 {-# INLINE minIndex #-}
 minIndex = minIndexBy compare
 
--- | \(O(n)\) Yield the index of the minimum element of the vector according to
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1996,33 +1996,33 @@ minIndexBy cmpr = fst . Bundle.foldl1' imin . Bundle.indexed . stream
 -- Monadic folds
 -- -------------
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 foldM :: (Monad m, Vector v b) => (a -> b -> m a) -> a -> v b -> m a
 {-# INLINE foldM #-}
 foldM m z = Bundle.foldM m z . stream
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 ifoldM :: (Monad m, Vector v b) => (a -> Int -> b -> m a) -> a -> v b -> m a
 {-# INLINE ifoldM #-}
 ifoldM m z = Bundle.foldM (uncurry . m) z . Bundle.indexed . stream
 
--- | \(O(n)\) Monadic fold over non-empty vectors.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors.
 fold1M :: (Monad m, Vector v a) => (a -> a -> m a) -> v a -> m a
 {-# INLINE fold1M #-}
 fold1M m = Bundle.fold1M m . stream
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 foldM' :: (Monad m, Vector v b) => (a -> b -> m a) -> a -> v b -> m a
 {-# INLINE foldM' #-}
 foldM' m z = Bundle.foldM' m z . stream
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldM' :: (Monad m, Vector v b) => (a -> Int -> b -> m a) -> a -> v b -> m a
 {-# INLINE ifoldM' #-}
 ifoldM' m z = Bundle.foldM' (uncurry . m) z . Bundle.indexed . stream
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: (Monad m, Vector v a) => (a -> a -> m a) -> v a -> m a
 {-# INLINE fold1M' #-}
 fold1M' m = Bundle.fold1M' m . stream
@@ -2031,34 +2031,34 @@ discard :: Monad m => m a -> m ()
 {-# INLINE discard #-}
 discard m = m >> return ()
 
--- | \(O(n)\) Monadic fold that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result.
 foldM_ :: (Monad m, Vector v b) => (a -> b -> m a) -> a -> v b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ m z = discard . Bundle.foldM m z . stream
 
--- | \(O(n)\) Monadic fold that discards the result using a function applied to
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 ifoldM_ :: (Monad m, Vector v b) => (a -> Int -> b -> m a) -> a -> v b -> m ()
 {-# INLINE ifoldM_ #-}
 ifoldM_ m z = discard . Bundle.foldM (uncurry . m) z . Bundle.indexed . stream
 
--- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: (Monad m, Vector v a) => (a -> a -> m a) -> v a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ m = discard . Bundle.fold1M m . stream
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: (Monad m, Vector v b) => (a -> b -> m a) -> a -> v b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ m z = discard . Bundle.foldM' m z . stream
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 ifoldM'_ :: (Monad m, Vector v b) => (a -> Int -> b -> m a) -> a -> v b -> m ()
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ m z = discard . Bundle.foldM' (uncurry . m) z . Bundle.indexed . stream
 
--- | \(O(n)\) Monad fold over non-empty vectors with strict accumulator
+-- | \(\mathcal{O}(n)\) Monad fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: (Monad m, Vector v a) => (a -> a -> m a) -> v a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -2080,7 +2080,7 @@ sequence_ = mapM_ id
 -- Scans
 -- -----
 
--- | \(O(n)\) Left-to-right prescan.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -2095,12 +2095,12 @@ prescanl :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE prescanl #-}
 prescanl f z = unstream . inplace (S.prescanl f z) id . stream
 
--- | \(O(n)\) Left-to-right prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE prescanl' #-}
 prescanl' f z = unstream . inplace (S.prescanl' f z) id . stream
 
--- | \(O(n)\) Left-to-right postscan.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -2115,12 +2115,12 @@ postscanl :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE postscanl #-}
 postscanl f z = unstream . inplace (S.postscanl f z) id . stream
 
--- | \(O(n)\) Left-to-right postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE postscanl' #-}
 postscanl' f z = unstream . inplace (S.postscanl' f z) id . stream
 
--- | \(O(n)\) Left-to-right scan.
+-- | \(\mathcal{O}(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -2135,12 +2135,12 @@ scanl :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE scanl #-}
 scanl f z = unstream . Bundle.scanl f z . stream
 
--- | \(O(n)\) Left-to-right scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE scanl' #-}
 scanl' f z = unstream . Bundle.scanl' f z . stream
 
--- | \(O(n)\) Left-to-right scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector with its index.
 iscanl :: (Vector v a, Vector v b) => (Int -> a -> b -> a) -> a -> v b -> v a
 {-# INLINE iscanl #-}
 iscanl f z =
@@ -2148,7 +2148,7 @@ iscanl f z =
   . inplace (S.scanl (\a (i, b) -> f i a b) z . S.indexed) (+1)
   . stream
 
--- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector (strictly) with its index.
 iscanl' :: (Vector v a, Vector v b) => (Int -> a -> b -> a) -> a -> v b -> v a
 {-# INLINE iscanl' #-}
 iscanl' f z =
@@ -2157,7 +2157,7 @@ iscanl' f z =
   . stream
 
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -2178,7 +2178,7 @@ scanl1 :: Vector v a => (a -> a -> a) -> v a -> v a
 {-# INLINE scanl1 #-}
 scanl1 f = unstream . inplace (S.scanl1 f) id . stream
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -2195,7 +2195,7 @@ scanl1' :: Vector v a => (a -> a -> a) -> v a -> v a
 {-# INLINE scanl1' #-}
 scanl1' f = unstream . inplace (S.scanl1' f) id . stream
 
--- | \(O(n)\) Right-to-left prescan.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -2204,32 +2204,32 @@ prescanr :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE prescanr #-}
 prescanr f z = unstreamR . inplace (S.prescanl (flip f) z) id . streamR
 
--- | \(O(n)\) Right-to-left prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE prescanr' #-}
 prescanr' f z = unstreamR . inplace (S.prescanl' (flip f) z) id . streamR
 
--- | \(O(n)\) Right-to-left postscan.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan.
 postscanr :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE postscanr #-}
 postscanr f z = unstreamR . inplace (S.postscanl (flip f) z) id . streamR
 
--- | \(O(n)\) Right-to-left postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE postscanr' #-}
 postscanr' f z = unstreamR . inplace (S.postscanl' (flip f) z) id . streamR
 
--- | \(O(n)\) Right-to-left scan.
+-- | \(\mathcal{O}(n)\) Right-to-left scan.
 scanr :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE scanr #-}
 scanr f z = unstreamR . Bundle.scanl (flip f) z . streamR
 
--- | \(O(n)\) Right-to-left scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE scanr' #-}
 scanr' f z = unstreamR . Bundle.scanl' (flip f) z . streamR
 
--- | \(O(n)\) Right-to-left scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector with its index.
 iscanr :: (Vector v a, Vector v b) => (Int -> a -> b -> b) -> b -> v a -> v b
 {-# INLINE iscanr #-}
 iscanr f z v =
@@ -2239,7 +2239,7 @@ iscanr f z v =
   $ v
  where n = length v
 
--- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector (strictly) with its index.
 iscanr' :: (Vector v a, Vector v b) => (Int -> a -> b -> b) -> b -> v a -> v b
 {-# INLINE iscanr' #-}
 iscanr' f z v =
@@ -2249,7 +2249,7 @@ iscanr' f z v =
   $ v
  where n = length v
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -2266,7 +2266,7 @@ scanr1 :: Vector v a => (a -> a -> a) -> v a -> v a
 {-# INLINE scanr1 #-}
 scanr1 f = unstreamR . inplace (S.scanl1 (flip f)) id . streamR
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -2287,17 +2287,17 @@ scanr1' f = unstreamR . inplace (S.scanl1' (flip f)) id . streamR
 -- Conversions - Lists
 -- ------------------------
 
--- | \(O(n)\) Convert a vector to a list.
+-- | \(\mathcal{O}(n)\) Convert a vector to a list.
 toList :: Vector v a => v a -> [a]
 {-# INLINE toList #-}
 toList = Bundle.toList . stream
 
--- | \(O(n)\) Convert a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert a list to a vector.
 fromList :: Vector v a => [a] -> v a
 {-# INLINE fromList #-}
 fromList = unstream . Bundle.fromList
 
--- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -2317,7 +2317,7 @@ fromListN n = unstream . Bundle.fromListN n
 -- Conversions - Immutable vectors
 -- -------------------------------
 
--- | \(O(n)\) Convert between different vector types.
+-- | \(\mathcal{O}(n)\) Convert between different vector types.
 convert :: (Vector v a, Vector w a) => v a -> w a
 {-# INLINE convert #-}
 convert = unstream . Bundle.reVector . stream
@@ -2325,19 +2325,19 @@ convert = unstream . Bundle.reVector . stream
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
+-- | \(\mathcal{O}(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze
   :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m (v a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = stToPrim . basicUnsafeFreeze
 
--- | \(O(n)\) Yield an immutable copy of the mutable vector.
+-- | \(\mathcal{O}(n)\) Yield an immutable copy of the mutable vector.
 freeze :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m (v a)
 {-# INLINE freeze #-}
 freeze mv = unsafeFreeze =<< M.clone mv
 
--- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
+-- | \(\mathcal{O}(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -2366,7 +2366,7 @@ unsafeThaw :: (PrimMonad m, Vector v a) => v a -> m (Mutable v (PrimState m) a)
 {-# INLINE_FUSED unsafeThaw #-}
 unsafeThaw = stToPrim . basicUnsafeThaw
 
--- | \(O(n)\) Yield a mutable copy of an immutable vector.
+-- | \(\mathcal{O}(n)\) Yield a mutable copy of an immutable vector.
 thaw :: (PrimMonad m, Vector v a) => v a -> m (Mutable v (PrimState m) a)
 {-# INLINE_FUSED thaw #-}
 thaw v = do
@@ -2385,7 +2385,7 @@ thaw v = do
 
 
 {-
--- | \(O(n)\) Yield a mutable vector containing copies of each vector in the
+-- | \(\mathcal{O}(n)\) Yield a mutable vector containing copies of each vector in the
 -- list.
 thawMany :: (PrimMonad m, Vector v a) => [v a] -> m (Mutable v (PrimState m) a)
 {-# INLINE_FUSED thawMany #-}
@@ -2407,14 +2407,14 @@ thawMany vs = do
           thaw_loop (M.unsafeDrop n mv) vs
 -}
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> v a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy dst src = check Unsafe "length mismatch" (M.length dst == basicLength src)
                    $ (dst `seq` src `seq` stToPrim (basicUnsafeCopy dst src))
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: (HasCallStack, PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> v a -> m ()
 {-# INLINE copy #-}
@@ -2424,7 +2424,7 @@ copy dst src = check Bounds "length mismatch" (M.length dst == basicLength src)
 -- Conversions to/from Bundles
 -- ---------------------------
 
--- | \(O(1)\) Convert a vector to a 'Bundle'.
+-- | \(\mathcal{O}(1)\) Convert a vector to a 'Bundle'.
 stream :: Vector v a => v a -> Bundle v a
 {-# INLINE_FUSED stream #-}
 stream v = Bundle.fromVector v
@@ -2441,7 +2441,7 @@ stream v = v `seq` n `seq` (Bundle.unfoldr get 0 `Bundle.sized` Exact n)
           | otherwise = case basicUnsafeIndexM v i of Box x -> Just (x, i+1)
 -}
 
--- | \(O(n)\) Construct a vector from a 'Bundle'.
+-- | \(\mathcal{O}(n)\) Construct a vector from a 'Bundle'.
 unstream :: Vector v a => Bundle v a -> v a
 {-# INLINE unstream #-}
 unstream s = new (New.unstream s)
@@ -2467,7 +2467,7 @@ unstream s = new (New.unstream s)
 
 
 
--- | \(O(1)\) Convert a vector to a 'Bundle', proceeding from right to left.
+-- | \(\mathcal{O}(1)\) Convert a vector to a 'Bundle', proceeding from right to left.
 streamR :: Vector v a => v a -> Bundle u a
 {-# INLINE_FUSED streamR #-}
 streamR v = v `seq` n `seq` (Bundle.unfoldr get n `Bundle.sized` Exact n)
@@ -2480,7 +2480,7 @@ streamR v = v `seq` n `seq` (Bundle.unfoldr get n `Bundle.sized` Exact n)
             in
             case basicUnsafeIndexM v i' of Box x -> Just (x, i')
 
--- | \(O(n)\) Construct a vector from a 'Bundle', proceeding from right to left.
+-- | \(\mathcal{O}(n)\) Construct a vector from a 'Bundle', proceeding from right to left.
 unstreamR :: Vector v a => Bundle v a -> v a
 {-# INLINE unstreamR #-}
 unstreamR s = new (New.unstreamR s)
@@ -2560,7 +2560,7 @@ clone v = v `seq` New.create (
 -- Comparisons
 -- -----------
 
--- | \(O(n)\) Check if two vectors are equal. All 'Vector' instances are also
+-- | \(\mathcal{O}(n)\) Check if two vectors are equal. All 'Vector' instances are also
 -- instances of 'Eq' and it is usually more appropriate to use those. This
 -- function is primarily intended for implementing 'Eq' instances for new
 -- vector types.
@@ -2568,13 +2568,13 @@ eq :: (Vector v a, Eq a) => v a -> v a -> Bool
 {-# INLINE eq #-}
 xs `eq` ys = stream xs == stream ys
 
--- | \(O(n)\) Check if two vectors are equal using the supplied equality
+-- | \(\mathcal{O}(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 eqBy :: (Vector v a, Vector v b) => (a -> b -> Bool) -> v a -> v b -> Bool
 {-# INLINE eqBy #-}
 eqBy e xs ys = Bundle.eqBy e (stream xs) (stream ys)
 
--- | \(O(n)\) Compare two vectors lexicographically. All 'Vector' instances are
+-- | \(\mathcal{O}(n)\) Compare two vectors lexicographically. All 'Vector' instances are
 -- also instances of 'Ord' and it is usually more appropriate to use those. This
 -- function is primarily intended for implementing 'Ord' instances for new
 -- vector types.
@@ -2582,7 +2582,7 @@ cmp :: (Vector v a, Ord a) => v a -> v a -> Ordering
 {-# INLINE cmp #-}
 cmp xs ys = compare (stream xs) (stream ys)
 
--- | \(O(n)\) Compare two vectors using the supplied comparison function for
+-- | \(\mathcal{O}(n)\) Compare two vectors using the supplied comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == cmp

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -222,12 +222,12 @@ import qualified Data.Traversable as T (Traversable(mapM))
 -- Length information
 -- ------------------
 
--- | /O(1)/ Yield the length of the vector.
+-- | \(O(1)\) Yield the length of the vector.
 length :: Vector v a => v a -> Int
 {-# INLINE length #-}
 length = Bundle.length . stream
 
--- | /O(1)/ Test whether a vector is empty.
+-- | \(O(1)\) Test whether a vector is empty.
 null :: Vector v a => v a -> Bool
 {-# INLINE null #-}
 null = Bundle.null . stream
@@ -250,27 +250,27 @@ v !? i | i `inRange` length v = case basicUnsafeIndexM v i of Box a -> Just a
        | otherwise            = Nothing
 
 
--- | /O(1)/ First element.
+-- | \(O(1)\) First element.
 head :: Vector v a => v a -> a
 {-# INLINE_FUSED head #-}
 head v = v ! 0
 
--- | /O(1)/ Last element.
+-- | \(O(1)\) Last element.
 last :: Vector v a => v a -> a
 {-# INLINE_FUSED last #-}
 last v = v ! (length v - 1)
 
--- | /O(1)/ Unsafe indexing without bounds checking.
+-- | \(O(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Vector v a => v a -> Int -> a
 {-# INLINE_FUSED unsafeIndex #-}
 unsafeIndex v i = checkIndex Unsafe i (length v) $ unBox (basicUnsafeIndexM v i)
 
--- | /O(1)/ First element, without checking if the vector is empty.
+-- | \(O(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Vector v a => v a -> a
 {-# INLINE_FUSED unsafeHead #-}
 unsafeHead v = unsafeIndex v 0
 
--- | /O(1)/ Last element, without checking if the vector is empty.
+-- | \(O(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Vector v a => v a -> a
 {-# INLINE_FUSED unsafeLast #-}
 unsafeLast v = unsafeIndex v (length v - 1)
@@ -303,7 +303,7 @@ unsafeLast v = unsafeIndex v (length v - 1)
 -- Monadic indexing
 -- ----------------
 
--- | /O(1)/ Indexing in a monad.
+-- | \(O(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -325,19 +325,19 @@ indexM :: (HasCallStack, Vector v a, Monad m) => v a -> Int -> m a
 {-# INLINE_FUSED indexM #-}
 indexM v i = checkIndex Bounds i (length v) $ liftBox $ basicUnsafeIndexM v i
 
--- | /O(1)/ First element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (Vector v a, Monad m) => v a -> m a
 {-# INLINE_FUSED headM #-}
 headM v = indexM v 0
 
--- | /O(1)/ Last element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (Vector v a, Monad m) => v a -> m a
 {-# INLINE_FUSED lastM #-}
 lastM v = indexM v (length v - 1)
 
--- | /O(1)/ Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (Vector v a, Monad m) => v a -> Int -> m a
 {-# INLINE_FUSED unsafeIndexM #-}
@@ -345,13 +345,13 @@ unsafeIndexM v i = checkIndex Unsafe i (length v)
                  $ liftBox
                  $ basicUnsafeIndexM v i
 
--- | /O(1)/ First element in a monad, without checking for empty vectors.
+-- | \(O(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (Vector v a, Monad m) => v a -> m a
 {-# INLINE_FUSED unsafeHeadM #-}
 unsafeHeadM v = unsafeIndexM v 0
 
--- | /O(1)/ Last element in a monad, without checking for empty vectors.
+-- | \(O(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (Vector v a, Monad m) => v a -> m a
 {-# INLINE_FUSED unsafeLastM #-}
@@ -382,7 +382,7 @@ unsafeLastM v = unsafeIndexM v (length v - 1)
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | /O(1)/ Yield a slice of the vector without copying it. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: (HasCallStack, Vector v a)
       => Int   -- ^ @i@ starting index
@@ -392,26 +392,26 @@ slice :: (HasCallStack, Vector v a)
 {-# INLINE_FUSED slice #-}
 slice i n v = checkSlice Bounds i n (length v) $ basicUnsafeSlice i n v
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Vector v a => v a -> v a
 {-# INLINE_FUSED init #-}
 init v = slice 0 (length v - 1) v
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Vector v a => v a -> v a
 {-# INLINE_FUSED tail #-}
 tail v = slice 1 (length v - 1) v
 
--- | /O(1)/ Yield the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Vector v a => Int -> v a -> v a
 {-# INLINE_FUSED take #-}
 take n v = unsafeSlice 0 (delay_inline min n' (length v)) v
   where n' = max n 0
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Vector v a => Int -> v a -> v a
 {-# INLINE_FUSED drop #-}
@@ -420,7 +420,7 @@ drop n v = unsafeSlice (delay_inline min n' len)
   where n' = max n 0
         len = length v
 
--- | /O(1)/ Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -436,7 +436,7 @@ splitAt n v = ( unsafeSlice 0 m v
       n'  = max n 0
       len = length v
 
--- | /O(1)/ Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -444,7 +444,7 @@ uncons :: Vector v a => v a -> Maybe (a, v a)
 {-# INLINE_FUSED uncons #-}
 uncons xs = flip (,) (unsafeTail xs) <$> xs !? 0
 
--- | /O(1)/ Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -452,7 +452,7 @@ unsnoc :: Vector v a => v a -> Maybe (v a, a)
 {-# INLINE_FUSED unsnoc #-}
 unsnoc xs = (,) (unsafeInit xs) <$> xs !? (length xs - 1)
 
--- | /O(1)/ Yield a slice of the vector without copying. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Vector v a => Int   -- ^ @i@ starting index
                           -> Int   -- ^ @n@ length
@@ -461,25 +461,25 @@ unsafeSlice :: Vector v a => Int   -- ^ @i@ starting index
 {-# INLINE_FUSED unsafeSlice #-}
 unsafeSlice i n v = checkSlice Unsafe i n (length v) $ basicUnsafeSlice i n v
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Vector v a => v a -> v a
 {-# INLINE_FUSED unsafeInit #-}
 unsafeInit v = unsafeSlice 0 (length v - 1) v
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Vector v a => v a -> v a
 {-# INLINE_FUSED unsafeTail #-}
 unsafeTail v = unsafeSlice 1 (length v - 1) v
 
--- | /O(1)/ Yield the first @n@ elements without copying. The vector must
+-- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Vector v a => Int -> v a -> v a
 {-# INLINE unsafeTake #-}
 unsafeTake n v = unsafeSlice 0 n v
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Vector v a => Int -> v a -> v a
 {-# INLINE unsafeDrop #-}
@@ -518,31 +518,31 @@ unsafeDrop n v = unsafeSlice n (length v - n) v
 -- Initialisation
 -- --------------
 
--- | /O(1)/ The empty vector.
+-- | \(O(1)\) The empty vector.
 empty :: Vector v a => v a
 {-# INLINE empty #-}
 empty = unstream Bundle.empty
 
--- | /O(1)/ A vector with exactly one element.
+-- | \(O(1)\) A vector with exactly one element.
 singleton :: forall v a. Vector v a => a -> v a
 {-# INLINE singleton #-}
 singleton x = elemseq (undefined :: v a) x
             $ unstream (Bundle.singleton x)
 
--- | /O(n)/ A vector of the given length with the same value in each position.
+-- | \(O(n)\) A vector of the given length with the same value in each position.
 replicate :: forall v a. Vector v a => Int -> a -> v a
 {-# INLINE replicate #-}
 replicate n x = elemseq (undefined :: v a) x
               $ unstream
               $ Bundle.replicate n x
 
--- | /O(n)/ Construct a vector of the given length by applying the function to
+-- | \(O(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Vector v a => Int -> (Int -> a) -> v a
 {-# INLINE generate #-}
 generate n f = unstream (Bundle.generate n f)
 
--- | /O(n)/ Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -556,7 +556,7 @@ iterateN n f x = unstream (Bundle.iterateN n f x)
 -- Unfolding
 -- ---------
 
--- | /O(n)/ Construct a vector by repeatedly applying the generator function
+-- | \(O(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -566,7 +566,7 @@ unfoldr :: Vector v a => (b -> Maybe (a, b)) -> b -> v a
 {-# INLINE unfoldr #-}
 unfoldr f = unstream . Bundle.unfoldr f
 
--- | /O(n)/ Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -575,7 +575,7 @@ unfoldrN  :: Vector v a => Int -> (b -> Maybe (a, b)) -> b -> v a
 {-# INLINE unfoldrN #-}
 unfoldrN n f = unstream . Bundle.unfoldrN n f
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -586,7 +586,7 @@ unfoldrExactN  :: Vector v a => Int -> (b -> (a, b)) -> b -> v a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN n f = unstream . Bundle.unfoldrExactN n f
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -594,7 +594,7 @@ unfoldrM :: (Monad m, Vector v a) => (b -> m (Maybe (a, b))) -> b -> m (v a)
 {-# INLINE unfoldrM #-}
 unfoldrM f = unstreamM . MBundle.unfoldrM f
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -602,7 +602,7 @@ unfoldrNM :: (Monad m, Vector v a) => Int -> (b -> m (Maybe (a, b))) -> b -> m (
 {-# INLINE unfoldrNM #-}
 unfoldrNM n f = unstreamM . MBundle.unfoldrNM n f
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -611,7 +611,7 @@ unfoldrExactNM :: (Monad m, Vector v a) => Int -> (b -> m (a, b)) -> b -> m (v a
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM n f = unstreamM . MBundle.unfoldrExactNM n f
 
--- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
+-- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -635,7 +635,7 @@ constructN !n f = runST (
                           fill v'' (i+1)
     fill v _ = return v
 
--- | /O(n)/ Construct a vector with @n@ elements from right to left by
+-- | \(O(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -664,7 +664,7 @@ constructrN !n f = runST (
 -- Enumeration
 -- -----------
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -672,7 +672,7 @@ enumFromN :: (Vector v a, Num a) => a -> Int -> v a
 {-# INLINE enumFromN #-}
 enumFromN x n = enumFromStepN x 1 n
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -683,7 +683,7 @@ enumFromStepN x y n = elemseq (undefined :: v a) x
                     $ unstream
                     $ Bundle.enumFromStepN  x y n
 
--- | /O(n)/ Enumerate values from @x@ to @y@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -691,7 +691,7 @@ enumFromTo :: (Vector v a, Enum a) => a -> a -> v a
 {-# INLINE enumFromTo #-}
 enumFromTo x y = unstream (Bundle.enumFromTo x y)
 
--- | /O(n)/ Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -702,7 +702,7 @@ enumFromThenTo x y z = unstream (Bundle.enumFromThenTo x y z)
 -- Concatenation
 -- -------------
 
--- | /O(n)/ Prepend an element.
+-- | \(O(n)\) Prepend an element.
 cons :: forall v a. Vector v a => a -> v a -> v a
 {-# INLINE cons #-}
 cons x v = elemseq (undefined :: v a) x
@@ -710,7 +710,7 @@ cons x v = elemseq (undefined :: v a) x
          $ Bundle.cons x
          $ stream v
 
--- | /O(n)/ Append an element.
+-- | \(O(n)\) Append an element.
 snoc :: forall v a. Vector v a => v a -> a -> v a
 {-# INLINE snoc #-}
 snoc v x = elemseq (undefined :: v a) x
@@ -718,12 +718,12 @@ snoc v x = elemseq (undefined :: v a) x
          $ Bundle.snoc (stream v) x
 
 infixr 5 ++
--- | /O(m+n)/ Concatenate two vectors.
+-- | \(O(m+n)\) Concatenate two vectors.
 (++) :: Vector v a => v a -> v a -> v a
 {-# INLINE (++) #-}
 v ++ w = unstream (stream v Bundle.++ stream w)
 
--- | /O(n)/ Concatenate all vectors in the list.
+-- | \(O(n)\) Concatenate all vectors in the list.
 concat :: Vector v a => [v a] -> v a
 {-# INLINE concat #-}
 concat = unstream . Bundle.fromVectors
@@ -744,26 +744,26 @@ concat vs = unstream (Bundle.flatten mk step (Exact n) (Bundle.fromList vs))
            k `seq` (v,0,k)
 -}
 
--- | /O(n)/ Concatenate all vectors in the non-empty list.
+-- | \(O(n)\) Concatenate all vectors in the non-empty list.
 concatNE :: Vector v a => NonEmpty.NonEmpty (v a) -> v a
 concatNE = concat . NonEmpty.toList
 
 -- Monadic initialisation
 -- ----------------------
 
--- | /O(n)/ Execute the monadic action the given number of times and store the
+-- | \(O(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: (Monad m, Vector v a) => Int -> m a -> m (v a)
 {-# INLINE replicateM #-}
 replicateM n m = unstreamM (MBundle.replicateM n m)
 
--- | /O(n)/ Construct a vector of the given length by applying the monadic
+-- | \(O(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: (Monad m, Vector v a) => Int -> (Int -> m a) -> m (v a)
 {-# INLINE generateM #-}
 generateM n f = unstreamM (MBundle.generateM n f)
 
--- | /O(n)/ Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -793,7 +793,7 @@ createT p = runST (p >>= T.mapM unsafeFreeze)
 -- Restricting memory usage
 -- ------------------------
 
--- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
+-- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -812,7 +812,7 @@ force v = new (clone v)
 -- Bulk updates
 -- ------------
 
--- | /O(m+n)/ For each pair @(i,a)@ from the list of index/value pairs,
+-- | \(O(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -823,7 +823,7 @@ force v = new (clone v)
 {-# INLINE (//) #-}
 v // us = update_stream v (Bundle.fromList us)
 
--- | /O(m+n)/ For each pair @(i,a)@ from the vector of index/value pairs,
+-- | \(O(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > update <5,9,2,7> <(2,1),(0,3),(2,8)> = <3,9,8,7>
@@ -835,7 +835,7 @@ update :: (Vector v a, Vector v (Int, a))
 {-# INLINE update #-}
 update v w = update_stream v (stream w)
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -882,7 +882,7 @@ unsafeUpdate_stream = modifyWithBundle M.unsafeUpdate
 -- Accumulations
 -- -------------
 
--- | /O(m+n)/ For each pair @(i,b)@ from the list, replace the vector element
+-- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -898,7 +898,7 @@ accum :: Vector v a
 {-# INLINE accum #-}
 accum f v us = accum_stream f v (Bundle.fromList us)
 
--- | /O(m+n)/ For each pair @(i,b)@ from the vector of pairs, replace the vector
+-- | \(O(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
 -- element @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -914,7 +914,7 @@ accumulate :: (Vector v a, Vector v (Int, b))
 {-# INLINE accumulate #-}
 accumulate f v us = accum_stream f v (stream us)
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -968,13 +968,13 @@ unsafeAccum_stream f = modifyWithBundle (M.unsafeAccum f)
 -- Permutations
 -- ------------
 
--- | /O(n)/ Reverse a vector.
+-- | \(O(n)\) Reverse a vector.
 reverse :: (Vector v a) => v a -> v a
 {-# INLINE reverse #-}
 -- FIXME: make this fuse better, add support for recycling
 reverse = unstream . streamR
 
--- | /O(n)/ Yield the vector obtained by replacing each element @i@ of the
+-- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -1044,7 +1044,7 @@ modifyWithBundle p v s = new (New.modifyWithBundle p (clone v) s)
 -- Indexing
 -- --------
 
--- | /O(n)/ Pair each element in a vector with its index.
+-- | \(O(n)\) Pair each element in a vector with its index.
 indexed :: (Vector v a, Vector v (Int,a)) => v a -> v (Int,a)
 {-# INLINE indexed #-}
 indexed = unstream . Bundle.indexed . stream
@@ -1052,12 +1052,12 @@ indexed = unstream . Bundle.indexed . stream
 -- Mapping
 -- -------
 
--- | /O(n)/ Map a function over a vector.
+-- | \(O(n)\) Map a function over a vector.
 map :: (Vector v a, Vector v b) => (a -> b) -> v a -> v b
 {-# INLINE map #-}
 map f = unstream . inplace (S.map f) id . stream
 
--- | /O(n)/ Apply a function to every element of a vector and its index.
+-- | \(O(n)\) Apply a function to every element of a vector and its index.
 imap :: (Vector v a, Vector v b) => (Int -> a -> b) -> v a -> v b
 {-# INLINE imap #-}
 imap f = unstream . inplace (S.map (uncurry f) . S.indexed) id
@@ -1101,43 +1101,43 @@ concatMap f = unstream
 -- Monadic mapping
 -- ---------------
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: (Monad m, Vector v a, Vector v b) => (a -> m b) -> v a -> m (v b)
 {-# INLINE mapM #-}
 mapM f = unstreamM . Bundle.mapM f . stream
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 imapM :: (Monad m, Vector v a, Vector v b)
       => (Int -> a -> m b) -> v a -> m (v b)
 imapM f = unstreamM . Bundle.mapM (uncurry f) . Bundle.indexed . stream
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: (Monad m, Vector v a) => (a -> m b) -> v a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ f = Bundle.mapM_ f . stream
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 imapM_ :: (Monad m, Vector v a) => (Int -> a -> m b) -> v a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ f = Bundle.mapM_ (uncurry f) . Bundle.indexed . stream
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Vector v a, Vector v b) => v a -> (a -> m b) -> m (v b)
 {-# INLINE forM #-}
 forM as f = mapM f as
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, Vector v a) => v a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ as f = mapM_ f as
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -1145,7 +1145,7 @@ iforM :: (Monad m, Vector v a, Vector v b) => v a -> (Int -> a -> m b) -> m (v b
 {-# INLINE iforM #-}
 iforM as f = imapM f as
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -1156,7 +1156,7 @@ iforM_ as f = imapM_ f as
 -- Zipping
 -- -------
 
--- | /O(min(m,n))/ Zip two vectors with the given function.
+-- | \(O(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (Vector v a, Vector v b, Vector v c)
         => (a -> b -> c) -> v a -> v b -> v c
 {-# INLINE zipWith #-}
@@ -1204,7 +1204,7 @@ zipWith6 f = \as bs cs ds es fs ->
                                 (stream es)
                                 (stream fs))
 
--- | /O(min(m,n))/ Zip two vectors with a function that also takes the
+-- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Vector v a, Vector v b, Vector v c)
         => (Int -> a -> b -> c) -> v a -> v b -> v c
@@ -1256,7 +1256,7 @@ izipWith6 f = \as bs cs ds es fs ->
                                                           (stream es)
                                                           (stream fs))
 
--- | /O(min(m,n))/ Zip two vectors.
+-- | \(O(\min(m,n))\) Zip two vectors.
 zip :: (Vector v a, Vector v b, Vector v (a,b)) => v a -> v b -> v (a, b)
 {-# INLINE zip #-}
 zip = zipWith (,)
@@ -1287,7 +1287,7 @@ zip6 = zipWith6 (,,,,,)
 -- Monadic zipping
 -- ---------------
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and yield a
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: (Monad m, Vector v a, Vector v b, Vector v c)
          => (a -> b -> m c) -> v a -> v b -> m (v c)
@@ -1295,7 +1295,7 @@ zipWithM :: (Monad m, Vector v a, Vector v b, Vector v c)
 {-# INLINE zipWithM #-}
 zipWithM f = \as bs -> unstreamM $ Bundle.zipWithM f (stream as) (stream bs)
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 izipWithM :: (Monad m, Vector v a, Vector v b, Vector v c)
          => (Int -> a -> b -> m c) -> v a -> v b -> m (v c)
@@ -1304,14 +1304,14 @@ izipWithM m as bs = unstreamM . Bundle.zipWithM (uncurry m)
                                 (Bundle.indexed (stream as))
                                 $ stream bs
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and ignore the
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: (Monad m, Vector v a, Vector v b)
           => (a -> b -> m c) -> v a -> v b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ f = \as bs -> Bundle.zipWithM_ f (stream as) (stream bs)
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 izipWithM_ :: (Monad m, Vector v a, Vector v b)
           => (Int -> a -> b -> m c) -> v a -> v b -> m ()
@@ -1323,7 +1323,7 @@ izipWithM_ m as bs = Bundle.zipWithM_ (uncurry m)
 -- Unzipping
 -- ---------
 
--- | /O(min(m,n))/ Unzip a vector of pairs.
+-- | \(O(\min(m,n))\) Unzip a vector of pairs.
 unzip :: (Vector v a, Vector v b, Vector v (a,b)) => v (a, b) -> (v a, v b)
 {-# INLINE unzip #-}
 unzip xs = (map fst xs, map snd xs)
@@ -1368,12 +1368,12 @@ unzip6 xs = (map (\(a, _, _, _, _, _) -> a) xs,
 -- Filtering
 -- ---------
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate.
 filter :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE filter #-}
 filter f = unstream . inplace (S.filter f) toMax . stream
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate which is applied to
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: Vector v a => (Int -> a -> Bool) -> v a -> v a
 {-# INLINE ifilter #-}
@@ -1381,7 +1381,7 @@ ifilter f = unstream
           . inplace (S.map snd . S.filter (uncurry f) . S.indexed) toMax
           . stream
 
--- | /O(n)/ Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1395,12 +1395,12 @@ uniq :: (Vector v a, Eq a) => v a -> v a
 {-# INLINE uniq #-}
 uniq = unstream . inplace S.uniq toMax . stream
 
--- | /O(n)/ Map the values and collect the 'Just' results.
+-- | \(O(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (Vector v a, Vector v b) => (a -> Maybe b) -> v a -> v b
 {-# INLINE mapMaybe #-}
 mapMaybe f = unstream . inplace (S.mapMaybe f) toMax . stream
 
--- | /O(n)/ Map the indices/values and collect the 'Just' results.
+-- | \(O(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Vector v a, Vector v b) => (Int -> a -> Maybe b) -> v a -> v b
 {-# INLINE imapMaybe #-}
 imapMaybe f = unstream
@@ -1408,12 +1408,12 @@ imapMaybe f = unstream
           . stream
 
 
--- | /O(n)/ Drop all elements that do not satisfy the monadic predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: (Monad m, Vector v a) => (a -> m Bool) -> v a -> m (v a)
 {-# INLINE filterM #-}
 filterM f = unstreamM . Bundle.filterM f . stream
 
--- | /O(n)/ Apply the monadic function to each element of the vector and
+-- | \(O(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1421,7 +1421,7 @@ mapMaybeM :: (Monad m, Vector v a, Vector v b) => (a -> m (Maybe b)) -> v a -> m
 {-# INLINE mapMaybeM #-}
 mapMaybeM f = unstreamM . Bundle.mapMaybeM f . stream
 
--- | /O(n)/ Apply the monadic function to each element of the vector and its index.
+-- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1430,14 +1430,14 @@ imapMaybeM :: (Monad m, Vector v a, Vector v b)
 {-# INLINE imapMaybeM #-}
 imapMaybeM f = unstreamM . Bundle.mapMaybeM (\(i, a) -> f i a) . Bundle.indexed . stream
 
--- | /O(n)/ Yield the longest prefix of elements satisfying the predicate.
+-- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE takeWhile #-}
 takeWhile f = unstream . Bundle.takeWhile f . stream
 
--- | /O(n)/ Drop the longest prefix of elements that satisfy the predicate
+-- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Vector v a => (a -> Bool) -> v a -> v a
 {-# INLINE_FUSED dropWhile #-}
@@ -1462,7 +1462,7 @@ dropWhile f xs = case findIndex (not . f) xs of
 -- Parititioning
 -- -------------
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1482,7 +1482,7 @@ partition_stream f s = s `seq` runST (
     v2 <- unsafeFreeze mv2
     return (v1,v2))
 
--- | /O(n)/ Split the vector into two parts, the first one containing the
+-- | \(O(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1500,7 +1500,7 @@ partition_with_stream f s = s `seq` runST (
     v2 <- unsafeFreeze mv2
     return (v1,v2))
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1538,13 +1538,13 @@ unstablePartition_new f (New.New p) = runST (
 
 -- FIXME: make span and break fusible
 
--- | /O(n)/ Split the vector into the longest prefix of elements that satisfy
+-- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: Vector v a => (a -> Bool) -> v a -> (v a, v a)
 {-# INLINE span #-}
 span f = break (not . f)
 
--- | /O(n)/ Split the vector into the longest prefix of elements that do not
+-- | \(O(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: Vector v a => (a -> Bool) -> v a -> (v a, v a)
 {-# INLINE break #-}
@@ -1552,7 +1552,7 @@ break f xs = case findIndex f xs of
                Just i  -> (unsafeSlice 0 i xs, unsafeSlice i (length xs - i) xs)
                Nothing -> (xs, empty)
 
--- | /O(n)/ Split a vector into a list of slices.
+-- | \(O(n)\) Split a vector into a list of slices.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1576,7 +1576,7 @@ groupBy f v =
       Nothing -> [v]
       Just n -> unsafeTake (n + 1) v : groupBy f (unsafeDrop (n + 1) v)
 
--- | /O(n)/ Split a vector into a list of slices.
+-- | \(O(n)\) Split a vector into a list of slices.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1598,30 +1598,30 @@ group = groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | /O(n)/ Check if the vector contains an element.
+-- | \(O(n)\) Check if the vector contains an element.
 elem :: (Vector v a, Eq a) => a -> v a -> Bool
 {-# INLINE elem #-}
 elem x = Bundle.elem x . stream
 
 infix 4 `notElem`
--- | /O(n)/ Check if the vector does not contain an element (inverse of 'elem').
+-- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: (Vector v a, Eq a) => a -> v a -> Bool
 {-# INLINE notElem #-}
 notElem x = Bundle.notElem x . stream
 
--- | /O(n)/ Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: Vector v a => (a -> Bool) -> v a -> Maybe a
 {-# INLINE find #-}
 find f = Bundle.find f . stream
 
--- | /O(n)/ Yield 'Just' the index of the first element matching the predicate
+-- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: Vector v a => (a -> Bool) -> v a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex f = Bundle.findIndex f . stream
 
--- | /O(n)/ Yield 'Just' the index of the /last/ element matching the predicate
+-- | \(O(n)\) Yield 'Just' the index of the /last/ element matching the predicate
 -- or 'Nothing' if no such element exists.
 --
 -- @since 0.12.2.0
@@ -1629,7 +1629,7 @@ findIndexR :: Vector v a => (a -> Bool) -> v a -> Maybe Int
 {-# INLINE findIndexR #-}
 findIndexR f v = fmap (length v - 1 -) . Bundle.findIndex f $ streamR v
 
--- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
+-- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: (Vector v a, Vector v Int) => (a -> Bool) -> v a -> v Int
 {-# INLINE findIndices #-}
@@ -1637,14 +1637,14 @@ findIndices f = unstream
               . inplace (S.map fst . S.filter (f . snd) . S.indexed) toMax
               . stream
 
--- | /O(n)/ Yield 'Just' the index of the first occurrence of the given element or
+-- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: (Vector v a, Eq a) => a -> v a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex x = findIndex (x ==)
 
--- | /O(n)/ Yield the indices of all occurrences of the given element in
+-- | \(O(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: (Vector v a, Vector v Int, Eq a) => a -> v a -> v Int
 {-# INLINE elemIndices #-}
@@ -1653,70 +1653,70 @@ elemIndices x = findIndices (x ==)
 -- Folding
 -- -------
 
--- | /O(n)/ Left fold.
+-- | \(O(n)\) Left fold.
 foldl :: Vector v b => (a -> b -> a) -> a -> v b -> a
 {-# INLINE foldl #-}
 foldl f z = Bundle.foldl f z . stream
 
--- | /O(n)/ Left fold on non-empty vectors.
+-- | \(O(n)\) Left fold on non-empty vectors.
 foldl1 :: Vector v a => (a -> a -> a) -> v a -> a
 {-# INLINE foldl1 #-}
 foldl1 f = Bundle.foldl1 f . stream
 
--- | /O(n)/ Left fold with strict accumulator.
+-- | \(O(n)\) Left fold with strict accumulator.
 foldl' :: Vector v b => (a -> b -> a) -> a -> v b -> a
 {-# INLINE foldl' #-}
 foldl' f z = Bundle.foldl' f z . stream
 
--- | /O(n)/ Left fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: Vector v a => (a -> a -> a) -> v a -> a
 {-# INLINE foldl1' #-}
 foldl1' f = Bundle.foldl1' f . stream
 
--- | /O(n)/ Right fold.
+-- | \(O(n)\) Right fold.
 foldr :: Vector v a => (a -> b -> b) -> b -> v a -> b
 {-# INLINE foldr #-}
 foldr f z = Bundle.foldr f z . stream
 
--- | /O(n)/ Right fold on non-empty vectors.
+-- | \(O(n)\) Right fold on non-empty vectors.
 foldr1 :: Vector v a => (a -> a -> a) -> v a -> a
 {-# INLINE foldr1 #-}
 foldr1 f = Bundle.foldr1 f . stream
 
--- | /O(n)/ Right fold with a strict accumulator.
+-- | \(O(n)\) Right fold with a strict accumulator.
 foldr' :: Vector v a => (a -> b -> b) -> b -> v a -> b
 {-# INLINE foldr' #-}
 foldr' f z = Bundle.foldl' (flip f) z . streamR
 
--- | /O(n)/ Right fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: Vector v a => (a -> a -> a) -> v a -> a
 {-# INLINE foldr1' #-}
 foldr1' f = Bundle.foldl1' (flip f) . streamR
 
--- | /O(n)/ Left fold using a function applied to each element and its index.
+-- | \(O(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: Vector v b => (a -> Int -> b -> a) -> a -> v b -> a
 {-# INLINE ifoldl #-}
 ifoldl f z = Bundle.foldl (uncurry . f) z . Bundle.indexed . stream
 
--- | /O(n)/ Left fold with strict accumulator using a function applied to each element
+-- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: Vector v b => (a -> Int -> b -> a) -> a -> v b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' f z = Bundle.foldl' (uncurry . f) z . Bundle.indexed . stream
 
--- | /O(n)/ Right fold using a function applied to each element and its index.
+-- | \(O(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: Vector v a => (Int -> a -> b -> b) -> b -> v a -> b
 {-# INLINE ifoldr #-}
 ifoldr f z = Bundle.foldr (uncurry f) z . Bundle.indexed . stream
 
--- | /O(n)/ Right fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: Vector v a => (Int -> a -> b -> b) -> b -> v a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' f z xs = Bundle.foldl' (flip (uncurry f)) z
                $ Bundle.indexedR (length xs) $ streamR xs
 
--- | /O(n)/ Map each element of the structure to a monoid and combine
+-- | \(O(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type cless. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1727,7 +1727,7 @@ foldMap :: (Monoid m, Vector v a) => (a -> m) -> v a -> m
 {-# INLINE foldMap #-}
 foldMap f = foldr (mappend . f) mempty
 
--- | /O(n)/ Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1741,7 +1741,7 @@ foldMap' f = foldl' (\acc a -> acc `mappend` f a) mempty
 -- Specialised folds
 -- -----------------
 
--- | /O(n)/ Check if all elements satisfy the predicate.
+-- | \(O(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1756,7 +1756,7 @@ all :: Vector v a => (a -> Bool) -> v a -> Bool
 {-# INLINE all #-}
 all f = Bundle.and . Bundle.map f . stream
 
--- | /O(n)/ Check if any element satisfies the predicate.
+-- | \(O(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1771,7 +1771,7 @@ any :: Vector v a => (a -> Bool) -> v a -> Bool
 {-# INLINE any #-}
 any f = Bundle.or . Bundle.map f . stream
 
--- | /O(n)/ Check if all elements are 'True'.
+-- | \(O(n)\) Check if all elements are 'True'.
 --
 -- ==== __Examples__
 --
@@ -1784,7 +1784,7 @@ and :: Vector v Bool => v Bool -> Bool
 {-# INLINE and #-}
 and = Bundle.and . stream
 
--- | /O(n)/ Check if any element is 'True'.
+-- | \(O(n)\) Check if any element is 'True'.
 --
 -- ==== __Examples__
 --
@@ -1797,7 +1797,7 @@ or :: Vector v Bool => v Bool -> Bool
 {-# INLINE or #-}
 or = Bundle.or . stream
 
--- | /O(n)/ Compute the sum of the elements.
+-- | \(O(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1810,7 +1810,7 @@ sum :: (Vector v a, Num a) => v a -> a
 {-# INLINE sum #-}
 sum = Bundle.foldl' (+) 0 . stream
 
--- | /O(n)/ Compute the product of the elements.
+-- | \(O(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1823,7 +1823,7 @@ product :: (Vector v a, Num a) => v a -> a
 {-# INLINE product #-}
 product = Bundle.foldl' (*) 1 . stream
 
--- | /O(n)/ Yield the maximum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1840,7 +1840,7 @@ maximum :: (Vector v a, Ord a) => v a -> a
 {-# INLINE maximum #-}
 maximum = Bundle.foldl1' max . stream
 
--- | /O(n)/ Yield the maximum element of the vector according to the
+-- | \(O(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1862,7 +1862,7 @@ maximumBy cmpr = Bundle.foldl1' maxBy . stream
                   LT -> y
                   _  -> x
 
--- | /O(n)/ Yield the maximum element of the vector by comparing the results
+-- | \(O(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1882,7 +1882,7 @@ maximumOn f = fst . Bundle.foldl1' maxBy . Bundle.map (\a -> (a, f a)) . stream
                   LT -> y
                   _  -> x
 
--- | /O(n)/ Yield the minimum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1899,7 +1899,7 @@ minimum :: (Vector v a, Ord a) => v a -> a
 {-# INLINE minimum #-}
 minimum = Bundle.foldl1' min . stream
 
--- | /O(n)/ Yield the minimum element of the vector according to the
+-- | \(O(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 --
@@ -1920,7 +1920,7 @@ minimumBy cmpr = Bundle.foldl1' minBy . stream
                   GT -> y
                   _  -> x
 
--- | /O(n)/ Yield the minimum element of the vector by comparing the results
+-- | \(O(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1940,13 +1940,13 @@ minimumOn f = fst . Bundle.foldl1' minBy . Bundle.map (\a -> (a, f a)) . stream
                   GT -> y
                   _  -> x
 
--- | /O(n)/ Yield the index of the maximum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (Vector v a, Ord a) => v a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = maxIndexBy compare
 
--- | /O(n)/ Yield the index of the maximum element of the vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
@@ -1967,13 +1967,13 @@ maxIndexBy cmpr = fst . Bundle.foldl1' imax . Bundle.indexed . stream
                          LT -> (j,y)
                          _  -> (i,x)
 
--- | /O(n)/ Yield the index of the minimum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (Vector v a, Ord a) => v a -> Int
 {-# INLINE minIndex #-}
 minIndex = minIndexBy compare
 
--- | /O(n)/ Yield the index of the minimum element of the vector according to
+-- | \(O(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1996,33 +1996,33 @@ minIndexBy cmpr = fst . Bundle.foldl1' imin . Bundle.indexed . stream
 -- Monadic folds
 -- -------------
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 foldM :: (Monad m, Vector v b) => (a -> b -> m a) -> a -> v b -> m a
 {-# INLINE foldM #-}
 foldM m z = Bundle.foldM m z . stream
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 ifoldM :: (Monad m, Vector v b) => (a -> Int -> b -> m a) -> a -> v b -> m a
 {-# INLINE ifoldM #-}
 ifoldM m z = Bundle.foldM (uncurry . m) z . Bundle.indexed . stream
 
--- | /O(n)/ Monadic fold over non-empty vectors.
+-- | \(O(n)\) Monadic fold over non-empty vectors.
 fold1M :: (Monad m, Vector v a) => (a -> a -> m a) -> v a -> m a
 {-# INLINE fold1M #-}
 fold1M m = Bundle.fold1M m . stream
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 foldM' :: (Monad m, Vector v b) => (a -> b -> m a) -> a -> v b -> m a
 {-# INLINE foldM' #-}
 foldM' m z = Bundle.foldM' m z . stream
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldM' :: (Monad m, Vector v b) => (a -> Int -> b -> m a) -> a -> v b -> m a
 {-# INLINE ifoldM' #-}
 ifoldM' m z = Bundle.foldM' (uncurry . m) z . Bundle.indexed . stream
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator.
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: (Monad m, Vector v a) => (a -> a -> m a) -> v a -> m a
 {-# INLINE fold1M' #-}
 fold1M' m = Bundle.fold1M' m . stream
@@ -2031,34 +2031,34 @@ discard :: Monad m => m a -> m ()
 {-# INLINE discard #-}
 discard m = m >> return ()
 
--- | /O(n)/ Monadic fold that discards the result.
+-- | \(O(n)\) Monadic fold that discards the result.
 foldM_ :: (Monad m, Vector v b) => (a -> b -> m a) -> a -> v b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ m z = discard . Bundle.foldM m z . stream
 
--- | /O(n)/ Monadic fold that discards the result using a function applied to
+-- | \(O(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 ifoldM_ :: (Monad m, Vector v b) => (a -> Int -> b -> m a) -> a -> v b -> m ()
 {-# INLINE ifoldM_ #-}
 ifoldM_ m z = discard . Bundle.foldM (uncurry . m) z . Bundle.indexed . stream
 
--- | /O(n)/ Monadic fold over non-empty vectors that discards the result.
+-- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: (Monad m, Vector v a) => (a -> a -> m a) -> v a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ m = discard . Bundle.fold1M m . stream
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result.
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: (Monad m, Vector v b) => (a -> b -> m a) -> a -> v b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ m z = discard . Bundle.foldM' m z . stream
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 ifoldM'_ :: (Monad m, Vector v b) => (a -> Int -> b -> m a) -> a -> v b -> m ()
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ m z = discard . Bundle.foldM' (uncurry . m) z . Bundle.indexed . stream
 
--- | /O(n)/ Monad fold over non-empty vectors with strict accumulator
+-- | \(O(n)\) Monad fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: (Monad m, Vector v a) => (a -> a -> m a) -> v a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -2080,7 +2080,7 @@ sequence_ = mapM_ id
 -- Scans
 -- -----
 
--- | /O(n)/ Left-to-right prescan.
+-- | \(O(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -2095,12 +2095,12 @@ prescanl :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE prescanl #-}
 prescanl f z = unstream . inplace (S.prescanl f z) id . stream
 
--- | /O(n)/ Left-to-right prescan with strict accumulator.
+-- | \(O(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE prescanl' #-}
 prescanl' f z = unstream . inplace (S.prescanl' f z) id . stream
 
--- | /O(n)/ Left-to-right postscan.
+-- | \(O(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -2115,12 +2115,12 @@ postscanl :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE postscanl #-}
 postscanl f z = unstream . inplace (S.postscanl f z) id . stream
 
--- | /O(n)/ Left-to-right postscan with strict accumulator.
+-- | \(O(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE postscanl' #-}
 postscanl' f z = unstream . inplace (S.postscanl' f z) id . stream
 
--- | /O(n)/ Left-to-right scan.
+-- | \(O(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -2135,12 +2135,12 @@ scanl :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE scanl #-}
 scanl f z = unstream . Bundle.scanl f z . stream
 
--- | /O(n)/ Left-to-right scan with strict accumulator.
+-- | \(O(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (Vector v a, Vector v b) => (a -> b -> a) -> a -> v b -> v a
 {-# INLINE scanl' #-}
 scanl' f z = unstream . Bundle.scanl' f z . stream
 
--- | /O(n)/ Left-to-right scan over a vector with its index.
+-- | \(O(n)\) Left-to-right scan over a vector with its index.
 iscanl :: (Vector v a, Vector v b) => (Int -> a -> b -> a) -> a -> v b -> v a
 {-# INLINE iscanl #-}
 iscanl f z =
@@ -2148,7 +2148,7 @@ iscanl f z =
   . inplace (S.scanl (\a (i, b) -> f i a b) z . S.indexed) (+1)
   . stream
 
--- | /O(n)/ Left-to-right scan over a vector (strictly) with its index.
+-- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
 iscanl' :: (Vector v a, Vector v b) => (Int -> a -> b -> a) -> a -> v b -> v a
 {-# INLINE iscanl' #-}
 iscanl' f z =
@@ -2157,7 +2157,7 @@ iscanl' f z =
   . stream
 
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -2178,7 +2178,7 @@ scanl1 :: Vector v a => (a -> a -> a) -> v a -> v a
 {-# INLINE scanl1 #-}
 scanl1 f = unstream . inplace (S.scanl1 f) id . stream
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -2195,7 +2195,7 @@ scanl1' :: Vector v a => (a -> a -> a) -> v a -> v a
 {-# INLINE scanl1' #-}
 scanl1' f = unstream . inplace (S.scanl1' f) id . stream
 
--- | /O(n)/ Right-to-left prescan.
+-- | \(O(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -2204,32 +2204,32 @@ prescanr :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE prescanr #-}
 prescanr f z = unstreamR . inplace (S.prescanl (flip f) z) id . streamR
 
--- | /O(n)/ Right-to-left prescan with strict accumulator.
+-- | \(O(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE prescanr' #-}
 prescanr' f z = unstreamR . inplace (S.prescanl' (flip f) z) id . streamR
 
--- | /O(n)/ Right-to-left postscan.
+-- | \(O(n)\) Right-to-left postscan.
 postscanr :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE postscanr #-}
 postscanr f z = unstreamR . inplace (S.postscanl (flip f) z) id . streamR
 
--- | /O(n)/ Right-to-left postscan with strict accumulator.
+-- | \(O(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE postscanr' #-}
 postscanr' f z = unstreamR . inplace (S.postscanl' (flip f) z) id . streamR
 
--- | /O(n)/ Right-to-left scan.
+-- | \(O(n)\) Right-to-left scan.
 scanr :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE scanr #-}
 scanr f z = unstreamR . Bundle.scanl (flip f) z . streamR
 
--- | /O(n)/ Right-to-left scan with strict accumulator.
+-- | \(O(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (Vector v a, Vector v b) => (a -> b -> b) -> b -> v a -> v b
 {-# INLINE scanr' #-}
 scanr' f z = unstreamR . Bundle.scanl' (flip f) z . streamR
 
--- | /O(n)/ Right-to-left scan over a vector with its index.
+-- | \(O(n)\) Right-to-left scan over a vector with its index.
 iscanr :: (Vector v a, Vector v b) => (Int -> a -> b -> b) -> b -> v a -> v b
 {-# INLINE iscanr #-}
 iscanr f z v =
@@ -2239,7 +2239,7 @@ iscanr f z v =
   $ v
  where n = length v
 
--- | /O(n)/ Right-to-left scan over a vector (strictly) with its index.
+-- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
 iscanr' :: (Vector v a, Vector v b) => (Int -> a -> b -> b) -> b -> v a -> v b
 {-# INLINE iscanr' #-}
 iscanr' f z v =
@@ -2249,7 +2249,7 @@ iscanr' f z v =
   $ v
  where n = length v
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector.
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -2266,7 +2266,7 @@ scanr1 :: Vector v a => (a -> a -> a) -> v a -> v a
 {-# INLINE scanr1 #-}
 scanr1 f = unstreamR . inplace (S.scanl1 (flip f)) id . streamR
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector with a strict
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -2287,17 +2287,17 @@ scanr1' f = unstreamR . inplace (S.scanl1' (flip f)) id . streamR
 -- Conversions - Lists
 -- ------------------------
 
--- | /O(n)/ Convert a vector to a list.
+-- | \(O(n)\) Convert a vector to a list.
 toList :: Vector v a => v a -> [a]
 {-# INLINE toList #-}
 toList = Bundle.toList . stream
 
--- | /O(n)/ Convert a list to a vector.
+-- | \(O(n)\) Convert a list to a vector.
 fromList :: Vector v a => [a] -> v a
 {-# INLINE fromList #-}
 fromList = unstream . Bundle.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -2317,7 +2317,7 @@ fromListN n = unstream . Bundle.fromListN n
 -- Conversions - Immutable vectors
 -- -------------------------------
 
--- | /O(n)/ Convert between different vector types.
+-- | \(O(n)\) Convert between different vector types.
 convert :: (Vector v a, Vector w a) => v a -> w a
 {-# INLINE convert #-}
 convert = unstream . Bundle.reVector . stream
@@ -2325,19 +2325,19 @@ convert = unstream . Bundle.reVector . stream
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | /O(1)/ Unsafely convert a mutable vector to an immutable one without
+-- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze
   :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m (v a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = stToPrim . basicUnsafeFreeze
 
--- | /O(n)/ Yield an immutable copy of the mutable vector.
+-- | \(O(n)\) Yield an immutable copy of the mutable vector.
 freeze :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m (v a)
 {-# INLINE freeze #-}
 freeze mv = unsafeFreeze =<< M.clone mv
 
--- | /O(1)/ Unsafely convert an immutable vector to a mutable one
+-- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -2366,7 +2366,7 @@ unsafeThaw :: (PrimMonad m, Vector v a) => v a -> m (Mutable v (PrimState m) a)
 {-# INLINE_FUSED unsafeThaw #-}
 unsafeThaw = stToPrim . basicUnsafeThaw
 
--- | /O(n)/ Yield a mutable copy of an immutable vector.
+-- | \(O(n)\) Yield a mutable copy of an immutable vector.
 thaw :: (PrimMonad m, Vector v a) => v a -> m (Mutable v (PrimState m) a)
 {-# INLINE_FUSED thaw #-}
 thaw v = do
@@ -2385,7 +2385,7 @@ thaw v = do
 
 
 {-
--- | /O(n)/ Yield a mutable vector containing copies of each vector in the
+-- | \(O(n)\) Yield a mutable vector containing copies of each vector in the
 -- list.
 thawMany :: (PrimMonad m, Vector v a) => [v a] -> m (Mutable v (PrimState m) a)
 {-# INLINE_FUSED thawMany #-}
@@ -2407,14 +2407,14 @@ thawMany vs = do
           thaw_loop (M.unsafeDrop n mv) vs
 -}
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy :: (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> v a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy dst src = check Unsafe "length mismatch" (M.length dst == basicLength src)
                    $ (dst `seq` src `seq` stToPrim (basicUnsafeCopy dst src))
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: (HasCallStack, PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> v a -> m ()
 {-# INLINE copy #-}
@@ -2424,7 +2424,7 @@ copy dst src = check Bounds "length mismatch" (M.length dst == basicLength src)
 -- Conversions to/from Bundles
 -- ---------------------------
 
--- | /O(1)/ Convert a vector to a 'Bundle'.
+-- | \(O(1)\) Convert a vector to a 'Bundle'.
 stream :: Vector v a => v a -> Bundle v a
 {-# INLINE_FUSED stream #-}
 stream v = Bundle.fromVector v
@@ -2441,7 +2441,7 @@ stream v = v `seq` n `seq` (Bundle.unfoldr get 0 `Bundle.sized` Exact n)
           | otherwise = case basicUnsafeIndexM v i of Box x -> Just (x, i+1)
 -}
 
--- | /O(n)/ Construct a vector from a 'Bundle'.
+-- | \(O(n)\) Construct a vector from a 'Bundle'.
 unstream :: Vector v a => Bundle v a -> v a
 {-# INLINE unstream #-}
 unstream s = new (New.unstream s)
@@ -2467,7 +2467,7 @@ unstream s = new (New.unstream s)
 
 
 
--- | /O(1)/ Convert a vector to a 'Bundle', proceeding from right to left.
+-- | \(O(1)\) Convert a vector to a 'Bundle', proceeding from right to left.
 streamR :: Vector v a => v a -> Bundle u a
 {-# INLINE_FUSED streamR #-}
 streamR v = v `seq` n `seq` (Bundle.unfoldr get n `Bundle.sized` Exact n)
@@ -2480,7 +2480,7 @@ streamR v = v `seq` n `seq` (Bundle.unfoldr get n `Bundle.sized` Exact n)
             in
             case basicUnsafeIndexM v i' of Box x -> Just (x, i')
 
--- | /O(n)/ Construct a vector from a 'Bundle', proceeding from right to left.
+-- | \(O(n)\) Construct a vector from a 'Bundle', proceeding from right to left.
 unstreamR :: Vector v a => Bundle v a -> v a
 {-# INLINE unstreamR #-}
 unstreamR s = new (New.unstreamR s)
@@ -2560,7 +2560,7 @@ clone v = v `seq` New.create (
 -- Comparisons
 -- -----------
 
--- | /O(n)/ Check if two vectors are equal. All 'Vector' instances are also
+-- | \(O(n)\) Check if two vectors are equal. All 'Vector' instances are also
 -- instances of 'Eq' and it is usually more appropriate to use those. This
 -- function is primarily intended for implementing 'Eq' instances for new
 -- vector types.
@@ -2568,13 +2568,13 @@ eq :: (Vector v a, Eq a) => v a -> v a -> Bool
 {-# INLINE eq #-}
 xs `eq` ys = stream xs == stream ys
 
--- | /O(n)/ Check if two vectors are equal using the supplied equality
+-- | \(O(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 eqBy :: (Vector v a, Vector v b) => (a -> b -> Bool) -> v a -> v b -> Bool
 {-# INLINE eqBy #-}
 eqBy e xs ys = Bundle.eqBy e (stream xs) (stream ys)
 
--- | /O(n)/ Compare two vectors lexicographically. All 'Vector' instances are
+-- | \(O(n)\) Compare two vectors lexicographically. All 'Vector' instances are
 -- also instances of 'Ord' and it is usually more appropriate to use those. This
 -- function is primarily intended for implementing 'Ord' instances for new
 -- vector types.
@@ -2582,7 +2582,7 @@ cmp :: (Vector v a, Ord a) => v a -> v a -> Ordering
 {-# INLINE cmp #-}
 cmp xs ys = compare (stream xs) (stream ys)
 
--- | /O(n)/ Compare two vectors using the supplied comparison function for
+-- | \(O(n)\) Compare two vectors using the supplied comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == cmp

--- a/vector/src/Data/Vector/Generic/Base.hs
+++ b/vector/src/Data/Vector/Generic/Base.hs
@@ -51,25 +51,25 @@ type family Mutable (v :: Type -> Type) = (mv :: Type -> Type -> Type) | mv -> v
 --   * 'basicUnsafeIndexM'
 --
 class MVector (Mutable v) a => Vector v a where
-  -- | /Assumed complexity:/ \(O(1)\)
+  -- | /Assumed complexity:/ \(\mathcal{O}(1)\)
   --
   -- Unsafely convert a mutable vector to its immutable version
   -- without copying. The mutable vector may not be used after
   -- this operation.
   basicUnsafeFreeze :: Mutable v s a -> ST s (v a)
 
-  -- | /Assumed complexity:/ \(O(1)\)
+  -- | /Assumed complexity:/ \(\mathcal{O}(1)\)
   --
   -- Unsafely convert an immutable vector to its mutable version without
   -- copying. The immutable vector may not be used after this operation.
   basicUnsafeThaw :: v a -> ST s (Mutable v s a)
 
-  -- | /Assumed complexity:/ \(O(1)\)
+  -- | /Assumed complexity:/ \(\mathcal{O}(1)\)
   --
   -- Yield the length of the vector.
   basicLength      :: v a -> Int
 
-  -- | /Assumed complexity:/ \(O(1)\)
+  -- | /Assumed complexity:/ \(\mathcal{O}(1)\)
   --
   -- Yield a slice of the vector without copying it. No range checks are
   -- performed.
@@ -77,7 +77,7 @@ class MVector (Mutable v) a => Vector v a where
                     -> Int -- ^ length
                     -> v a -> v a
 
-  -- | /Assumed complexity:/ \(O(1)\)
+  -- | /Assumed complexity:/ \(\mathcal{O}(1)\)
   --
   -- Yield the element at the given position in a monad. No range checks are
   -- performed.
@@ -103,7 +103,7 @@ class MVector (Mutable v) a => Vector v a where
   -- element!) is evaluated immediately.
   basicUnsafeIndexM  :: v a -> Int -> Box a
 
-  -- |  /Assumed complexity:/ \(O(n)\)
+  -- |  /Assumed complexity:/ \(\mathcal{O}(n)\)
   --
   -- Copy an immutable vector into a mutable one. The two vectors must have
   -- the same length, but this is not checked.

--- a/vector/src/Data/Vector/Generic/Base.hs
+++ b/vector/src/Data/Vector/Generic/Base.hs
@@ -51,25 +51,25 @@ type family Mutable (v :: Type -> Type) = (mv :: Type -> Type -> Type) | mv -> v
 --   * 'basicUnsafeIndexM'
 --
 class MVector (Mutable v) a => Vector v a where
-  -- | /Assumed complexity: O(1)/
+  -- | /Assumed complexity:/ \(O(1)\)
   --
   -- Unsafely convert a mutable vector to its immutable version
   -- without copying. The mutable vector may not be used after
   -- this operation.
   basicUnsafeFreeze :: Mutable v s a -> ST s (v a)
 
-  -- | /Assumed complexity: O(1)/
+  -- | /Assumed complexity:/ \(O(1)\)
   --
   -- Unsafely convert an immutable vector to its mutable version without
   -- copying. The immutable vector may not be used after this operation.
   basicUnsafeThaw :: v a -> ST s (Mutable v s a)
 
-  -- | /Assumed complexity: O(1)/
+  -- | /Assumed complexity:/ \(O(1)\)
   --
   -- Yield the length of the vector.
   basicLength      :: v a -> Int
 
-  -- | /Assumed complexity: O(1)/
+  -- | /Assumed complexity:/ \(O(1)\)
   --
   -- Yield a slice of the vector without copying it. No range checks are
   -- performed.
@@ -77,7 +77,7 @@ class MVector (Mutable v) a => Vector v a where
                     -> Int -- ^ length
                     -> v a -> v a
 
-  -- | /Assumed complexity: O(1)/
+  -- | /Assumed complexity:/ \(O(1)\)
   --
   -- Yield the element at the given position in a monad. No range checks are
   -- performed.
@@ -103,7 +103,7 @@ class MVector (Mutable v) a => Vector v a where
   -- element!) is evaluated immediately.
   basicUnsafeIndexM  :: v a -> Int -> Box a
 
-  -- |  /Assumed complexity: O(n)/
+  -- |  /Assumed complexity:/ \(O(n)\)
   --
   -- Copy an immutable vector into a mutable one. The two vectors must have
   -- the same length, but this is not checked.

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -386,7 +386,7 @@ drop n v = unsafeSlice (min m n') (max 0 (m - n')) v
     n' = max n 0
     m  = length v
 
--- | \(O(1)\) Split the mutable vector into the first @n@ elements
+-- | \(\mathcal{O}(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -486,7 +486,7 @@ replicateM :: (PrimMonad m, MVector v a) => Int -> m a -> m (v (PrimState m) a)
 {-# INLINE replicateM #-}
 replicateM n m = munstream (MBundle.replicateM n m)
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -495,7 +495,7 @@ generate :: (PrimMonad m, MVector v a) => Int -> (Int -> a) -> m (v (PrimState m
 {-# INLINE generate #-}
 generate n f = stToPrim $ generateM n (return . f)
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -761,21 +761,21 @@ forI_ v f = loop 0
            | otherwise = f i >> loop (i + 1)
     n = length v
 
--- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m, MVector v a) => (a -> m b) -> v (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ f v = forI_ v $ \i -> f =<< unsafeRead v i
 
--- | \(O(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
 --
 -- @since 0.12.3.0
 imapM_ :: (PrimMonad m, MVector v a) => (Int -> a -> m b) -> v (PrimState m) a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ f v = forI_ v $ \i -> f i =<< unsafeRead v i
 
--- | \(O(n)\) Apply the monadic action to every element of the vector,
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -783,7 +783,7 @@ forM_ :: (PrimMonad m, MVector v a) => v (PrimState m) a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = flip mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -791,56 +791,56 @@ iforM_ :: (PrimMonad m, MVector v a) => v (PrimState m) a -> (Int -> a -> m b) -
 {-# INLINE iforM_ #-}
 iforM_ = flip imapM_
 
--- | \(O(n)\) Pure left fold.
+-- | \(\mathcal{O}(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m, MVector v a) => (b -> a -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl f = ifoldl (\b _ -> f b)
 
--- | \(O(n)\) Pure left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m, MVector v a) => (b -> a -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' f = ifoldl' (\b _ -> f b)
 
--- | \(O(n)\) Pure left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m, MVector v a) => (b -> Int -> a -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl f b0 v = stToPrim $ ifoldM (\b i a -> return $ f b i a) b0 v
 
--- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m, MVector v a) => (b -> Int -> a -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' f b0 v = stToPrim $ ifoldM' (\b i a -> return $ f b i a) b0 v
 
--- | \(O(n)\) Pure right fold.
+-- | \(\mathcal{O}(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m, MVector v a) => (a -> b -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr f = ifoldr (const f)
 
--- | \(O(n)\) Pure right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m, MVector v a) => (a -> b -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' f = ifoldr' (const f)
 
--- | \(O(n)\) Pure right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m, MVector v a) => (Int -> a -> b -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr f b0 v = stToPrim $ ifoldrM (\i a b -> return $ f i a b) b0 v
 
--- | \(O(n)\) Pure right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -848,21 +848,21 @@ ifoldr' :: (PrimMonad m, MVector v a) => (Int -> a -> b -> b) -> b -> v (PrimSta
 {-# INLINE ifoldr' #-}
 ifoldr' f b0 v = stToPrim $ ifoldrM' (\i a b -> return $ f i a b) b0 v
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m, MVector v a) => (b -> a -> m b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM f = ifoldM (\x _ -> f x)
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m, MVector v a) => (b -> a -> m b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' f = ifoldM' (\x _ -> f x)
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m, MVector v a) => (b -> Int -> a -> m b) -> b -> v (PrimState m) a -> m b
@@ -874,7 +874,7 @@ ifoldM f b0 v = loop 0 b0
                               loop (i + 1) =<< f b i a
     n = length v
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m, MVector v a) => (b -> Int -> a -> m b) -> b -> v (PrimState m) a -> m b
@@ -886,21 +886,21 @@ ifoldM' f b0 v = loop 0 b0
                                loop (i + 1) =<< f b i a
     n = length v
 
--- | \(O(n)\) Monadic right fold.
+-- | \(\mathcal{O}(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m, MVector v a) => (a -> b -> m b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM f = ifoldrM (const f)
 
--- | \(O(n)\) Monadic right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m, MVector v a) => (a -> b -> m b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' f = ifoldrM' (const f)
 
--- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m, MVector v a) => (Int -> a -> b -> m b) -> b -> v (PrimState m) a -> m b
@@ -912,7 +912,7 @@ ifoldrM f b0 v = loop (n-1) b0
                               loop (i - 1) =<< f i a b
     n = length v
 
--- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -386,7 +386,7 @@ drop n v = unsafeSlice (min m n') (max 0 (m - n')) v
     n' = max n 0
     m  = length v
 
--- | /O(1)/ Split the mutable vector into the first @n@ elements
+-- | \(O(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -486,7 +486,7 @@ replicateM :: (PrimMonad m, MVector v a) => Int -> m a -> m (v (PrimState m) a)
 {-# INLINE replicateM #-}
 replicateM n m = munstream (MBundle.replicateM n m)
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is negative)
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -495,7 +495,7 @@ generate :: (PrimMonad m, MVector v a) => Int -> (Int -> a) -> m (v (PrimState m
 {-# INLINE generate #-}
 generate n f = stToPrim $ generateM n (return . f)
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -761,21 +761,21 @@ forI_ v f = loop 0
            | otherwise = f i >> loop (i + 1)
     n = length v
 
--- | /O(n)/ Apply the monadic action to every element of the vector, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m, MVector v a) => (a -> m b) -> v (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ f v = forI_ v $ \i -> f =<< unsafeRead v i
 
--- | /O(n)/ Apply the monadic action to every element of the vector and its index, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
 --
 -- @since 0.12.3.0
 imapM_ :: (PrimMonad m, MVector v a) => (Int -> a -> m b) -> v (PrimState m) a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ f v = forI_ v $ \i -> f i =<< unsafeRead v i
 
--- | /O(n)/ Apply the monadic action to every element of the vector,
+-- | \(O(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -783,7 +783,7 @@ forM_ :: (PrimMonad m, MVector v a) => v (PrimState m) a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = flip mapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector
+-- | \(O(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -791,56 +791,56 @@ iforM_ :: (PrimMonad m, MVector v a) => v (PrimState m) a -> (Int -> a -> m b) -
 {-# INLINE iforM_ #-}
 iforM_ = flip imapM_
 
--- | /O(n)/ Pure left fold.
+-- | \(O(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m, MVector v a) => (b -> a -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl f = ifoldl (\b _ -> f b)
 
--- | /O(n)/ Pure left fold with strict accumulator.
+-- | \(O(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m, MVector v a) => (b -> a -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' f = ifoldl' (\b _ -> f b)
 
--- | /O(n)/ Pure left fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m, MVector v a) => (b -> Int -> a -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl f b0 v = stToPrim $ ifoldM (\b i a -> return $ f b i a) b0 v
 
--- | /O(n)/ Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m, MVector v a) => (b -> Int -> a -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' f b0 v = stToPrim $ ifoldM' (\b i a -> return $ f b i a) b0 v
 
--- | /O(n)/ Pure right fold.
+-- | \(O(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m, MVector v a) => (a -> b -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr f = ifoldr (const f)
 
--- | /O(n)/ Pure right fold with strict accumulator.
+-- | \(O(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m, MVector v a) => (a -> b -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' f = ifoldr' (const f)
 
--- | /O(n)/ Pure right fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m, MVector v a) => (Int -> a -> b -> b) -> b -> v (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr f b0 v = stToPrim $ ifoldrM (\i a b -> return $ f i a b) b0 v
 
--- | /O(n)/ Pure right fold with strict accumulator using a function applied
+-- | \(O(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -848,21 +848,21 @@ ifoldr' :: (PrimMonad m, MVector v a) => (Int -> a -> b -> b) -> b -> v (PrimSta
 {-# INLINE ifoldr' #-}
 ifoldr' f b0 v = stToPrim $ ifoldrM' (\i a b -> return $ f i a b) b0 v
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m, MVector v a) => (b -> a -> m b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM f = ifoldM (\x _ -> f x)
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m, MVector v a) => (b -> a -> m b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' f = ifoldM' (\x _ -> f x)
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m, MVector v a) => (b -> Int -> a -> m b) -> b -> v (PrimState m) a -> m b
@@ -874,7 +874,7 @@ ifoldM f b0 v = loop 0 b0
                               loop (i + 1) =<< f b i a
     n = length v
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m, MVector v a) => (b -> Int -> a -> m b) -> b -> v (PrimState m) a -> m b
@@ -886,21 +886,21 @@ ifoldM' f b0 v = loop 0 b0
                                loop (i + 1) =<< f b i a
     n = length v
 
--- | /O(n)/ Monadic right fold.
+-- | \(O(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m, MVector v a) => (a -> b -> m b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM f = ifoldrM (const f)
 
--- | /O(n)/ Monadic right fold with strict accumulator.
+-- | \(O(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m, MVector v a) => (a -> b -> m b) -> b -> v (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' f = ifoldrM' (const f)
 
--- | /O(n)/ Monadic right fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m, MVector v a) => (Int -> a -> b -> m b) -> b -> v (PrimState m) a -> m b
@@ -912,7 +912,7 @@ ifoldrM f b0 v = loop (n-1) b0
                               loop (i - 1) =<< f i a b
     n = length v
 
--- | /O(n)/ Monadic right fold with strict accumulator using a function applied
+-- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -250,7 +250,7 @@ drop :: Int -> MVector s a -> MVector s a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | /O(1)/ Split the mutable vector into the first @n@ elements
+-- | \(O(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -338,7 +338,7 @@ replicateM :: PrimMonad m => Int -> m a -> m (MVector (PrimState m) a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is negative)
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -347,7 +347,7 @@ generate :: (PrimMonad m) => Int -> (Int -> a) -> m (MVector (PrimState m) a)
 {-# INLINE generate #-}
 generate = G.generate
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -577,21 +577,21 @@ nextPermutation = G.nextPermutation
 -- Folds
 -- -----
 
--- | /O(n)/ Apply the monadic action to every element of the vector, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m) => (a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector and its index, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
 --
 -- @since 0.12.3.0
 imapM_ :: (PrimMonad m) => (Int -> a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector,
+-- | \(O(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -599,7 +599,7 @@ forM_ :: (PrimMonad m) => MVector (PrimState m) a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector
+-- | \(O(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -607,56 +607,56 @@ iforM_ :: (PrimMonad m) => MVector (PrimState m) a -> (Int -> a -> m b) -> m ()
 {-# INLINE iforM_ #-}
 iforM_ = G.iforM_
 
--- | /O(n)/ Pure left fold.
+-- | \(O(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | /O(n)/ Pure left fold with strict accumulator.
+-- | \(O(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | /O(n)/ Pure left fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | /O(n)/ Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | /O(n)/ Pure right fold.
+-- | \(O(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | /O(n)/ Pure right fold with strict accumulator.
+-- | \(O(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | /O(n)/ Pure right fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | /O(n)/ Pure right fold with strict accumulator using a function applied
+-- | \(O(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -664,56 +664,56 @@ ifoldr' :: (PrimMonad m) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | /O(n)/ Monadic right fold.
+-- | \(O(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM = G.foldrM
 
--- | /O(n)/ Monadic right fold with strict accumulator.
+-- | \(O(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' = G.foldrM'
 
--- | /O(n)/ Monadic right fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM #-}
 ifoldrM = G.ifoldrM
 
--- | /O(n)/ Monadic right fold with strict accumulator using a function applied
+-- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -724,7 +724,7 @@ ifoldrM' = G.ifoldrM'
 -- Conversions - Arrays
 -- -----------------------------
 
--- | /O(n)/ Make a copy of a mutable array to a new mutable vector.
+-- | \(O(n)\) Make a copy of a mutable array to a new mutable vector.
 --
 -- @since 0.12.2.0
 fromMutableArray :: PrimMonad m => MutableArray (PrimState m) a -> m (MVector (PrimState m) a)
@@ -733,7 +733,7 @@ fromMutableArray marr =
   let size = sizeofMutableArray marr
   in MVector 0 size `liftM` cloneMutableArray marr 0 size
 
--- | /O(n)/ Make a copy of a mutable vector into a new mutable array.
+-- | \(O(n)\) Make a copy of a mutable vector into a new mutable array.
 --
 -- @since 0.12.2.0
 toMutableArray :: PrimMonad m => MVector (PrimState m) a -> m (MutableArray (PrimState m) a)

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -250,7 +250,7 @@ drop :: Int -> MVector s a -> MVector s a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | \(O(1)\) Split the mutable vector into the first @n@ elements
+-- | \(\mathcal{O}(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -338,7 +338,7 @@ replicateM :: PrimMonad m => Int -> m a -> m (MVector (PrimState m) a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -347,7 +347,7 @@ generate :: (PrimMonad m) => Int -> (Int -> a) -> m (MVector (PrimState m) a)
 {-# INLINE generate #-}
 generate = G.generate
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -577,21 +577,21 @@ nextPermutation = G.nextPermutation
 -- Folds
 -- -----
 
--- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m) => (a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
 --
 -- @since 0.12.3.0
 imapM_ :: (PrimMonad m) => (Int -> a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector,
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -599,7 +599,7 @@ forM_ :: (PrimMonad m) => MVector (PrimState m) a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -607,56 +607,56 @@ iforM_ :: (PrimMonad m) => MVector (PrimState m) a -> (Int -> a -> m b) -> m ()
 {-# INLINE iforM_ #-}
 iforM_ = G.iforM_
 
--- | \(O(n)\) Pure left fold.
+-- | \(\mathcal{O}(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | \(O(n)\) Pure left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | \(O(n)\) Pure left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | \(O(n)\) Pure right fold.
+-- | \(\mathcal{O}(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | \(O(n)\) Pure right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | \(O(n)\) Pure right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | \(O(n)\) Pure right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -664,56 +664,56 @@ ifoldr' :: (PrimMonad m) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | \(O(n)\) Monadic right fold.
+-- | \(\mathcal{O}(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM = G.foldrM
 
--- | \(O(n)\) Monadic right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' = G.foldrM'
 
--- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM #-}
 ifoldrM = G.ifoldrM
 
--- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -724,7 +724,7 @@ ifoldrM' = G.ifoldrM'
 -- Conversions - Arrays
 -- -----------------------------
 
--- | \(O(n)\) Make a copy of a mutable array to a new mutable vector.
+-- | \(\mathcal{O}(n)\) Make a copy of a mutable array to a new mutable vector.
 --
 -- @since 0.12.2.0
 fromMutableArray :: PrimMonad m => MutableArray (PrimState m) a -> m (MVector (PrimState m) a)
@@ -733,7 +733,7 @@ fromMutableArray marr =
   let size = sizeofMutableArray marr
   in MVector 0 size `liftM` cloneMutableArray marr 0 size
 
--- | \(O(n)\) Make a copy of a mutable vector into a new mutable array.
+-- | \(\mathcal{O}(n)\) Make a copy of a mutable vector into a new mutable array.
 --
 -- @since 0.12.2.0
 toMutableArray :: PrimMonad m => MVector (PrimState m) a -> m (MutableArray (PrimState m) a)

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -197,7 +197,7 @@ import qualified GHC.Exts as Exts
 
 type role Vector nominal
 
--- | /O(1)/ Unsafely coerce an immutable vector from one element type to another,
+-- | \(O(1)\) Unsafely coerce an immutable vector from one element type to another,
 -- representationally equal type. The operation just changes the type of the
 -- underlying pointer and does not modify the elements.
 --
@@ -316,12 +316,12 @@ instance Prim a => Exts.IsList (Vector a) where
 -- Length
 -- ------
 
--- | /O(1)/ Yield the length of the vector.
+-- | \(O(1)\) Yield the length of the vector.
 length :: Prim a => Vector a -> Int
 {-# INLINE length #-}
 length = G.length
 
--- | /O(1)/ Test whether a vector is empty.
+-- | \(O(1)\) Test whether a vector is empty.
 null :: Prim a => Vector a -> Bool
 {-# INLINE null #-}
 null = G.null
@@ -339,27 +339,27 @@ null = G.null
 {-# INLINE (!?) #-}
 (!?) = (G.!?)
 
--- | /O(1)/ First element.
+-- | \(O(1)\) First element.
 head :: Prim a => Vector a -> a
 {-# INLINE head #-}
 head = G.head
 
--- | /O(1)/ Last element.
+-- | \(O(1)\) Last element.
 last :: Prim a => Vector a -> a
 {-# INLINE last #-}
 last = G.last
 
--- | /O(1)/ Unsafe indexing without bounds checking.
+-- | \(O(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Prim a => Vector a -> Int -> a
 {-# INLINE unsafeIndex #-}
 unsafeIndex = G.unsafeIndex
 
--- | /O(1)/ First element, without checking if the vector is empty.
+-- | \(O(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Prim a => Vector a -> a
 {-# INLINE unsafeHead #-}
 unsafeHead = G.unsafeHead
 
--- | /O(1)/ Last element, without checking if the vector is empty.
+-- | \(O(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Prim a => Vector a -> a
 {-# INLINE unsafeLast #-}
 unsafeLast = G.unsafeLast
@@ -367,7 +367,7 @@ unsafeLast = G.unsafeLast
 -- Monadic indexing
 -- ----------------
 
--- | /O(1)/ Indexing in a monad.
+-- | \(O(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -389,31 +389,31 @@ indexM :: (Prim a, Monad m) => Vector a -> Int -> m a
 {-# INLINE indexM #-}
 indexM = G.indexM
 
--- | /O(1)/ First element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (Prim a, Monad m) => Vector a -> m a
 {-# INLINE headM #-}
 headM = G.headM
 
--- | /O(1)/ Last element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (Prim a, Monad m) => Vector a -> m a
 {-# INLINE lastM #-}
 lastM = G.lastM
 
--- | /O(1)/ Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (Prim a, Monad m) => Vector a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
 unsafeIndexM = G.unsafeIndexM
 
--- | /O(1)/ First element in a monad, without checking for empty vectors.
+-- | \(O(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (Prim a, Monad m) => Vector a -> m a
 {-# INLINE unsafeHeadM #-}
 unsafeHeadM = G.unsafeHeadM
 
--- | /O(1)/ Last element in a monad, without checking for empty vectors.
+-- | \(O(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (Prim a, Monad m) => Vector a -> m a
 {-# INLINE unsafeLastM #-}
@@ -422,7 +422,7 @@ unsafeLastM = G.unsafeLastM
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | /O(1)/ Yield a slice of the vector without copying it. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: Prim a
       => Int   -- ^ @i@ starting index
@@ -432,31 +432,31 @@ slice :: Prim a
 {-# INLINE slice #-}
 slice = G.slice
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Prim a => Vector a -> Vector a
 {-# INLINE init #-}
 init = G.init
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Prim a => Vector a -> Vector a
 {-# INLINE tail #-}
 tail = G.tail
 
--- | /O(1)/ Yield at the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield at the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Prim a => Int -> Vector a -> Vector a
 {-# INLINE take #-}
 take = G.take
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Prim a => Int -> Vector a -> Vector a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | /O(1)/ Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -466,7 +466,7 @@ splitAt :: Prim a => Int -> Vector a -> (Vector a, Vector a)
 {-# INLINE splitAt #-}
 splitAt = G.splitAt
 
--- | /O(1)/ Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -474,7 +474,7 @@ uncons :: Prim a => Vector a -> Maybe (a, Vector a)
 {-# INLINE uncons #-}
 uncons = G.uncons
 
--- | /O(1)/ Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -482,7 +482,7 @@ unsnoc :: Prim a => Vector a -> Maybe (Vector a, a)
 {-# INLINE unsnoc #-}
 unsnoc = G.unsnoc
 
--- | /O(1)/ Yield a slice of the vector without copying. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Prim a => Int   -- ^ @i@ starting index
                        -> Int   -- ^ @n@ length
@@ -491,25 +491,25 @@ unsafeSlice :: Prim a => Int   -- ^ @i@ starting index
 {-# INLINE unsafeSlice #-}
 unsafeSlice = G.unsafeSlice
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Prim a => Vector a -> Vector a
 {-# INLINE unsafeInit #-}
 unsafeInit = G.unsafeInit
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Prim a => Vector a -> Vector a
 {-# INLINE unsafeTail #-}
 unsafeTail = G.unsafeTail
 
--- | /O(1)/ Yield the first @n@ elements without copying. The vector must
+-- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Prim a => Int -> Vector a -> Vector a
 {-# INLINE unsafeTake #-}
 unsafeTake = G.unsafeTake
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Prim a => Int -> Vector a -> Vector a
 {-# INLINE unsafeDrop #-}
@@ -518,28 +518,28 @@ unsafeDrop = G.unsafeDrop
 -- Initialisation
 -- --------------
 
--- | /O(1)/ The empty vector.
+-- | \(O(1)\) The empty vector.
 empty :: Prim a => Vector a
 {-# INLINE empty #-}
 empty = G.empty
 
--- | /O(1)/ A vector with exactly one element.
+-- | \(O(1)\) A vector with exactly one element.
 singleton :: Prim a => a -> Vector a
 {-# INLINE singleton #-}
 singleton = G.singleton
 
--- | /O(n)/ A vector of the given length with the same value in each position.
+-- | \(O(n)\) A vector of the given length with the same value in each position.
 replicate :: Prim a => Int -> a -> Vector a
 {-# INLINE replicate #-}
 replicate = G.replicate
 
--- | /O(n)/ Construct a vector of the given length by applying the function to
+-- | \(O(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Prim a => Int -> (Int -> a) -> Vector a
 {-# INLINE generate #-}
 generate = G.generate
 
--- | /O(n)/ Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -561,7 +561,7 @@ iterateN = G.iterateN
 -- Unfolding
 -- ---------
 
--- | /O(n)/ Construct a vector by repeatedly applying the generator function
+-- | \(O(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -571,7 +571,7 @@ unfoldr :: Prim a => (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldr #-}
 unfoldr = G.unfoldr
 
--- | /O(n)/ Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -580,7 +580,7 @@ unfoldrN :: Prim a => Int -> (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldrN #-}
 unfoldrN = G.unfoldrN
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -591,7 +591,7 @@ unfoldrExactN :: (Prim a) => Int -> (b -> (a, b)) -> b -> Vector a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = G.unfoldrExactN
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -599,7 +599,7 @@ unfoldrM :: (Monad m, Prim a) => (b -> m (Maybe (a, b))) -> b -> m (Vector a)
 {-# INLINE unfoldrM #-}
 unfoldrM = G.unfoldrM
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -607,7 +607,7 @@ unfoldrNM :: (Monad m, Prim a) => Int -> (b -> m (Maybe (a, b))) -> b -> m (Vect
 {-# INLINE unfoldrNM #-}
 unfoldrNM = G.unfoldrNM
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -616,7 +616,7 @@ unfoldrExactNM :: (Monad m, Prim a) => Int -> (b -> m (a, b)) -> b -> m (Vector 
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM = G.unfoldrExactNM
 
--- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
+-- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -624,7 +624,7 @@ constructN :: Prim a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
 constructN = G.constructN
 
--- | /O(n)/ Construct a vector with @n@ elements from right to left by
+-- | \(O(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -636,7 +636,7 @@ constructrN = G.constructrN
 -- Enumeration
 -- -----------
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -644,7 +644,7 @@ enumFromN :: (Prim a, Num a) => a -> Int -> Vector a
 {-# INLINE enumFromN #-}
 enumFromN = G.enumFromN
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -652,7 +652,7 @@ enumFromStepN :: (Prim a, Num a) => a -> a -> Int -> Vector a
 {-# INLINE enumFromStepN #-}
 enumFromStepN = G.enumFromStepN
 
--- | /O(n)/ Enumerate values from @x@ to @y@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -660,7 +660,7 @@ enumFromTo :: (Prim a, Enum a) => a -> a -> Vector a
 {-# INLINE enumFromTo #-}
 enumFromTo = G.enumFromTo
 
--- | /O(n)/ Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -671,23 +671,23 @@ enumFromThenTo = G.enumFromThenTo
 -- Concatenation
 -- -------------
 
--- | /O(n)/ Prepend an element.
+-- | \(O(n)\) Prepend an element.
 cons :: Prim a => a -> Vector a -> Vector a
 {-# INLINE cons #-}
 cons = G.cons
 
--- | /O(n)/ Append an element.
+-- | \(O(n)\) Append an element.
 snoc :: Prim a => Vector a -> a -> Vector a
 {-# INLINE snoc #-}
 snoc = G.snoc
 
 infixr 5 ++
--- | /O(m+n)/ Concatenate two vectors.
+-- | \(O(m+n)\) Concatenate two vectors.
 (++) :: Prim a => Vector a -> Vector a -> Vector a
 {-# INLINE (++) #-}
 (++) = (G.++)
 
--- | /O(n)/ Concatenate all vectors in the list.
+-- | \(O(n)\) Concatenate all vectors in the list.
 concat :: Prim a => [Vector a] -> Vector a
 {-# INLINE concat #-}
 concat = G.concat
@@ -695,19 +695,19 @@ concat = G.concat
 -- Monadic initialisation
 -- ----------------------
 
--- | /O(n)/ Execute the monadic action the given number of times and store the
+-- | \(O(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: (Monad m, Prim a) => Int -> m a -> m (Vector a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | /O(n)/ Construct a vector of the given length by applying the monadic
+-- | \(O(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: (Monad m, Prim a) => Int -> (Int -> m a) -> m (Vector a)
 {-# INLINE generateM #-}
 generateM = G.generateM
 
--- | /O(n)/ Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -736,7 +736,7 @@ createT p = G.createT p
 -- Restricting memory usage
 -- ------------------------
 
--- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
+-- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -753,7 +753,7 @@ force = G.force
 -- Bulk updates
 -- ------------
 
--- | /O(m+n)/ For each pair @(i,a)@ from the list of index/value pairs,
+-- | \(O(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -764,7 +764,7 @@ force = G.force
 {-# INLINE (//) #-}
 (//) = (G.//)
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -791,7 +791,7 @@ unsafeUpdate_ = G.unsafeUpdate_
 -- Accumulations
 -- -------------
 
--- | /O(m+n)/ For each pair @(i,b)@ from the list, replace the vector element
+-- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -807,7 +807,7 @@ accum :: Prim a
 {-# INLINE accum #-}
 accum = G.accum
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -837,12 +837,12 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- Permutations
 -- ------------
 
--- | /O(n)/ Reverse a vector.
+-- | \(O(n)\) Reverse a vector.
 reverse :: Prim a => Vector a -> Vector a
 {-# INLINE reverse #-}
 reverse = G.reverse
 
--- | /O(n)/ Yield the vector obtained by replacing each element @i@ of the
+-- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -873,12 +873,12 @@ modify p = G.modify p
 -- Mapping
 -- -------
 
--- | /O(n)/ Map a function over a vector.
+-- | \(O(n)\) Map a function over a vector.
 map :: (Prim a, Prim b) => (a -> b) -> Vector a -> Vector b
 {-# INLINE map #-}
 map = G.map
 
--- | /O(n)/ Apply a function to every element of a vector and its index.
+-- | \(O(n)\) Apply a function to every element of a vector and its index.
 imap :: (Prim a, Prim b) => (Int -> a -> b) -> Vector a -> Vector b
 {-# INLINE imap #-}
 imap = G.imap
@@ -891,13 +891,13 @@ concatMap = G.concatMap
 -- Monadic mapping
 -- ---------------
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: (Monad m, Prim a, Prim b) => (a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE mapM #-}
 mapM = G.mapM
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 --
 -- @since 0.12.2.0
@@ -906,13 +906,13 @@ imapM :: (Monad m, Prim a, Prim b)
 {-# INLINE imapM #-}
 imapM = G.imapM
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: (Monad m, Prim a) => (a -> m b) -> Vector a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 --
 -- @since 0.12.2.0
@@ -920,19 +920,19 @@ imapM_ :: (Monad m, Prim a) => (Int -> a -> m b) -> Vector a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Prim a, Prim b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, Prim a) => Vector a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -940,7 +940,7 @@ iforM :: (Monad m, Prim a, Prim b) => Vector a -> (Int -> a -> m b) -> m (Vector
 {-# INLINE iforM #-}
 iforM = G.iforM
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -951,7 +951,7 @@ iforM_ = G.iforM_
 -- Zipping
 -- -------
 
--- | /O(min(m,n))/ Zip two vectors with the given function.
+-- | \(O(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (Prim a, Prim b, Prim c)
         => (a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE zipWith #-}
@@ -985,7 +985,7 @@ zipWith6 :: (Prim a, Prim b, Prim c, Prim d, Prim e,
 {-# INLINE zipWith6 #-}
 zipWith6 = G.zipWith6
 
--- | /O(min(m,n))/ Zip two vectors with a function that also takes the
+-- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Prim a, Prim b, Prim c)
          => (Int -> a -> b -> c) -> Vector a -> Vector b -> Vector c
@@ -1024,14 +1024,14 @@ izipWith6 = G.izipWith6
 -- Monadic zipping
 -- ---------------
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and yield a
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: (Monad m, Prim a, Prim b, Prim c)
          => (a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE zipWithM #-}
 zipWithM = G.zipWithM
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 --
 -- @since 0.12.2.0
@@ -1040,14 +1040,14 @@ izipWithM :: (Monad m, Prim a, Prim b, Prim c)
 {-# INLINE izipWithM #-}
 izipWithM = G.izipWithM
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and ignore the
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: (Monad m, Prim a, Prim b)
           => (a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ = G.zipWithM_
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 --
 -- @since 0.12.2.0
@@ -1059,18 +1059,18 @@ izipWithM_ = G.izipWithM_
 -- Filtering
 -- ---------
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate.
 filter :: Prim a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate which is applied to
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: Prim a => (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | /O(n)/ Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1081,22 +1081,22 @@ uniq :: (Prim a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq
 
--- | /O(n)/ Map the values and collect the 'Just' results.
+-- | \(O(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (Prim a, Prim b) => (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
--- | /O(n)/ Map the indices/values and collect the 'Just' results.
+-- | \(O(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Prim a, Prim b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
 
--- | /O(n)/ Drop all elements that do not satisfy the monadic predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: (Monad m, Prim a) => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
 
--- | /O(n)/ Apply the monadic function to each element of the vector and
+-- | \(O(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1106,7 +1106,7 @@ mapMaybeM
 {-# INLINE mapMaybeM #-}
 mapMaybeM = G.mapMaybeM
 
--- | /O(n)/ Apply the monadic function to each element of the vector and its index.
+-- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1116,14 +1116,14 @@ imapMaybeM
 {-# INLINE imapMaybeM #-}
 imapMaybeM = G.imapMaybeM
 
--- | /O(n)/ Yield the longest prefix of elements satisfying the predicate.
+-- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: Prim a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE takeWhile #-}
 takeWhile = G.takeWhile
 
--- | /O(n)/ Drop the longest prefix of elements that satisfy the predicate
+-- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Prim a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
@@ -1132,7 +1132,7 @@ dropWhile = G.dropWhile
 -- Parititioning
 -- -------------
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1140,7 +1140,7 @@ partition :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE partition #-}
 partition = G.partition
 
--- | /O(n)/ Split the vector into two parts, the first one containing the
+-- | \(O(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1149,7 +1149,7 @@ partitionWith :: (Prim a, Prim b, Prim c) => (a -> Either b c) -> Vector a -> (V
 {-# INLINE partitionWith #-}
 partitionWith = G.partitionWith
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1157,19 +1157,19 @@ unstablePartition :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE unstablePartition #-}
 unstablePartition = G.unstablePartition
 
--- | /O(n)/ Split the vector into the longest prefix of elements that satisfy
+-- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE span #-}
 span = G.span
 
--- | /O(n)/ Split the vector into the longest prefix of elements that do not
+-- | \(O(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE break #-}
 break = G.break
 
--- | /O(n)/ Split a vector into a list of slices, using a predicate function.
+-- | \(O(n)\) Split a vector into a list of slices, using a predicate function.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1189,7 +1189,7 @@ groupBy :: Prim a => (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
 
--- | /O(n)/ Split a vector into a list of slices of the input vector.
+-- | \(O(n)\) Split a vector into a list of slices of the input vector.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1213,43 +1213,43 @@ group = G.groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | /O(n)/ Check if the vector contains an element.
+-- | \(O(n)\) Check if the vector contains an element.
 elem :: (Prim a, Eq a) => a -> Vector a -> Bool
 {-# INLINE elem #-}
 elem = G.elem
 
 infix 4 `notElem`
--- | /O(n)/ Check if the vector does not contain an element (inverse of 'elem').
+-- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: (Prim a, Eq a) => a -> Vector a -> Bool
 {-# INLINE notElem #-}
 notElem = G.notElem
 
--- | /O(n)/ Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: Prim a => (a -> Bool) -> Vector a -> Maybe a
 {-# INLINE find #-}
 find = G.find
 
--- | /O(n)/ Yield 'Just' the index of the first element matching the predicate
+-- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: Prim a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
 
--- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
+-- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: Prim a => (a -> Bool) -> Vector a -> Vector Int
 {-# INLINE findIndices #-}
 findIndices = G.findIndices
 
--- | /O(n)/ Yield 'Just' the index of the first occurrence of the given element or
+-- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: (Prim a, Eq a) => a -> Vector a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex = G.elemIndex
 
--- | /O(n)/ Yield the indices of all occurrences of the given element in
+-- | \(O(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: (Prim a, Eq a) => a -> Vector a -> Vector Int
 {-# INLINE elemIndices #-}
@@ -1258,69 +1258,69 @@ elemIndices = G.elemIndices
 -- Folding
 -- -------
 
--- | /O(n)/ Left fold.
+-- | \(O(n)\) Left fold.
 foldl :: Prim b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | /O(n)/ Left fold on non-empty vectors.
+-- | \(O(n)\) Left fold on non-empty vectors.
 foldl1 :: Prim a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1 #-}
 foldl1 = G.foldl1
 
--- | /O(n)/ Left fold with strict accumulator.
+-- | \(O(n)\) Left fold with strict accumulator.
 foldl' :: Prim b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | /O(n)/ Left fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: Prim a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1' #-}
 foldl1' = G.foldl1'
 
--- | /O(n)/ Right fold.
+-- | \(O(n)\) Right fold.
 foldr :: Prim a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | /O(n)/ Right fold on non-empty vectors.
+-- | \(O(n)\) Right fold on non-empty vectors.
 foldr1 :: Prim a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1 #-}
 foldr1 = G.foldr1
 
--- | /O(n)/ Right fold with a strict accumulator.
+-- | \(O(n)\) Right fold with a strict accumulator.
 foldr' :: Prim a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | /O(n)/ Right fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: Prim a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1' #-}
 foldr1' = G.foldr1'
 
--- | /O(n)/ Left fold using a function applied to each element and its index.
+-- | \(O(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: Prim b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | /O(n)/ Left fold with strict accumulator using a function applied to each element
+-- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: Prim b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | /O(n)/ Right fold using a function applied to each element and its index.
+-- | \(O(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: Prim a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | /O(n)/ Right fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: Prim a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | /O(n)/ Map each element of the structure to a monoid and combine
+-- | \(O(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type cless. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1331,7 +1331,7 @@ foldMap :: (Monoid m, Prim a) => (a -> m) -> Vector a -> m
 {-# INLINE foldMap #-}
 foldMap = G.foldMap
 
--- | /O(n)/ Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1344,7 +1344,7 @@ foldMap' = G.foldMap'
 -- Specialised folds
 -- -----------------
 
--- | /O(n)/ Check if all elements satisfy the predicate.
+-- | \(O(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1359,7 +1359,7 @@ all :: Prim a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE all #-}
 all = G.all
 
--- | /O(n)/ Check if any element satisfies the predicate.
+-- | \(O(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1374,7 +1374,7 @@ any :: Prim a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE any #-}
 any = G.any
 
--- | /O(n)/ Compute the sum of the elements.
+-- | \(O(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1387,7 +1387,7 @@ sum :: (Prim a, Num a) => Vector a -> a
 {-# INLINE sum #-}
 sum = G.sum
 
--- | /O(n)/ Compute the product of the elements.
+-- | \(O(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1400,7 +1400,7 @@ product :: (Prim a, Num a) => Vector a -> a
 {-# INLINE product #-}
 product = G.product
 
--- | /O(n)/ Yield the maximum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1412,7 +1412,7 @@ maximum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | /O(n)/ Yield the maximum element of the vector according to the
+-- | \(O(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1420,14 +1420,14 @@ maximumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
--- | /O(n)/ Yield the maximum element of the vector by comparing the results
+-- | \(O(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 maximumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
 
--- | /O(n)/ Yield the minimum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1439,40 +1439,40 @@ minimum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | /O(n)/ Yield the minimum element of the vector according to the
+-- | \(O(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 minimumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
 
--- | /O(n)/ Yield the minimum element of the vector by comparing the results
+-- | \(O(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 minimumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
 
--- | /O(n)/ Yield the index of the maximum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (Prim a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | /O(n)/ Yield the index of the maximum element of the vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 maxIndexBy :: Prim a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
 
--- | /O(n)/ Yield the index of the minimum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (Prim a, Ord a) => Vector a -> Int
 {-# INLINE minIndex #-}
 minIndex = G.minIndex
 
--- | /O(n)/ Yield the index of the minimum element of the vector according to
+-- | \(O(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 minIndexBy :: Prim a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE minIndexBy #-}
@@ -1481,29 +1481,29 @@ minIndexBy = G.minIndexBy
 -- Monadic folds
 -- -------------
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 foldM :: (Monad m, Prim b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.2.0
 ifoldM :: (Monad m, Prim b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | /O(n)/ Monadic fold over non-empty vectors.
+-- | \(O(n)\) Monadic fold over non-empty vectors.
 fold1M :: (Monad m, Prim a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M #-}
 fold1M = G.fold1M
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 foldM' :: (Monad m, Prim b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 --
 -- @since 0.12.2.0
@@ -1511,17 +1511,17 @@ ifoldM' :: (Monad m, Prim b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator.
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: (Monad m, Prim a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M' #-}
 fold1M' = G.fold1M'
 
--- | /O(n)/ Monadic fold that discards the result.
+-- | \(O(n)\) Monadic fold that discards the result.
 foldM_ :: (Monad m, Prim b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ = G.foldM_
 
--- | /O(n)/ Monadic fold that discards the result using a function applied to
+-- | \(O(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 --
 -- @since 0.12.2.0
@@ -1529,17 +1529,17 @@ ifoldM_ :: (Monad m, Prim b) => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM_ #-}
 ifoldM_ = G.ifoldM_
 
--- | /O(n)/ Monadic fold over non-empty vectors that discards the result.
+-- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: (Monad m, Prim a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ = G.fold1M_
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result.
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: (Monad m, Prim b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ = G.foldM'_
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 --
 -- @since 0.12.2.0
@@ -1548,7 +1548,7 @@ ifoldM'_ :: (Monad m, Prim b)
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ = G.ifoldM'_
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: (Monad m, Prim a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -1557,7 +1557,7 @@ fold1M'_ = G.fold1M'_
 -- Scans
 -- -----
 
--- | /O(n)/ Left-to-right prescan.
+-- | \(O(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -1572,12 +1572,12 @@ prescanl :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl #-}
 prescanl = G.prescanl
 
--- | /O(n)/ Left-to-right prescan with strict accumulator.
+-- | \(O(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl' #-}
 prescanl' = G.prescanl'
 
--- | /O(n)/ Left-to-right postscan.
+-- | \(O(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -1592,12 +1592,12 @@ postscanl :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl #-}
 postscanl = G.postscanl
 
--- | /O(n)/ Left-to-right postscan with strict accumulator.
+-- | \(O(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl' #-}
 postscanl' = G.postscanl'
 
--- | /O(n)/ Left-to-right scan.
+-- | \(O(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -1612,19 +1612,19 @@ scanl :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl #-}
 scanl = G.scanl
 
--- | /O(n)/ Left-to-right scan with strict accumulator.
+-- | \(O(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl' #-}
 scanl' = G.scanl'
 
--- | /O(n)/ Left-to-right scan over a vector with its index.
+-- | \(O(n)\) Left-to-right scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanl :: (Prim a, Prim b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl #-}
 iscanl = G.iscanl
 
--- | /O(n)/ Left-to-right scan over a vector (strictly) with its index.
+-- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanl' :: (Prim a, Prim b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
@@ -1632,7 +1632,7 @@ iscanl' :: (Prim a, Prim b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 iscanl' = G.iscanl'
 
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -1653,7 +1653,7 @@ scanl1 :: Prim a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1 #-}
 scanl1 = G.scanl1
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1670,7 +1670,7 @@ scanl1' :: Prim a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1' #-}
 scanl1' = G.scanl1'
 
--- | /O(n)/ Right-to-left prescan.
+-- | \(O(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -1679,46 +1679,46 @@ prescanr :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr #-}
 prescanr = G.prescanr
 
--- | /O(n)/ Right-to-left prescan with strict accumulator.
+-- | \(O(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr' #-}
 prescanr' = G.prescanr'
 
--- | /O(n)/ Right-to-left postscan.
+-- | \(O(n)\) Right-to-left postscan.
 postscanr :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr #-}
 postscanr = G.postscanr
 
--- | /O(n)/ Right-to-left postscan with strict accumulator.
+-- | \(O(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr' #-}
 postscanr' = G.postscanr'
 
--- | /O(n)/ Right-to-left scan.
+-- | \(O(n)\) Right-to-left scan.
 scanr :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr #-}
 scanr = G.scanr
 
--- | /O(n)/ Right-to-left scan with strict accumulator.
+-- | \(O(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr' #-}
 scanr' = G.scanr'
 
--- | /O(n)/ Right-to-left scan over a vector with its index.
+-- | \(O(n)\) Right-to-left scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanr :: (Prim a, Prim b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr #-}
 iscanr = G.iscanr
 
--- | /O(n)/ Right-to-left scan over a vector (strictly) with its index.
+-- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanr' :: (Prim a, Prim b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr' #-}
 iscanr' = G.iscanr'
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector.
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1735,7 +1735,7 @@ scanr1 :: Prim a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanr1 #-}
 scanr1 = G.scanr1
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector with a strict
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -1756,7 +1756,7 @@ scanr1' = G.scanr1'
 -- Comparisons
 -- ------------------------
 
--- | /O(n)/ Check if two vectors are equal using the supplied equality
+-- | \(O(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 --
 -- @since 0.12.2.0
@@ -1764,7 +1764,7 @@ eqBy :: (Prim a, Prim b) => (a -> b -> Bool) -> Vector a -> Vector b -> Bool
 {-# INLINE eqBy #-}
 eqBy = G.eqBy
 
--- | /O(n)/ Compare two vectors using the supplied comparison function for
+-- | \(O(n)\) Compare two vectors using the supplied comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == compare
@@ -1776,17 +1776,17 @@ cmpBy = G.cmpBy
 -- Conversions - Lists
 -- ------------------------
 
--- | /O(n)/ Convert a vector to a list.
+-- | \(O(n)\) Convert a vector to a list.
 toList :: Prim a => Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | /O(n)/ Convert a list to a vector.
+-- | \(O(n)\) Convert a list to a vector.
 fromList :: Prim a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -1806,7 +1806,7 @@ fromListN = G.fromListN
 -- Conversions - Unsafe casts
 -- --------------------------
 
--- | /O(1)/ Unsafely cast a vector from one element type to another.
+-- | \(O(1)\) Unsafely cast a vector from one element type to another.
 -- This operation just changes the type of the vector and does not
 -- modify the elements.
 --
@@ -1822,18 +1822,18 @@ unsafeCast (Vector o n ba)
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | /O(1)/ Unsafely convert a mutable vector to an immutable one without
+-- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = G.unsafeFreeze
 
--- | /O(n)/ Yield an immutable copy of the mutable vector.
+-- | \(O(n)\) Yield an immutable copy of the mutable vector.
 freeze :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE freeze #-}
 freeze = G.freeze
 
--- | /O(1)/ Unsafely convert an immutable vector to a mutable one
+-- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -1862,19 +1862,19 @@ unsafeThaw :: (Prim a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw
 
--- | /O(n)/ Yield a mutable copy of an immutable vector.
+-- | \(O(n)\) Yield a mutable copy of an immutable vector.
 thaw :: (Prim a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE thaw #-}
 thaw = G.thaw
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy
   :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy = G.unsafeCopy
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -329,12 +329,12 @@ null = G.null
 -- Indexing
 -- --------
 
--- | O(1) Indexing.
+-- | \(O(1)\) Indexing.
 (!) :: Prim a => Vector a -> Int -> a
 {-# INLINE (!) #-}
 (!) = (G.!)
 
--- | O(1) Safe indexing.
+-- | \(O(1)\) Safe indexing.
 (!?) :: Prim a => Vector a -> Int -> Maybe a
 {-# INLINE (!?) #-}
 (!?) = (G.!?)

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -197,7 +197,7 @@ import qualified GHC.Exts as Exts
 
 type role Vector nominal
 
--- | \(O(1)\) Unsafely coerce an immutable vector from one element type to another,
+-- | \(\mathcal{O}(1)\) Unsafely coerce an immutable vector from one element type to another,
 -- representationally equal type. The operation just changes the type of the
 -- underlying pointer and does not modify the elements.
 --
@@ -316,12 +316,12 @@ instance Prim a => Exts.IsList (Vector a) where
 -- Length
 -- ------
 
--- | \(O(1)\) Yield the length of the vector.
+-- | \(\mathcal{O}(1)\) Yield the length of the vector.
 length :: Prim a => Vector a -> Int
 {-# INLINE length #-}
 length = G.length
 
--- | \(O(1)\) Test whether a vector is empty.
+-- | \(\mathcal{O}(1)\) Test whether a vector is empty.
 null :: Prim a => Vector a -> Bool
 {-# INLINE null #-}
 null = G.null
@@ -329,37 +329,37 @@ null = G.null
 -- Indexing
 -- --------
 
--- | \(O(1)\) Indexing.
+-- | \(\mathcal{O}(1)\) Indexing.
 (!) :: Prim a => Vector a -> Int -> a
 {-# INLINE (!) #-}
 (!) = (G.!)
 
--- | \(O(1)\) Safe indexing.
+-- | \(\mathcal{O}(1)\) Safe indexing.
 (!?) :: Prim a => Vector a -> Int -> Maybe a
 {-# INLINE (!?) #-}
 (!?) = (G.!?)
 
--- | \(O(1)\) First element.
+-- | \(\mathcal{O}(1)\) First element.
 head :: Prim a => Vector a -> a
 {-# INLINE head #-}
 head = G.head
 
--- | \(O(1)\) Last element.
+-- | \(\mathcal{O}(1)\) Last element.
 last :: Prim a => Vector a -> a
 {-# INLINE last #-}
 last = G.last
 
--- | \(O(1)\) Unsafe indexing without bounds checking.
+-- | \(\mathcal{O}(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Prim a => Vector a -> Int -> a
 {-# INLINE unsafeIndex #-}
 unsafeIndex = G.unsafeIndex
 
--- | \(O(1)\) First element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Prim a => Vector a -> a
 {-# INLINE unsafeHead #-}
 unsafeHead = G.unsafeHead
 
--- | \(O(1)\) Last element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Prim a => Vector a -> a
 {-# INLINE unsafeLast #-}
 unsafeLast = G.unsafeLast
@@ -367,7 +367,7 @@ unsafeLast = G.unsafeLast
 -- Monadic indexing
 -- ----------------
 
--- | \(O(1)\) Indexing in a monad.
+-- | \(\mathcal{O}(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -389,31 +389,31 @@ indexM :: (Prim a, Monad m) => Vector a -> Int -> m a
 {-# INLINE indexM #-}
 indexM = G.indexM
 
--- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (Prim a, Monad m) => Vector a -> m a
 {-# INLINE headM #-}
 headM = G.headM
 
--- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (Prim a, Monad m) => Vector a -> m a
 {-# INLINE lastM #-}
 lastM = G.lastM
 
--- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (Prim a, Monad m) => Vector a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
 unsafeIndexM = G.unsafeIndexM
 
--- | \(O(1)\) First element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (Prim a, Monad m) => Vector a -> m a
 {-# INLINE unsafeHeadM #-}
 unsafeHeadM = G.unsafeHeadM
 
--- | \(O(1)\) Last element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (Prim a, Monad m) => Vector a -> m a
 {-# INLINE unsafeLastM #-}
@@ -422,7 +422,7 @@ unsafeLastM = G.unsafeLastM
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: Prim a
       => Int   -- ^ @i@ starting index
@@ -432,31 +432,31 @@ slice :: Prim a
 {-# INLINE slice #-}
 slice = G.slice
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Prim a => Vector a -> Vector a
 {-# INLINE init #-}
 init = G.init
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Prim a => Vector a -> Vector a
 {-# INLINE tail #-}
 tail = G.tail
 
--- | \(O(1)\) Yield at the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield at the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Prim a => Int -> Vector a -> Vector a
 {-# INLINE take #-}
 take = G.take
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Prim a => Int -> Vector a -> Vector a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -466,7 +466,7 @@ splitAt :: Prim a => Int -> Vector a -> (Vector a, Vector a)
 {-# INLINE splitAt #-}
 splitAt = G.splitAt
 
--- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -474,7 +474,7 @@ uncons :: Prim a => Vector a -> Maybe (a, Vector a)
 {-# INLINE uncons #-}
 uncons = G.uncons
 
--- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -482,7 +482,7 @@ unsnoc :: Prim a => Vector a -> Maybe (Vector a, a)
 {-# INLINE unsnoc #-}
 unsnoc = G.unsnoc
 
--- | \(O(1)\) Yield a slice of the vector without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Prim a => Int   -- ^ @i@ starting index
                        -> Int   -- ^ @n@ length
@@ -491,25 +491,25 @@ unsafeSlice :: Prim a => Int   -- ^ @i@ starting index
 {-# INLINE unsafeSlice #-}
 unsafeSlice = G.unsafeSlice
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Prim a => Vector a -> Vector a
 {-# INLINE unsafeInit #-}
 unsafeInit = G.unsafeInit
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Prim a => Vector a -> Vector a
 {-# INLINE unsafeTail #-}
 unsafeTail = G.unsafeTail
 
--- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Prim a => Int -> Vector a -> Vector a
 {-# INLINE unsafeTake #-}
 unsafeTake = G.unsafeTake
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Prim a => Int -> Vector a -> Vector a
 {-# INLINE unsafeDrop #-}
@@ -518,28 +518,28 @@ unsafeDrop = G.unsafeDrop
 -- Initialisation
 -- --------------
 
--- | \(O(1)\) The empty vector.
+-- | \(\mathcal{O}(1)\) The empty vector.
 empty :: Prim a => Vector a
 {-# INLINE empty #-}
 empty = G.empty
 
--- | \(O(1)\) A vector with exactly one element.
+-- | \(\mathcal{O}(1)\) A vector with exactly one element.
 singleton :: Prim a => a -> Vector a
 {-# INLINE singleton #-}
 singleton = G.singleton
 
--- | \(O(n)\) A vector of the given length with the same value in each position.
+-- | \(\mathcal{O}(n)\) A vector of the given length with the same value in each position.
 replicate :: Prim a => Int -> a -> Vector a
 {-# INLINE replicate #-}
 replicate = G.replicate
 
--- | \(O(n)\) Construct a vector of the given length by applying the function to
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Prim a => Int -> (Int -> a) -> Vector a
 {-# INLINE generate #-}
 generate = G.generate
 
--- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -561,7 +561,7 @@ iterateN = G.iterateN
 -- Unfolding
 -- ---------
 
--- | \(O(n)\) Construct a vector by repeatedly applying the generator function
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -571,7 +571,7 @@ unfoldr :: Prim a => (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldr #-}
 unfoldr = G.unfoldr
 
--- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -580,7 +580,7 @@ unfoldrN :: Prim a => Int -> (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldrN #-}
 unfoldrN = G.unfoldrN
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -591,7 +591,7 @@ unfoldrExactN :: (Prim a) => Int -> (b -> (a, b)) -> b -> Vector a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = G.unfoldrExactN
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -599,7 +599,7 @@ unfoldrM :: (Monad m, Prim a) => (b -> m (Maybe (a, b))) -> b -> m (Vector a)
 {-# INLINE unfoldrM #-}
 unfoldrM = G.unfoldrM
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -607,7 +607,7 @@ unfoldrNM :: (Monad m, Prim a) => Int -> (b -> m (Maybe (a, b))) -> b -> m (Vect
 {-# INLINE unfoldrNM #-}
 unfoldrNM = G.unfoldrNM
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -616,7 +616,7 @@ unfoldrExactNM :: (Monad m, Prim a) => Int -> (b -> m (a, b)) -> b -> m (Vector 
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM = G.unfoldrExactNM
 
--- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -624,7 +624,7 @@ constructN :: Prim a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
 constructN = G.constructN
 
--- | \(O(n)\) Construct a vector with @n@ elements from right to left by
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -636,7 +636,7 @@ constructrN = G.constructrN
 -- Enumeration
 -- -----------
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -644,7 +644,7 @@ enumFromN :: (Prim a, Num a) => a -> Int -> Vector a
 {-# INLINE enumFromN #-}
 enumFromN = G.enumFromN
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -652,7 +652,7 @@ enumFromStepN :: (Prim a, Num a) => a -> a -> Int -> Vector a
 {-# INLINE enumFromStepN #-}
 enumFromStepN = G.enumFromStepN
 
--- | \(O(n)\) Enumerate values from @x@ to @y@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -660,7 +660,7 @@ enumFromTo :: (Prim a, Enum a) => a -> a -> Vector a
 {-# INLINE enumFromTo #-}
 enumFromTo = G.enumFromTo
 
--- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -671,23 +671,23 @@ enumFromThenTo = G.enumFromThenTo
 -- Concatenation
 -- -------------
 
--- | \(O(n)\) Prepend an element.
+-- | \(\mathcal{O}(n)\) Prepend an element.
 cons :: Prim a => a -> Vector a -> Vector a
 {-# INLINE cons #-}
 cons = G.cons
 
--- | \(O(n)\) Append an element.
+-- | \(\mathcal{O}(n)\) Append an element.
 snoc :: Prim a => Vector a -> a -> Vector a
 {-# INLINE snoc #-}
 snoc = G.snoc
 
 infixr 5 ++
--- | \(O(m+n)\) Concatenate two vectors.
+-- | \(\mathcal{O}(m+n)\) Concatenate two vectors.
 (++) :: Prim a => Vector a -> Vector a -> Vector a
 {-# INLINE (++) #-}
 (++) = (G.++)
 
--- | \(O(n)\) Concatenate all vectors in the list.
+-- | \(\mathcal{O}(n)\) Concatenate all vectors in the list.
 concat :: Prim a => [Vector a] -> Vector a
 {-# INLINE concat #-}
 concat = G.concat
@@ -695,19 +695,19 @@ concat = G.concat
 -- Monadic initialisation
 -- ----------------------
 
--- | \(O(n)\) Execute the monadic action the given number of times and store the
+-- | \(\mathcal{O}(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: (Monad m, Prim a) => Int -> m a -> m (Vector a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | \(O(n)\) Construct a vector of the given length by applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: (Monad m, Prim a) => Int -> (Int -> m a) -> m (Vector a)
 {-# INLINE generateM #-}
 generateM = G.generateM
 
--- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -736,7 +736,7 @@ createT p = G.createT p
 -- Restricting memory usage
 -- ------------------------
 
--- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
+-- | \(\mathcal{O}(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -753,7 +753,7 @@ force = G.force
 -- Bulk updates
 -- ------------
 
--- | \(O(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -764,7 +764,7 @@ force = G.force
 {-# INLINE (//) #-}
 (//) = (G.//)
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -791,7 +791,7 @@ unsafeUpdate_ = G.unsafeUpdate_
 -- Accumulations
 -- -------------
 
--- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -807,7 +807,7 @@ accum :: Prim a
 {-# INLINE accum #-}
 accum = G.accum
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -837,12 +837,12 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- Permutations
 -- ------------
 
--- | \(O(n)\) Reverse a vector.
+-- | \(\mathcal{O}(n)\) Reverse a vector.
 reverse :: Prim a => Vector a -> Vector a
 {-# INLINE reverse #-}
 reverse = G.reverse
 
--- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
+-- | \(\mathcal{O}(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -873,12 +873,12 @@ modify p = G.modify p
 -- Mapping
 -- -------
 
--- | \(O(n)\) Map a function over a vector.
+-- | \(\mathcal{O}(n)\) Map a function over a vector.
 map :: (Prim a, Prim b) => (a -> b) -> Vector a -> Vector b
 {-# INLINE map #-}
 map = G.map
 
--- | \(O(n)\) Apply a function to every element of a vector and its index.
+-- | \(\mathcal{O}(n)\) Apply a function to every element of a vector and its index.
 imap :: (Prim a, Prim b) => (Int -> a -> b) -> Vector a -> Vector b
 {-# INLINE imap #-}
 imap = G.imap
@@ -891,13 +891,13 @@ concatMap = G.concatMap
 -- Monadic mapping
 -- ---------------
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: (Monad m, Prim a, Prim b) => (a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE mapM #-}
 mapM = G.mapM
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 --
 -- @since 0.12.2.0
@@ -906,13 +906,13 @@ imapM :: (Monad m, Prim a, Prim b)
 {-# INLINE imapM #-}
 imapM = G.imapM
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: (Monad m, Prim a) => (a -> m b) -> Vector a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 --
 -- @since 0.12.2.0
@@ -920,19 +920,19 @@ imapM_ :: (Monad m, Prim a) => (Int -> a -> m b) -> Vector a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Prim a, Prim b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, Prim a) => Vector a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -940,7 +940,7 @@ iforM :: (Monad m, Prim a, Prim b) => Vector a -> (Int -> a -> m b) -> m (Vector
 {-# INLINE iforM #-}
 iforM = G.iforM
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -951,7 +951,7 @@ iforM_ = G.iforM_
 -- Zipping
 -- -------
 
--- | \(O(\min(m,n))\) Zip two vectors with the given function.
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (Prim a, Prim b, Prim c)
         => (a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE zipWith #-}
@@ -985,7 +985,7 @@ zipWith6 :: (Prim a, Prim b, Prim c, Prim d, Prim e,
 {-# INLINE zipWith6 #-}
 zipWith6 = G.zipWith6
 
--- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Prim a, Prim b, Prim c)
          => (Int -> a -> b -> c) -> Vector a -> Vector b -> Vector c
@@ -1024,14 +1024,14 @@ izipWith6 = G.izipWith6
 -- Monadic zipping
 -- ---------------
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: (Monad m, Prim a, Prim b, Prim c)
          => (a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE zipWithM #-}
 zipWithM = G.zipWithM
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 --
 -- @since 0.12.2.0
@@ -1040,14 +1040,14 @@ izipWithM :: (Monad m, Prim a, Prim b, Prim c)
 {-# INLINE izipWithM #-}
 izipWithM = G.izipWithM
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: (Monad m, Prim a, Prim b)
           => (a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ = G.zipWithM_
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 --
 -- @since 0.12.2.0
@@ -1059,18 +1059,18 @@ izipWithM_ = G.izipWithM_
 -- Filtering
 -- ---------
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate.
 filter :: Prim a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: Prim a => (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(\mathcal{O}(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1081,22 +1081,22 @@ uniq :: (Prim a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq
 
--- | \(O(n)\) Map the values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (Prim a, Prim b) => (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
--- | \(O(n)\) Map the indices/values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Prim a, Prim b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
 
--- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: (Monad m, Prim a) => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1106,7 +1106,7 @@ mapMaybeM
 {-# INLINE mapMaybeM #-}
 mapMaybeM = G.mapMaybeM
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1116,14 +1116,14 @@ imapMaybeM
 {-# INLINE imapMaybeM #-}
 imapMaybeM = G.imapMaybeM
 
--- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
+-- | \(\mathcal{O}(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: Prim a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE takeWhile #-}
 takeWhile = G.takeWhile
 
--- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
+-- | \(\mathcal{O}(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Prim a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
@@ -1132,7 +1132,7 @@ dropWhile = G.dropWhile
 -- Parititioning
 -- -------------
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1140,7 +1140,7 @@ partition :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE partition #-}
 partition = G.partition
 
--- | \(O(n)\) Split the vector into two parts, the first one containing the
+-- | \(\mathcal{O}(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1149,7 +1149,7 @@ partitionWith :: (Prim a, Prim b, Prim c) => (a -> Either b c) -> Vector a -> (V
 {-# INLINE partitionWith #-}
 partitionWith = G.partitionWith
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1157,19 +1157,19 @@ unstablePartition :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE unstablePartition #-}
 unstablePartition = G.unstablePartition
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE span #-}
 span = G.span
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that do not
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE break #-}
 break = G.break
 
--- | \(O(n)\) Split a vector into a list of slices, using a predicate function.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices, using a predicate function.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1189,7 +1189,7 @@ groupBy :: Prim a => (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
 
--- | \(O(n)\) Split a vector into a list of slices of the input vector.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices of the input vector.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1213,43 +1213,43 @@ group = G.groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | \(O(n)\) Check if the vector contains an element.
+-- | \(\mathcal{O}(n)\) Check if the vector contains an element.
 elem :: (Prim a, Eq a) => a -> Vector a -> Bool
 {-# INLINE elem #-}
 elem = G.elem
 
 infix 4 `notElem`
--- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
+-- | \(\mathcal{O}(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: (Prim a, Eq a) => a -> Vector a -> Bool
 {-# INLINE notElem #-}
 notElem = G.notElem
 
--- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(\mathcal{O}(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: Prim a => (a -> Bool) -> Vector a -> Maybe a
 {-# INLINE find #-}
 find = G.find
 
--- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: Prim a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
 
--- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
+-- | \(\mathcal{O}(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: Prim a => (a -> Bool) -> Vector a -> Vector Int
 {-# INLINE findIndices #-}
 findIndices = G.findIndices
 
--- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: (Prim a, Eq a) => a -> Vector a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex = G.elemIndex
 
--- | \(O(n)\) Yield the indices of all occurrences of the given element in
+-- | \(\mathcal{O}(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: (Prim a, Eq a) => a -> Vector a -> Vector Int
 {-# INLINE elemIndices #-}
@@ -1258,69 +1258,69 @@ elemIndices = G.elemIndices
 -- Folding
 -- -------
 
--- | \(O(n)\) Left fold.
+-- | \(\mathcal{O}(n)\) Left fold.
 foldl :: Prim b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | \(O(n)\) Left fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors.
 foldl1 :: Prim a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1 #-}
 foldl1 = G.foldl1
 
--- | \(O(n)\) Left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator.
 foldl' :: Prim b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: Prim a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1' #-}
 foldl1' = G.foldl1'
 
--- | \(O(n)\) Right fold.
+-- | \(\mathcal{O}(n)\) Right fold.
 foldr :: Prim a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | \(O(n)\) Right fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors.
 foldr1 :: Prim a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1 #-}
 foldr1 = G.foldr1
 
--- | \(O(n)\) Right fold with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold with a strict accumulator.
 foldr' :: Prim a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: Prim a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1' #-}
 foldr1' = G.foldr1'
 
--- | \(O(n)\) Left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: Prim b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: Prim b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | \(O(n)\) Right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: Prim a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | \(O(n)\) Right fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: Prim a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | \(O(n)\) Map each element of the structure to a monoid and combine
+-- | \(\mathcal{O}(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type cless. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1331,7 +1331,7 @@ foldMap :: (Monoid m, Prim a) => (a -> m) -> Vector a -> m
 {-# INLINE foldMap #-}
 foldMap = G.foldMap
 
--- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(\mathcal{O}(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1344,7 +1344,7 @@ foldMap' = G.foldMap'
 -- Specialised folds
 -- -----------------
 
--- | \(O(n)\) Check if all elements satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1359,7 +1359,7 @@ all :: Prim a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE all #-}
 all = G.all
 
--- | \(O(n)\) Check if any element satisfies the predicate.
+-- | \(\mathcal{O}(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1374,7 +1374,7 @@ any :: Prim a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE any #-}
 any = G.any
 
--- | \(O(n)\) Compute the sum of the elements.
+-- | \(\mathcal{O}(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1387,7 +1387,7 @@ sum :: (Prim a, Num a) => Vector a -> a
 {-# INLINE sum #-}
 sum = G.sum
 
--- | \(O(n)\) Compute the product of the elements.
+-- | \(\mathcal{O}(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1400,7 +1400,7 @@ product :: (Prim a, Num a) => Vector a -> a
 {-# INLINE product #-}
 product = G.product
 
--- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1412,7 +1412,7 @@ maximum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | \(O(n)\) Yield the maximum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1420,14 +1420,14 @@ maximumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
--- | \(O(n)\) Yield the maximum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 maximumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
 
--- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1439,40 +1439,40 @@ minimum :: (Prim a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | \(O(n)\) Yield the minimum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 minimumBy :: Prim a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
 
--- | \(O(n)\) Yield the minimum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 minimumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
 
--- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (Prim a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | \(O(n)\) Yield the index of the maximum element of the vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 maxIndexBy :: Prim a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
 
--- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (Prim a, Ord a) => Vector a -> Int
 {-# INLINE minIndex #-}
 minIndex = G.minIndex
 
--- | \(O(n)\) Yield the index of the minimum element of the vector according to
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 minIndexBy :: Prim a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE minIndexBy #-}
@@ -1481,29 +1481,29 @@ minIndexBy = G.minIndexBy
 -- Monadic folds
 -- -------------
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 foldM :: (Monad m, Prim b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.2.0
 ifoldM :: (Monad m, Prim b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | \(O(n)\) Monadic fold over non-empty vectors.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors.
 fold1M :: (Monad m, Prim a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M #-}
 fold1M = G.fold1M
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 foldM' :: (Monad m, Prim b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 --
 -- @since 0.12.2.0
@@ -1511,17 +1511,17 @@ ifoldM' :: (Monad m, Prim b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: (Monad m, Prim a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M' #-}
 fold1M' = G.fold1M'
 
--- | \(O(n)\) Monadic fold that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result.
 foldM_ :: (Monad m, Prim b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ = G.foldM_
 
--- | \(O(n)\) Monadic fold that discards the result using a function applied to
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 --
 -- @since 0.12.2.0
@@ -1529,17 +1529,17 @@ ifoldM_ :: (Monad m, Prim b) => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM_ #-}
 ifoldM_ = G.ifoldM_
 
--- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: (Monad m, Prim a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ = G.fold1M_
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: (Monad m, Prim b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ = G.foldM'_
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 --
 -- @since 0.12.2.0
@@ -1548,7 +1548,7 @@ ifoldM'_ :: (Monad m, Prim b)
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ = G.ifoldM'_
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: (Monad m, Prim a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -1557,7 +1557,7 @@ fold1M'_ = G.fold1M'_
 -- Scans
 -- -----
 
--- | \(O(n)\) Left-to-right prescan.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -1572,12 +1572,12 @@ prescanl :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl #-}
 prescanl = G.prescanl
 
--- | \(O(n)\) Left-to-right prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl' #-}
 prescanl' = G.prescanl'
 
--- | \(O(n)\) Left-to-right postscan.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -1592,12 +1592,12 @@ postscanl :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl #-}
 postscanl = G.postscanl
 
--- | \(O(n)\) Left-to-right postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl' #-}
 postscanl' = G.postscanl'
 
--- | \(O(n)\) Left-to-right scan.
+-- | \(\mathcal{O}(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -1612,19 +1612,19 @@ scanl :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl #-}
 scanl = G.scanl
 
--- | \(O(n)\) Left-to-right scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (Prim a, Prim b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl' #-}
 scanl' = G.scanl'
 
--- | \(O(n)\) Left-to-right scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanl :: (Prim a, Prim b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl #-}
 iscanl = G.iscanl
 
--- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanl' :: (Prim a, Prim b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
@@ -1632,7 +1632,7 @@ iscanl' :: (Prim a, Prim b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 iscanl' = G.iscanl'
 
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -1653,7 +1653,7 @@ scanl1 :: Prim a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1 #-}
 scanl1 = G.scanl1
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1670,7 +1670,7 @@ scanl1' :: Prim a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1' #-}
 scanl1' = G.scanl1'
 
--- | \(O(n)\) Right-to-left prescan.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -1679,46 +1679,46 @@ prescanr :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr #-}
 prescanr = G.prescanr
 
--- | \(O(n)\) Right-to-left prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr' #-}
 prescanr' = G.prescanr'
 
--- | \(O(n)\) Right-to-left postscan.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan.
 postscanr :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr #-}
 postscanr = G.postscanr
 
--- | \(O(n)\) Right-to-left postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr' #-}
 postscanr' = G.postscanr'
 
--- | \(O(n)\) Right-to-left scan.
+-- | \(\mathcal{O}(n)\) Right-to-left scan.
 scanr :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr #-}
 scanr = G.scanr
 
--- | \(O(n)\) Right-to-left scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (Prim a, Prim b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr' #-}
 scanr' = G.scanr'
 
--- | \(O(n)\) Right-to-left scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanr :: (Prim a, Prim b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr #-}
 iscanr = G.iscanr
 
--- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanr' :: (Prim a, Prim b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr' #-}
 iscanr' = G.iscanr'
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1735,7 +1735,7 @@ scanr1 :: Prim a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanr1 #-}
 scanr1 = G.scanr1
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -1756,7 +1756,7 @@ scanr1' = G.scanr1'
 -- Comparisons
 -- ------------------------
 
--- | \(O(n)\) Check if two vectors are equal using the supplied equality
+-- | \(\mathcal{O}(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 --
 -- @since 0.12.2.0
@@ -1764,7 +1764,7 @@ eqBy :: (Prim a, Prim b) => (a -> b -> Bool) -> Vector a -> Vector b -> Bool
 {-# INLINE eqBy #-}
 eqBy = G.eqBy
 
--- | \(O(n)\) Compare two vectors using the supplied comparison function for
+-- | \(\mathcal{O}(n)\) Compare two vectors using the supplied comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == compare
@@ -1776,17 +1776,17 @@ cmpBy = G.cmpBy
 -- Conversions - Lists
 -- ------------------------
 
--- | \(O(n)\) Convert a vector to a list.
+-- | \(\mathcal{O}(n)\) Convert a vector to a list.
 toList :: Prim a => Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | \(O(n)\) Convert a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert a list to a vector.
 fromList :: Prim a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -1806,7 +1806,7 @@ fromListN = G.fromListN
 -- Conversions - Unsafe casts
 -- --------------------------
 
--- | \(O(1)\) Unsafely cast a vector from one element type to another.
+-- | \(\mathcal{O}(1)\) Unsafely cast a vector from one element type to another.
 -- This operation just changes the type of the vector and does not
 -- modify the elements.
 --
@@ -1822,18 +1822,18 @@ unsafeCast (Vector o n ba)
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
+-- | \(\mathcal{O}(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = G.unsafeFreeze
 
--- | \(O(n)\) Yield an immutable copy of the mutable vector.
+-- | \(\mathcal{O}(n)\) Yield an immutable copy of the mutable vector.
 freeze :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE freeze #-}
 freeze = G.freeze
 
--- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
+-- | \(\mathcal{O}(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -1862,19 +1862,19 @@ unsafeThaw :: (Prim a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw
 
--- | \(O(n)\) Yield a mutable copy of an immutable vector.
+-- | \(\mathcal{O}(n)\) Yield a mutable copy of an immutable vector.
 thaw :: (Prim a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE thaw #-}
 thaw = G.thaw
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy
   :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy = G.unsafeCopy
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -92,7 +92,7 @@ import Unsafe.Coerce
 
 type role MVector nominal nominal
 
--- | \(O(1)\) Unsafely coerce a mutable vector from one element type to another,
+-- | \(\mathcal{O}(1)\) Unsafely coerce a mutable vector from one element type to another,
 -- representationally equal type. The operation just changes the type of the
 -- underlying pointer and does not modify the elements.
 --
@@ -208,7 +208,7 @@ drop :: Prim a => Int -> MVector s a -> MVector s a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | \(O(1)\) Split the mutable vector into the first @n@ elements
+-- | \(\mathcal{O}(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -298,7 +298,7 @@ replicateM :: (PrimMonad m, Prim a) => Int -> m a -> m (MVector (PrimState m) a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -307,7 +307,7 @@ generate :: (PrimMonad m, Prim a) => Int -> (Int -> a) -> m (MVector (PrimState 
 {-# INLINE generate #-}
 generate = G.generate
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -543,21 +543,21 @@ nextPermutation = G.nextPermutation
 -- Folds
 -- -----
 
--- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m, Prim a) => (a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
 --
 -- @since 0.12.3.0
 imapM_ :: (PrimMonad m, Prim a) => (Int -> a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector,
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -565,7 +565,7 @@ forM_ :: (PrimMonad m, Prim a) => MVector (PrimState m) a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -573,56 +573,56 @@ iforM_ :: (PrimMonad m, Prim a) => MVector (PrimState m) a -> (Int -> a -> m b) 
 {-# INLINE iforM_ #-}
 iforM_ = G.iforM_
 
--- | \(O(n)\) Pure left fold.
+-- | \(\mathcal{O}(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m, Prim a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | \(O(n)\) Pure left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m, Prim a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | \(O(n)\) Pure left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m, Prim a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m, Prim a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | \(O(n)\) Pure right fold.
+-- | \(\mathcal{O}(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m, Prim a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | \(O(n)\) Pure right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m, Prim a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | \(O(n)\) Pure right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m, Prim a) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | \(O(n)\) Pure right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -630,56 +630,56 @@ ifoldr' :: (PrimMonad m, Prim a) => (Int -> a -> b -> b) -> b -> MVector (PrimSt
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m, Prim a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m, Prim a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m, Prim a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m, Prim a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | \(O(n)\) Monadic right fold.
+-- | \(\mathcal{O}(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m, Prim a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM = G.foldrM
 
--- | \(O(n)\) Monadic right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m, Prim a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' = G.foldrM'
 
--- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m, Prim a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM #-}
 ifoldrM = G.ifoldrM
 
--- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -690,7 +690,7 @@ ifoldrM' = G.ifoldrM'
 -- Unsafe conversions
 -- ------------------
 
--- | \(O(1)\) Unsafely cast a vector from one element type to another.
+-- | \(\mathcal{O}(1)\) Unsafely cast a vector from one element type to another.
 -- This operation just changes the type of the vector and does not
 -- modify the elements.
 --

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -92,7 +92,7 @@ import Unsafe.Coerce
 
 type role MVector nominal nominal
 
--- | /O(1)/ Unsafely coerce a mutable vector from one element type to another,
+-- | \(O(1)\) Unsafely coerce a mutable vector from one element type to another,
 -- representationally equal type. The operation just changes the type of the
 -- underlying pointer and does not modify the elements.
 --
@@ -208,7 +208,7 @@ drop :: Prim a => Int -> MVector s a -> MVector s a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | /O(1)/ Split the mutable vector into the first @n@ elements
+-- | \(O(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -298,7 +298,7 @@ replicateM :: (PrimMonad m, Prim a) => Int -> m a -> m (MVector (PrimState m) a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is negative)
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -307,7 +307,7 @@ generate :: (PrimMonad m, Prim a) => Int -> (Int -> a) -> m (MVector (PrimState 
 {-# INLINE generate #-}
 generate = G.generate
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -543,21 +543,21 @@ nextPermutation = G.nextPermutation
 -- Folds
 -- -----
 
--- | /O(n)/ Apply the monadic action to every element of the vector, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m, Prim a) => (a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector and its index, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
 --
 -- @since 0.12.3.0
 imapM_ :: (PrimMonad m, Prim a) => (Int -> a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector,
+-- | \(O(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -565,7 +565,7 @@ forM_ :: (PrimMonad m, Prim a) => MVector (PrimState m) a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector
+-- | \(O(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -573,56 +573,56 @@ iforM_ :: (PrimMonad m, Prim a) => MVector (PrimState m) a -> (Int -> a -> m b) 
 {-# INLINE iforM_ #-}
 iforM_ = G.iforM_
 
--- | /O(n)/ Pure left fold.
+-- | \(O(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m, Prim a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | /O(n)/ Pure left fold with strict accumulator.
+-- | \(O(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m, Prim a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | /O(n)/ Pure left fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m, Prim a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | /O(n)/ Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m, Prim a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | /O(n)/ Pure right fold.
+-- | \(O(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m, Prim a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | /O(n)/ Pure right fold with strict accumulator.
+-- | \(O(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m, Prim a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | /O(n)/ Pure right fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m, Prim a) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | /O(n)/ Pure right fold with strict accumulator using a function applied
+-- | \(O(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -630,56 +630,56 @@ ifoldr' :: (PrimMonad m, Prim a) => (Int -> a -> b -> b) -> b -> MVector (PrimSt
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m, Prim a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m, Prim a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m, Prim a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m, Prim a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | /O(n)/ Monadic right fold.
+-- | \(O(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m, Prim a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM = G.foldrM
 
--- | /O(n)/ Monadic right fold with strict accumulator.
+-- | \(O(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m, Prim a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' = G.foldrM'
 
--- | /O(n)/ Monadic right fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m, Prim a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM #-}
 ifoldrM = G.ifoldrM
 
--- | /O(n)/ Monadic right fold with strict accumulator using a function applied
+-- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -690,7 +690,7 @@ ifoldrM' = G.ifoldrM'
 -- Unsafe conversions
 -- ------------------
 
--- | /O(1)/ Unsafely cast a vector from one element type to another.
+-- | \(O(1)\) Unsafely cast a vector from one element type to another.
 -- This operation just changes the type of the vector and does not
 -- modify the elements.
 --

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -208,7 +208,7 @@ import Unsafe.Coerce
 
 type role Vector nominal
 
--- | /O(1)/ Unsafely coerce a mutable vector from one element type to another,
+-- | \(O(1)\) Unsafely coerce a mutable vector from one element type to another,
 -- representationally equal type. The operation just changes the type of the
 -- underlying pointer and does not modify the elements.
 --
@@ -327,12 +327,12 @@ instance Storable a => Exts.IsList (Vector a) where
 -- Length
 -- ------
 
--- | /O(1)/ Yield the length of the vector.
+-- | \(O(1)\) Yield the length of the vector.
 length :: Storable a => Vector a -> Int
 {-# INLINE length #-}
 length = G.length
 
--- | /O(1)/ Test whether a vector is empty.
+-- | \(O(1)\) Test whether a vector is empty.
 null :: Storable a => Vector a -> Bool
 {-# INLINE null #-}
 null = G.null
@@ -350,27 +350,27 @@ null = G.null
 {-# INLINE (!?) #-}
 (!?) = (G.!?)
 
--- | /O(1)/ First element.
+-- | \(O(1)\) First element.
 head :: Storable a => Vector a -> a
 {-# INLINE head #-}
 head = G.head
 
--- | /O(1)/ Last element.
+-- | \(O(1)\) Last element.
 last :: Storable a => Vector a -> a
 {-# INLINE last #-}
 last = G.last
 
--- | /O(1)/ Unsafe indexing without bounds checking.
+-- | \(O(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Storable a => Vector a -> Int -> a
 {-# INLINE unsafeIndex #-}
 unsafeIndex = G.unsafeIndex
 
--- | /O(1)/ First element, without checking if the vector is empty.
+-- | \(O(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Storable a => Vector a -> a
 {-# INLINE unsafeHead #-}
 unsafeHead = G.unsafeHead
 
--- | /O(1)/ Last element, without checking if the vector is empty.
+-- | \(O(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Storable a => Vector a -> a
 {-# INLINE unsafeLast #-}
 unsafeLast = G.unsafeLast
@@ -378,7 +378,7 @@ unsafeLast = G.unsafeLast
 -- Monadic indexing
 -- ----------------
 
--- | /O(1)/ Indexing in a monad.
+-- | \(O(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -400,31 +400,31 @@ indexM :: (Storable a, Monad m) => Vector a -> Int -> m a
 {-# INLINE indexM #-}
 indexM = G.indexM
 
--- | /O(1)/ First element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (Storable a, Monad m) => Vector a -> m a
 {-# INLINE headM #-}
 headM = G.headM
 
--- | /O(1)/ Last element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (Storable a, Monad m) => Vector a -> m a
 {-# INLINE lastM #-}
 lastM = G.lastM
 
--- | /O(1)/ Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (Storable a, Monad m) => Vector a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
 unsafeIndexM = G.unsafeIndexM
 
--- | /O(1)/ First element in a monad, without checking for empty vectors.
+-- | \(O(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (Storable a, Monad m) => Vector a -> m a
 {-# INLINE unsafeHeadM #-}
 unsafeHeadM = G.unsafeHeadM
 
--- | /O(1)/ Last element in a monad, without checking for empty vectors.
+-- | \(O(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (Storable a, Monad m) => Vector a -> m a
 {-# INLINE unsafeLastM #-}
@@ -433,7 +433,7 @@ unsafeLastM = G.unsafeLastM
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | /O(1)/ Yield a slice of the vector without copying it. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: Storable a
       => Int   -- ^ @i@ starting index
@@ -443,31 +443,31 @@ slice :: Storable a
 {-# INLINE slice #-}
 slice = G.slice
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Storable a => Vector a -> Vector a
 {-# INLINE init #-}
 init = G.init
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Storable a => Vector a -> Vector a
 {-# INLINE tail #-}
 tail = G.tail
 
--- | /O(1)/ Yield at the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield at the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Storable a => Int -> Vector a -> Vector a
 {-# INLINE take #-}
 take = G.take
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Storable a => Int -> Vector a -> Vector a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | /O(1)/ Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -477,7 +477,7 @@ splitAt :: Storable a => Int -> Vector a -> (Vector a, Vector a)
 {-# INLINE splitAt #-}
 splitAt = G.splitAt
 
--- | /O(1)/ Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -485,7 +485,7 @@ uncons :: Storable a => Vector a -> Maybe (a, Vector a)
 {-# INLINE uncons #-}
 uncons = G.uncons
 
--- | /O(1)/ Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -493,7 +493,7 @@ unsnoc :: Storable a => Vector a -> Maybe (Vector a, a)
 {-# INLINE unsnoc #-}
 unsnoc = G.unsnoc
 
--- | /O(1)/ Yield a slice of the vector without copying. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Storable a => Int   -- ^ @i@ starting index
                        -> Int   -- ^ @n@ length
@@ -502,25 +502,25 @@ unsafeSlice :: Storable a => Int   -- ^ @i@ starting index
 {-# INLINE unsafeSlice #-}
 unsafeSlice = G.unsafeSlice
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Storable a => Vector a -> Vector a
 {-# INLINE unsafeInit #-}
 unsafeInit = G.unsafeInit
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Storable a => Vector a -> Vector a
 {-# INLINE unsafeTail #-}
 unsafeTail = G.unsafeTail
 
--- | /O(1)/ Yield the first @n@ elements without copying. The vector must
+-- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Storable a => Int -> Vector a -> Vector a
 {-# INLINE unsafeTake #-}
 unsafeTake = G.unsafeTake
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Storable a => Int -> Vector a -> Vector a
 {-# INLINE unsafeDrop #-}
@@ -529,28 +529,28 @@ unsafeDrop = G.unsafeDrop
 -- Initialisation
 -- --------------
 
--- | /O(1)/ The empty vector.
+-- | \(O(1)\) The empty vector.
 empty :: Storable a => Vector a
 {-# INLINE empty #-}
 empty = G.empty
 
--- | /O(1)/ A vector with exactly one element.
+-- | \(O(1)\) A vector with exactly one element.
 singleton :: Storable a => a -> Vector a
 {-# INLINE singleton #-}
 singleton = G.singleton
 
--- | /O(n)/ A vector of the given length with the same value in each position.
+-- | \(O(n)\) A vector of the given length with the same value in each position.
 replicate :: Storable a => Int -> a -> Vector a
 {-# INLINE replicate #-}
 replicate = G.replicate
 
--- | /O(n)/ Construct a vector of the given length by applying the function to
+-- | \(O(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Storable a => Int -> (Int -> a) -> Vector a
 {-# INLINE generate #-}
 generate = G.generate
 
--- | /O(n)/ Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -572,7 +572,7 @@ iterateN = G.iterateN
 -- Unfolding
 -- ---------
 
--- | /O(n)/ Construct a vector by repeatedly applying the generator function
+-- | \(O(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -582,7 +582,7 @@ unfoldr :: Storable a => (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldr #-}
 unfoldr = G.unfoldr
 
--- | /O(n)/ Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -591,7 +591,7 @@ unfoldrN :: Storable a => Int -> (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldrN #-}
 unfoldrN = G.unfoldrN
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -602,7 +602,7 @@ unfoldrExactN :: (Storable a) => Int -> (b -> (a, b)) -> b -> Vector a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = G.unfoldrExactN
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -610,7 +610,7 @@ unfoldrM :: (Monad m, Storable a) => (b -> m (Maybe (a, b))) -> b -> m (Vector a
 {-# INLINE unfoldrM #-}
 unfoldrM = G.unfoldrM
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -618,7 +618,7 @@ unfoldrNM :: (Monad m, Storable a) => Int -> (b -> m (Maybe (a, b))) -> b -> m (
 {-# INLINE unfoldrNM #-}
 unfoldrNM = G.unfoldrNM
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -627,7 +627,7 @@ unfoldrExactNM :: (Monad m, Storable a) => Int -> (b -> m (a, b)) -> b -> m (Vec
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM = G.unfoldrExactNM
 
--- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
+-- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -635,7 +635,7 @@ constructN :: Storable a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
 constructN = G.constructN
 
--- | /O(n)/ Construct a vector with @n@ elements from right to left by
+-- | \(O(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -647,7 +647,7 @@ constructrN = G.constructrN
 -- Enumeration
 -- -----------
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -655,7 +655,7 @@ enumFromN :: (Storable a, Num a) => a -> Int -> Vector a
 {-# INLINE enumFromN #-}
 enumFromN = G.enumFromN
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -663,7 +663,7 @@ enumFromStepN :: (Storable a, Num a) => a -> a -> Int -> Vector a
 {-# INLINE enumFromStepN #-}
 enumFromStepN = G.enumFromStepN
 
--- | /O(n)/ Enumerate values from @x@ to @y@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -671,7 +671,7 @@ enumFromTo :: (Storable a, Enum a) => a -> a -> Vector a
 {-# INLINE enumFromTo #-}
 enumFromTo = G.enumFromTo
 
--- | /O(n)/ Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -682,23 +682,23 @@ enumFromThenTo = G.enumFromThenTo
 -- Concatenation
 -- -------------
 
--- | /O(n)/ Prepend an element.
+-- | \(O(n)\) Prepend an element.
 cons :: Storable a => a -> Vector a -> Vector a
 {-# INLINE cons #-}
 cons = G.cons
 
--- | /O(n)/ Append an element.
+-- | \(O(n)\) Append an element.
 snoc :: Storable a => Vector a -> a -> Vector a
 {-# INLINE snoc #-}
 snoc = G.snoc
 
 infixr 5 ++
--- | /O(m+n)/ Concatenate two vectors.
+-- | \(O(m+n)\) Concatenate two vectors.
 (++) :: Storable a => Vector a -> Vector a -> Vector a
 {-# INLINE (++) #-}
 (++) = (G.++)
 
--- | /O(n)/ Concatenate all vectors in the list.
+-- | \(O(n)\) Concatenate all vectors in the list.
 concat :: Storable a => [Vector a] -> Vector a
 {-# INLINE concat #-}
 concat = G.concat
@@ -706,19 +706,19 @@ concat = G.concat
 -- Monadic initialisation
 -- ----------------------
 
--- | /O(n)/ Execute the monadic action the given number of times and store the
+-- | \(O(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: (Monad m, Storable a) => Int -> m a -> m (Vector a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | /O(n)/ Construct a vector of the given length by applying the monadic
+-- | \(O(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: (Monad m, Storable a) => Int -> (Int -> m a) -> m (Vector a)
 {-# INLINE generateM #-}
 generateM = G.generateM
 
--- | /O(n)/ Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -747,7 +747,7 @@ createT p = G.createT p
 -- Restricting memory usage
 -- ------------------------
 
--- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
+-- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -764,7 +764,7 @@ force = G.force
 -- Bulk updates
 -- ------------
 
--- | /O(m+n)/ For each pair @(i,a)@ from the list of index/value pairs,
+-- | \(O(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -775,7 +775,7 @@ force = G.force
 {-# INLINE (//) #-}
 (//) = (G.//)
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -802,7 +802,7 @@ unsafeUpdate_ = G.unsafeUpdate_
 -- Accumulations
 -- -------------
 
--- | /O(m+n)/ For each pair @(i,b)@ from the list, replace the vector element
+-- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -818,7 +818,7 @@ accum :: Storable a
 {-# INLINE accum #-}
 accum = G.accum
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -848,12 +848,12 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- Permutations
 -- ------------
 
--- | /O(n)/ Reverse a vector.
+-- | \(O(n)\) Reverse a vector.
 reverse :: Storable a => Vector a -> Vector a
 {-# INLINE reverse #-}
 reverse = G.reverse
 
--- | /O(n)/ Yield the vector obtained by replacing each element @i@ of the
+-- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -884,12 +884,12 @@ modify p = G.modify p
 -- Mapping
 -- -------
 
--- | /O(n)/ Map a function over a vector.
+-- | \(O(n)\) Map a function over a vector.
 map :: (Storable a, Storable b) => (a -> b) -> Vector a -> Vector b
 {-# INLINE map #-}
 map = G.map
 
--- | /O(n)/ Apply a function to every element of a vector and its index.
+-- | \(O(n)\) Apply a function to every element of a vector and its index.
 imap :: (Storable a, Storable b) => (Int -> a -> b) -> Vector a -> Vector b
 {-# INLINE imap #-}
 imap = G.imap
@@ -902,13 +902,13 @@ concatMap = G.concatMap
 -- Monadic mapping
 -- ---------------
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: (Monad m, Storable a, Storable b) => (a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE mapM #-}
 mapM = G.mapM
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 --
 -- @since 0.12.2.0
@@ -917,13 +917,13 @@ imapM :: (Monad m, Storable a, Storable b)
 {-# INLINE imapM #-}
 imapM = G.imapM
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: (Monad m, Storable a) => (a -> m b) -> Vector a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 --
 -- @since 0.12.2.0
@@ -931,19 +931,19 @@ imapM_ :: (Monad m, Storable a) => (Int -> a -> m b) -> Vector a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Storable a, Storable b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, Storable a) => Vector a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -951,7 +951,7 @@ iforM :: (Monad m, Storable a, Storable b) => Vector a -> (Int -> a -> m b) -> m
 {-# INLINE iforM #-}
 iforM = G.iforM
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -962,7 +962,7 @@ iforM_ = G.iforM_
 -- Zipping
 -- -------
 
--- | /O(min(m,n))/ Zip two vectors with the given function.
+-- | \(O(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (Storable a, Storable b, Storable c)
         => (a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE zipWith #-}
@@ -996,7 +996,7 @@ zipWith6 :: (Storable a, Storable b, Storable c, Storable d, Storable e,
 {-# INLINE zipWith6 #-}
 zipWith6 = G.zipWith6
 
--- | /O(min(m,n))/ Zip two vectors with a function that also takes the
+-- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Storable a, Storable b, Storable c)
          => (Int -> a -> b -> c) -> Vector a -> Vector b -> Vector c
@@ -1045,14 +1045,14 @@ isSameVector (Vector n1 ptr1) (Vector n2 ptr2) = n1 == n2 && ptr1 == ptr2
 -- Monadic zipping
 -- ---------------
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and yield a
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: (Monad m, Storable a, Storable b, Storable c)
          => (a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE zipWithM #-}
 zipWithM = G.zipWithM
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 --
 -- @since 0.12.2.0
@@ -1061,14 +1061,14 @@ izipWithM :: (Monad m, Storable a, Storable b, Storable c)
 {-# INLINE izipWithM #-}
 izipWithM = G.izipWithM
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and ignore the
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: (Monad m, Storable a, Storable b)
           => (a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ = G.zipWithM_
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 --
 -- @since 0.12.2.0
@@ -1080,18 +1080,18 @@ izipWithM_ = G.izipWithM_
 -- Filtering
 -- ---------
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate.
 filter :: Storable a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate which is applied to
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: Storable a => (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | /O(n)/ Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1102,22 +1102,22 @@ uniq :: (Storable a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq
 
--- | /O(n)/ Map the values and collect the 'Just' results.
+-- | \(O(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (Storable a, Storable b) => (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
--- | /O(n)/ Map the indices/values and collect the 'Just' results.
+-- | \(O(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Storable a, Storable b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
 
--- | /O(n)/ Drop all elements that do not satisfy the monadic predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: (Monad m, Storable a) => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
 
--- | /O(n)/ Apply the monadic function to each element of the vector and
+-- | \(O(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1127,7 +1127,7 @@ mapMaybeM
 {-# INLINE mapMaybeM #-}
 mapMaybeM = G.mapMaybeM
 
--- | /O(n)/ Apply the monadic function to each element of the vector and its index.
+-- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1137,14 +1137,14 @@ imapMaybeM
 {-# INLINE imapMaybeM #-}
 imapMaybeM = G.imapMaybeM
 
--- | /O(n)/ Yield the longest prefix of elements satisfying the predicate.
+-- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: Storable a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE takeWhile #-}
 takeWhile = G.takeWhile
 
--- | /O(n)/ Drop the longest prefix of elements that satisfy the predicate
+-- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Storable a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
@@ -1153,7 +1153,7 @@ dropWhile = G.dropWhile
 -- Parititioning
 -- -------------
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1161,7 +1161,7 @@ partition :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE partition #-}
 partition = G.partition
 
--- | /O(n)/ Split the vector into two parts, the first one containing the
+-- | \(O(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1170,7 +1170,7 @@ partitionWith :: (Storable a, Storable b, Storable c) => (a -> Either b c) -> Ve
 {-# INLINE partitionWith #-}
 partitionWith = G.partitionWith
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1178,19 +1178,19 @@ unstablePartition :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector 
 {-# INLINE unstablePartition #-}
 unstablePartition = G.unstablePartition
 
--- | /O(n)/ Split the vector into the longest prefix of elements that satisfy
+-- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE span #-}
 span = G.span
 
--- | /O(n)/ Split the vector into the longest prefix of elements that do not
+-- | \(O(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE break #-}
 break = G.break
 
--- | /O(n)/ Split a vector into a list of slices, using a predicate function.
+-- | \(O(n)\) Split a vector into a list of slices, using a predicate function.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1210,7 +1210,7 @@ groupBy :: Storable a => (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
 
--- | /O(n)/ Split a vector into a list of slices of the input vector.
+-- | \(O(n)\) Split a vector into a list of slices of the input vector.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1234,43 +1234,43 @@ group = G.groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | /O(n)/ Check if the vector contains an element.
+-- | \(O(n)\) Check if the vector contains an element.
 elem :: (Storable a, Eq a) => a -> Vector a -> Bool
 {-# INLINE elem #-}
 elem = G.elem
 
 infix 4 `notElem`
--- | /O(n)/ Check if the vector does not contain an element (inverse of 'elem').
+-- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: (Storable a, Eq a) => a -> Vector a -> Bool
 {-# INLINE notElem #-}
 notElem = G.notElem
 
--- | /O(n)/ Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: Storable a => (a -> Bool) -> Vector a -> Maybe a
 {-# INLINE find #-}
 find = G.find
 
--- | /O(n)/ Yield 'Just' the index of the first element matching the predicate
+-- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: Storable a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
 
--- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
+-- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: Storable a => (a -> Bool) -> Vector a -> Vector Int
 {-# INLINE findIndices #-}
 findIndices = G.findIndices
 
--- | /O(n)/ Yield 'Just' the index of the first occurrence of the given element or
+-- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: (Storable a, Eq a) => a -> Vector a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex = G.elemIndex
 
--- | /O(n)/ Yield the indices of all occurrences of the given element in
+-- | \(O(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: (Storable a, Eq a) => a -> Vector a -> Vector Int
 {-# INLINE elemIndices #-}
@@ -1279,69 +1279,69 @@ elemIndices = G.elemIndices
 -- Folding
 -- -------
 
--- | /O(n)/ Left fold.
+-- | \(O(n)\) Left fold.
 foldl :: Storable b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | /O(n)/ Left fold on non-empty vectors.
+-- | \(O(n)\) Left fold on non-empty vectors.
 foldl1 :: Storable a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1 #-}
 foldl1 = G.foldl1
 
--- | /O(n)/ Left fold with strict accumulator.
+-- | \(O(n)\) Left fold with strict accumulator.
 foldl' :: Storable b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | /O(n)/ Left fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: Storable a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1' #-}
 foldl1' = G.foldl1'
 
--- | /O(n)/ Right fold.
+-- | \(O(n)\) Right fold.
 foldr :: Storable a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | /O(n)/ Right fold on non-empty vectors.
+-- | \(O(n)\) Right fold on non-empty vectors.
 foldr1 :: Storable a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1 #-}
 foldr1 = G.foldr1
 
--- | /O(n)/ Right fold with a strict accumulator.
+-- | \(O(n)\) Right fold with a strict accumulator.
 foldr' :: Storable a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | /O(n)/ Right fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: Storable a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1' #-}
 foldr1' = G.foldr1'
 
--- | /O(n)/ Left fold using a function applied to each element and its index.
+-- | \(O(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: Storable b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | /O(n)/ Left fold with strict accumulator using a function applied to each element
+-- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: Storable b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | /O(n)/ Right fold using a function applied to each element and its index.
+-- | \(O(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: Storable a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | /O(n)/ Right fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: Storable a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | /O(n)/ Map each element of the structure to a monoid and combine
+-- | \(O(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type class. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1352,7 +1352,7 @@ foldMap :: (Monoid m, Storable a) => (a -> m) -> Vector a -> m
 {-# INLINE foldMap #-}
 foldMap = G.foldMap
 
--- | /O(n)/ Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1365,7 +1365,7 @@ foldMap' = G.foldMap'
 -- Specialised folds
 -- -----------------
 
--- | /O(n)/ Check if all elements satisfy the predicate.
+-- | \(O(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1380,7 +1380,7 @@ all :: Storable a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE all #-}
 all = G.all
 
--- | /O(n)/ Check if any element satisfies the predicate.
+-- | \(O(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1395,7 +1395,7 @@ any :: Storable a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE any #-}
 any = G.any
 
--- | /O(n)/ Check if all elements are 'True'.
+-- | \(O(n)\) Check if all elements are 'True'.
 --
 -- ==== __Examples__
 --
@@ -1408,7 +1408,7 @@ and :: Vector Bool -> Bool
 {-# INLINE and #-}
 and = G.and
 
--- | /O(n)/ Check if any element is 'True'.
+-- | \(O(n)\) Check if any element is 'True'.
 --
 -- ==== __Examples__
 --
@@ -1421,7 +1421,7 @@ or :: Vector Bool -> Bool
 {-# INLINE or #-}
 or = G.or
 
--- | /O(n)/ Compute the sum of the elements.
+-- | \(O(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1434,7 +1434,7 @@ sum :: (Storable a, Num a) => Vector a -> a
 {-# INLINE sum #-}
 sum = G.sum
 
--- | /O(n)/ Compute the product of the elements.
+-- | \(O(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1447,7 +1447,7 @@ product :: (Storable a, Num a) => Vector a -> a
 {-# INLINE product #-}
 product = G.product
 
--- | /O(n)/ Yield the maximum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1459,7 +1459,7 @@ maximum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | /O(n)/ Yield the maximum element of the vector according to the
+-- | \(O(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1467,14 +1467,14 @@ maximumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
--- | /O(n)/ Yield the maximum element of the vector by comparing the results
+-- | \(O(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 maximumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
 
--- | /O(n)/ Yield the minimum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1486,40 +1486,40 @@ minimum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | /O(n)/ Yield the minimum element of the vector according to the
+-- | \(O(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 minimumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
 
--- | /O(n)/ Yield the minimum element of the vector by comparing the results
+-- | \(O(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 minimumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
 
--- | /O(n)/ Yield the index of the maximum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (Storable a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | /O(n)/ Yield the index of the maximum element of the vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 maxIndexBy :: Storable a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
 
--- | /O(n)/ Yield the index of the minimum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (Storable a, Ord a) => Vector a -> Int
 {-# INLINE minIndex #-}
 minIndex = G.minIndex
 
--- | /O(n)/ Yield the index of the minimum element of the vector according to
+-- | \(O(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 minIndexBy :: Storable a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE minIndexBy #-}
@@ -1528,29 +1528,29 @@ minIndexBy = G.minIndexBy
 -- Monadic folds
 -- -------------
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 foldM :: (Monad m, Storable b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.2.0
 ifoldM :: (Monad m, Storable b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | /O(n)/ Monadic fold over non-empty vectors.
+-- | \(O(n)\) Monadic fold over non-empty vectors.
 fold1M :: (Monad m, Storable a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M #-}
 fold1M = G.fold1M
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 foldM' :: (Monad m, Storable b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 --
 -- @since 0.12.2.0
@@ -1558,17 +1558,17 @@ ifoldM' :: (Monad m, Storable b) => (a -> Int -> b -> m a) -> a -> Vector b -> m
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator.
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: (Monad m, Storable a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M' #-}
 fold1M' = G.fold1M'
 
--- | /O(n)/ Monadic fold that discards the result.
+-- | \(O(n)\) Monadic fold that discards the result.
 foldM_ :: (Monad m, Storable b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ = G.foldM_
 
--- | /O(n)/ Monadic fold that discards the result using a function applied to
+-- | \(O(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 --
 -- @since 0.12.2.0
@@ -1576,17 +1576,17 @@ ifoldM_ :: (Monad m, Storable b) => (a -> Int -> b -> m a) -> a -> Vector b -> m
 {-# INLINE ifoldM_ #-}
 ifoldM_ = G.ifoldM_
 
--- | /O(n)/ Monadic fold over non-empty vectors that discards the result.
+-- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: (Monad m, Storable a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ = G.fold1M_
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result.
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: (Monad m, Storable b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ = G.foldM'_
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 --
 -- @since 0.12.2.0
@@ -1595,7 +1595,7 @@ ifoldM'_ :: (Monad m, Storable b)
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ = G.ifoldM'_
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: (Monad m, Storable a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -1604,7 +1604,7 @@ fold1M'_ = G.fold1M'_
 -- Scans
 -- -----
 
--- | /O(n)/ Left-to-right prescan.
+-- | \(O(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -1619,12 +1619,12 @@ prescanl :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector
 {-# INLINE prescanl #-}
 prescanl = G.prescanl
 
--- | /O(n)/ Left-to-right prescan with strict accumulator.
+-- | \(O(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl' #-}
 prescanl' = G.prescanl'
 
--- | /O(n)/ Left-to-right postscan.
+-- | \(O(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -1639,12 +1639,12 @@ postscanl :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vecto
 {-# INLINE postscanl #-}
 postscanl = G.postscanl
 
--- | /O(n)/ Left-to-right postscan with strict accumulator.
+-- | \(O(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl' #-}
 postscanl' = G.postscanl'
 
--- | /O(n)/ Left-to-right scan.
+-- | \(O(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -1659,26 +1659,26 @@ scanl :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl #-}
 scanl = G.scanl
 
--- | /O(n)/ Left-to-right scan with strict accumulator.
+-- | \(O(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl' #-}
 scanl' = G.scanl'
 
--- | /O(n)/ Left-to-right scan over a vector with its index.
+-- | \(O(n)\) Left-to-right scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanl :: (Storable a, Storable b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl #-}
 iscanl = G.iscanl
 
--- | /O(n)/ Left-to-right scan over a vector (strictly) with its index.
+-- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanl' :: (Storable a, Storable b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl' #-}
 iscanl' = G.iscanl'
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -1699,7 +1699,7 @@ scanl1 :: Storable a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1 #-}
 scanl1 = G.scanl1
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1716,7 +1716,7 @@ scanl1' :: Storable a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1' #-}
 scanl1' = G.scanl1'
 
--- | /O(n)/ Right-to-left prescan.
+-- | \(O(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -1725,46 +1725,46 @@ prescanr :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector
 {-# INLINE prescanr #-}
 prescanr = G.prescanr
 
--- | /O(n)/ Right-to-left prescan with strict accumulator.
+-- | \(O(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr' #-}
 prescanr' = G.prescanr'
 
--- | /O(n)/ Right-to-left postscan.
+-- | \(O(n)\) Right-to-left postscan.
 postscanr :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr #-}
 postscanr = G.postscanr
 
--- | /O(n)/ Right-to-left postscan with strict accumulator.
+-- | \(O(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr' #-}
 postscanr' = G.postscanr'
 
--- | /O(n)/ Right-to-left scan.
+-- | \(O(n)\) Right-to-left scan.
 scanr :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr #-}
 scanr = G.scanr
 
--- | /O(n)/ Right-to-left scan with strict accumulator.
+-- | \(O(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr' #-}
 scanr' = G.scanr'
 
--- | /O(n)/ Right-to-left scan over a vector with its index.
+-- | \(O(n)\) Right-to-left scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanr :: (Storable a, Storable b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr #-}
 iscanr = G.iscanr
 
--- | /O(n)/ Right-to-left scan over a vector (strictly) with its index.
+-- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanr' :: (Storable a, Storable b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr' #-}
 iscanr' = G.iscanr'
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector.
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1781,7 +1781,7 @@ scanr1 :: Storable a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanr1 #-}
 scanr1 = G.scanr1
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector with a strict
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -1802,7 +1802,7 @@ scanr1' = G.scanr1'
 -- Comparisons
 -- ------------------------
 
--- | /O(n)/ Check if two vectors are equal using the supplied equality
+-- | \(O(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 --
 -- @since 0.12.2.0
@@ -1810,7 +1810,7 @@ eqBy :: (Storable a, Storable b) => (a -> b -> Bool) -> Vector a -> Vector b -> 
 {-# INLINE eqBy #-}
 eqBy = G.eqBy
 
--- | /O(n)/ Compare two vectors using supplied the comparison function for
+-- | \(O(n)\) Compare two vectors using supplied the comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == compare
@@ -1822,17 +1822,17 @@ cmpBy = G.cmpBy
 -- Conversions - Lists
 -- ------------------------
 
--- | /O(n)/ Convert a vector to a list.
+-- | \(O(n)\) Convert a vector to a list.
 toList :: Storable a => Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | /O(n)/ Convert a list to a vector.
+-- | \(O(n)\) Convert a list to a vector.
 fromList :: Storable a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -1852,7 +1852,7 @@ fromListN = G.fromListN
 -- Conversions - Unsafe casts
 -- --------------------------
 
--- | /O(1)/ Unsafely cast a vector from one element type to another.
+-- | \(O(1)\) Unsafely cast a vector from one element type to another.
 -- This operation just changes the type of the underlying pointer and does not
 -- modify the elements.
 --
@@ -1867,19 +1867,19 @@ unsafeCast (Vector n fp)
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | /O(1)/ Unsafely convert a mutable vector to an immutable one without
+-- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze
         :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = G.unsafeFreeze
 
--- | /O(n)/ Yield an immutable copy of the mutable vector.
+-- | \(O(n)\) Yield an immutable copy of the mutable vector.
 freeze :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE freeze #-}
 freeze = G.freeze
 
--- | /O(1)/ Unsafely convert an immutable vector to a mutable one
+-- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -1909,19 +1909,19 @@ unsafeThaw
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw
 
--- | /O(n)/ Yield a mutable copy of an immutable vector.
+-- | \(O(n)\) Yield a mutable copy of an immutable vector.
 thaw :: (Storable a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE thaw #-}
 thaw = G.thaw
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy
   :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy = G.unsafeCopy
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
@@ -1930,7 +1930,7 @@ copy = G.copy
 -- Conversions - Raw pointers
 -- --------------------------
 
--- | /O(1)/ Create a vector from a 'ForeignPtr' with an offset and a length.
+-- | \(O(1)\) Create a vector from a 'ForeignPtr' with an offset and a length.
 --
 -- The data may not be modified through the pointer afterwards.
 --
@@ -1950,7 +1950,7 @@ unsafeFromForeignPtr fp i n = unsafeFromForeignPtr0 fp' n
   unsafeFromForeignPtr fp 0 n = unsafeFromForeignPtr0 fp n   #-}
 
 
--- | /O(1)/ Create a vector from a 'ForeignPtr' and a length.
+-- | \(O(1)\) Create a vector from a 'ForeignPtr' and a length.
 --
 -- It is assumed the pointer points directly to the data (no offset).
 -- Use 'unsafeFromForeignPtr' if you need to specify an offset.
@@ -1962,13 +1962,13 @@ unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
 {-# INLINE unsafeFromForeignPtr0 #-}
 unsafeFromForeignPtr0 fp n = Vector n fp
 
--- | /O(1)/ Yield the underlying 'ForeignPtr' together with the offset to the
+-- | \(O(1)\) Yield the underlying 'ForeignPtr' together with the offset to the
 -- data and its length. The data may not be modified through the 'ForeignPtr'.
 unsafeToForeignPtr :: Vector a -> (ForeignPtr a, Int, Int)
 {-# INLINE unsafeToForeignPtr #-}
 unsafeToForeignPtr (Vector n fp) = (fp, 0, n)
 
--- | /O(1)/ Yield the underlying 'ForeignPtr' together with its length.
+-- | \(O(1)\) Yield the underlying 'ForeignPtr' together with its length.
 --
 -- You can assume that the pointer points directly to the data (no offset).
 --

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -340,12 +340,12 @@ null = G.null
 -- Indexing
 -- --------
 
--- | O(1) Indexing.
+-- | \(O(1)\) Indexing.
 (!) :: Storable a => Vector a -> Int -> a
 {-# INLINE (!) #-}
 (!) = (G.!)
 
--- | O(1) Safe indexing.
+-- | \(O(1)\) Safe indexing.
 (!?) :: Storable a => Vector a -> Int -> Maybe a
 {-# INLINE (!?) #-}
 (!?) = (G.!?)

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -208,7 +208,7 @@ import Unsafe.Coerce
 
 type role Vector nominal
 
--- | \(O(1)\) Unsafely coerce a mutable vector from one element type to another,
+-- | \(\mathcal{O}(1)\) Unsafely coerce a mutable vector from one element type to another,
 -- representationally equal type. The operation just changes the type of the
 -- underlying pointer and does not modify the elements.
 --
@@ -327,12 +327,12 @@ instance Storable a => Exts.IsList (Vector a) where
 -- Length
 -- ------
 
--- | \(O(1)\) Yield the length of the vector.
+-- | \(\mathcal{O}(1)\) Yield the length of the vector.
 length :: Storable a => Vector a -> Int
 {-# INLINE length #-}
 length = G.length
 
--- | \(O(1)\) Test whether a vector is empty.
+-- | \(\mathcal{O}(1)\) Test whether a vector is empty.
 null :: Storable a => Vector a -> Bool
 {-# INLINE null #-}
 null = G.null
@@ -340,37 +340,37 @@ null = G.null
 -- Indexing
 -- --------
 
--- | \(O(1)\) Indexing.
+-- | \(\mathcal{O}(1)\) Indexing.
 (!) :: Storable a => Vector a -> Int -> a
 {-# INLINE (!) #-}
 (!) = (G.!)
 
--- | \(O(1)\) Safe indexing.
+-- | \(\mathcal{O}(1)\) Safe indexing.
 (!?) :: Storable a => Vector a -> Int -> Maybe a
 {-# INLINE (!?) #-}
 (!?) = (G.!?)
 
--- | \(O(1)\) First element.
+-- | \(\mathcal{O}(1)\) First element.
 head :: Storable a => Vector a -> a
 {-# INLINE head #-}
 head = G.head
 
--- | \(O(1)\) Last element.
+-- | \(\mathcal{O}(1)\) Last element.
 last :: Storable a => Vector a -> a
 {-# INLINE last #-}
 last = G.last
 
--- | \(O(1)\) Unsafe indexing without bounds checking.
+-- | \(\mathcal{O}(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Storable a => Vector a -> Int -> a
 {-# INLINE unsafeIndex #-}
 unsafeIndex = G.unsafeIndex
 
--- | \(O(1)\) First element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Storable a => Vector a -> a
 {-# INLINE unsafeHead #-}
 unsafeHead = G.unsafeHead
 
--- | \(O(1)\) Last element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Storable a => Vector a -> a
 {-# INLINE unsafeLast #-}
 unsafeLast = G.unsafeLast
@@ -378,7 +378,7 @@ unsafeLast = G.unsafeLast
 -- Monadic indexing
 -- ----------------
 
--- | \(O(1)\) Indexing in a monad.
+-- | \(\mathcal{O}(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -400,31 +400,31 @@ indexM :: (Storable a, Monad m) => Vector a -> Int -> m a
 {-# INLINE indexM #-}
 indexM = G.indexM
 
--- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (Storable a, Monad m) => Vector a -> m a
 {-# INLINE headM #-}
 headM = G.headM
 
--- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (Storable a, Monad m) => Vector a -> m a
 {-# INLINE lastM #-}
 lastM = G.lastM
 
--- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (Storable a, Monad m) => Vector a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
 unsafeIndexM = G.unsafeIndexM
 
--- | \(O(1)\) First element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (Storable a, Monad m) => Vector a -> m a
 {-# INLINE unsafeHeadM #-}
 unsafeHeadM = G.unsafeHeadM
 
--- | \(O(1)\) Last element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (Storable a, Monad m) => Vector a -> m a
 {-# INLINE unsafeLastM #-}
@@ -433,7 +433,7 @@ unsafeLastM = G.unsafeLastM
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: Storable a
       => Int   -- ^ @i@ starting index
@@ -443,31 +443,31 @@ slice :: Storable a
 {-# INLINE slice #-}
 slice = G.slice
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Storable a => Vector a -> Vector a
 {-# INLINE init #-}
 init = G.init
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Storable a => Vector a -> Vector a
 {-# INLINE tail #-}
 tail = G.tail
 
--- | \(O(1)\) Yield at the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield at the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Storable a => Int -> Vector a -> Vector a
 {-# INLINE take #-}
 take = G.take
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Storable a => Int -> Vector a -> Vector a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -477,7 +477,7 @@ splitAt :: Storable a => Int -> Vector a -> (Vector a, Vector a)
 {-# INLINE splitAt #-}
 splitAt = G.splitAt
 
--- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -485,7 +485,7 @@ uncons :: Storable a => Vector a -> Maybe (a, Vector a)
 {-# INLINE uncons #-}
 uncons = G.uncons
 
--- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -493,7 +493,7 @@ unsnoc :: Storable a => Vector a -> Maybe (Vector a, a)
 {-# INLINE unsnoc #-}
 unsnoc = G.unsnoc
 
--- | \(O(1)\) Yield a slice of the vector without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Storable a => Int   -- ^ @i@ starting index
                        -> Int   -- ^ @n@ length
@@ -502,25 +502,25 @@ unsafeSlice :: Storable a => Int   -- ^ @i@ starting index
 {-# INLINE unsafeSlice #-}
 unsafeSlice = G.unsafeSlice
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Storable a => Vector a -> Vector a
 {-# INLINE unsafeInit #-}
 unsafeInit = G.unsafeInit
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Storable a => Vector a -> Vector a
 {-# INLINE unsafeTail #-}
 unsafeTail = G.unsafeTail
 
--- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Storable a => Int -> Vector a -> Vector a
 {-# INLINE unsafeTake #-}
 unsafeTake = G.unsafeTake
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Storable a => Int -> Vector a -> Vector a
 {-# INLINE unsafeDrop #-}
@@ -529,28 +529,28 @@ unsafeDrop = G.unsafeDrop
 -- Initialisation
 -- --------------
 
--- | \(O(1)\) The empty vector.
+-- | \(\mathcal{O}(1)\) The empty vector.
 empty :: Storable a => Vector a
 {-# INLINE empty #-}
 empty = G.empty
 
--- | \(O(1)\) A vector with exactly one element.
+-- | \(\mathcal{O}(1)\) A vector with exactly one element.
 singleton :: Storable a => a -> Vector a
 {-# INLINE singleton #-}
 singleton = G.singleton
 
--- | \(O(n)\) A vector of the given length with the same value in each position.
+-- | \(\mathcal{O}(n)\) A vector of the given length with the same value in each position.
 replicate :: Storable a => Int -> a -> Vector a
 {-# INLINE replicate #-}
 replicate = G.replicate
 
--- | \(O(n)\) Construct a vector of the given length by applying the function to
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Storable a => Int -> (Int -> a) -> Vector a
 {-# INLINE generate #-}
 generate = G.generate
 
--- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -572,7 +572,7 @@ iterateN = G.iterateN
 -- Unfolding
 -- ---------
 
--- | \(O(n)\) Construct a vector by repeatedly applying the generator function
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -582,7 +582,7 @@ unfoldr :: Storable a => (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldr #-}
 unfoldr = G.unfoldr
 
--- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -591,7 +591,7 @@ unfoldrN :: Storable a => Int -> (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldrN #-}
 unfoldrN = G.unfoldrN
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -602,7 +602,7 @@ unfoldrExactN :: (Storable a) => Int -> (b -> (a, b)) -> b -> Vector a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = G.unfoldrExactN
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -610,7 +610,7 @@ unfoldrM :: (Monad m, Storable a) => (b -> m (Maybe (a, b))) -> b -> m (Vector a
 {-# INLINE unfoldrM #-}
 unfoldrM = G.unfoldrM
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -618,7 +618,7 @@ unfoldrNM :: (Monad m, Storable a) => Int -> (b -> m (Maybe (a, b))) -> b -> m (
 {-# INLINE unfoldrNM #-}
 unfoldrNM = G.unfoldrNM
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -627,7 +627,7 @@ unfoldrExactNM :: (Monad m, Storable a) => Int -> (b -> m (a, b)) -> b -> m (Vec
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM = G.unfoldrExactNM
 
--- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -635,7 +635,7 @@ constructN :: Storable a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
 constructN = G.constructN
 
--- | \(O(n)\) Construct a vector with @n@ elements from right to left by
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -647,7 +647,7 @@ constructrN = G.constructrN
 -- Enumeration
 -- -----------
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -655,7 +655,7 @@ enumFromN :: (Storable a, Num a) => a -> Int -> Vector a
 {-# INLINE enumFromN #-}
 enumFromN = G.enumFromN
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -663,7 +663,7 @@ enumFromStepN :: (Storable a, Num a) => a -> a -> Int -> Vector a
 {-# INLINE enumFromStepN #-}
 enumFromStepN = G.enumFromStepN
 
--- | \(O(n)\) Enumerate values from @x@ to @y@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -671,7 +671,7 @@ enumFromTo :: (Storable a, Enum a) => a -> a -> Vector a
 {-# INLINE enumFromTo #-}
 enumFromTo = G.enumFromTo
 
--- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -682,23 +682,23 @@ enumFromThenTo = G.enumFromThenTo
 -- Concatenation
 -- -------------
 
--- | \(O(n)\) Prepend an element.
+-- | \(\mathcal{O}(n)\) Prepend an element.
 cons :: Storable a => a -> Vector a -> Vector a
 {-# INLINE cons #-}
 cons = G.cons
 
--- | \(O(n)\) Append an element.
+-- | \(\mathcal{O}(n)\) Append an element.
 snoc :: Storable a => Vector a -> a -> Vector a
 {-# INLINE snoc #-}
 snoc = G.snoc
 
 infixr 5 ++
--- | \(O(m+n)\) Concatenate two vectors.
+-- | \(\mathcal{O}(m+n)\) Concatenate two vectors.
 (++) :: Storable a => Vector a -> Vector a -> Vector a
 {-# INLINE (++) #-}
 (++) = (G.++)
 
--- | \(O(n)\) Concatenate all vectors in the list.
+-- | \(\mathcal{O}(n)\) Concatenate all vectors in the list.
 concat :: Storable a => [Vector a] -> Vector a
 {-# INLINE concat #-}
 concat = G.concat
@@ -706,19 +706,19 @@ concat = G.concat
 -- Monadic initialisation
 -- ----------------------
 
--- | \(O(n)\) Execute the monadic action the given number of times and store the
+-- | \(\mathcal{O}(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: (Monad m, Storable a) => Int -> m a -> m (Vector a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | \(O(n)\) Construct a vector of the given length by applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: (Monad m, Storable a) => Int -> (Int -> m a) -> m (Vector a)
 {-# INLINE generateM #-}
 generateM = G.generateM
 
--- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -747,7 +747,7 @@ createT p = G.createT p
 -- Restricting memory usage
 -- ------------------------
 
--- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
+-- | \(\mathcal{O}(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -764,7 +764,7 @@ force = G.force
 -- Bulk updates
 -- ------------
 
--- | \(O(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,a)@ from the list of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -775,7 +775,7 @@ force = G.force
 {-# INLINE (//) #-}
 (//) = (G.//)
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -802,7 +802,7 @@ unsafeUpdate_ = G.unsafeUpdate_
 -- Accumulations
 -- -------------
 
--- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -818,7 +818,7 @@ accum :: Storable a
 {-# INLINE accum #-}
 accum = G.accum
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -848,12 +848,12 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- Permutations
 -- ------------
 
--- | \(O(n)\) Reverse a vector.
+-- | \(\mathcal{O}(n)\) Reverse a vector.
 reverse :: Storable a => Vector a -> Vector a
 {-# INLINE reverse #-}
 reverse = G.reverse
 
--- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
+-- | \(\mathcal{O}(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -884,12 +884,12 @@ modify p = G.modify p
 -- Mapping
 -- -------
 
--- | \(O(n)\) Map a function over a vector.
+-- | \(\mathcal{O}(n)\) Map a function over a vector.
 map :: (Storable a, Storable b) => (a -> b) -> Vector a -> Vector b
 {-# INLINE map #-}
 map = G.map
 
--- | \(O(n)\) Apply a function to every element of a vector and its index.
+-- | \(\mathcal{O}(n)\) Apply a function to every element of a vector and its index.
 imap :: (Storable a, Storable b) => (Int -> a -> b) -> Vector a -> Vector b
 {-# INLINE imap #-}
 imap = G.imap
@@ -902,13 +902,13 @@ concatMap = G.concatMap
 -- Monadic mapping
 -- ---------------
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: (Monad m, Storable a, Storable b) => (a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE mapM #-}
 mapM = G.mapM
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 --
 -- @since 0.12.2.0
@@ -917,13 +917,13 @@ imapM :: (Monad m, Storable a, Storable b)
 {-# INLINE imapM #-}
 imapM = G.imapM
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: (Monad m, Storable a) => (a -> m b) -> Vector a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 --
 -- @since 0.12.2.0
@@ -931,19 +931,19 @@ imapM_ :: (Monad m, Storable a) => (Int -> a -> m b) -> Vector a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Storable a, Storable b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, Storable a) => Vector a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -951,7 +951,7 @@ iforM :: (Monad m, Storable a, Storable b) => Vector a -> (Int -> a -> m b) -> m
 {-# INLINE iforM #-}
 iforM = G.iforM
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -962,7 +962,7 @@ iforM_ = G.iforM_
 -- Zipping
 -- -------
 
--- | \(O(\min(m,n))\) Zip two vectors with the given function.
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (Storable a, Storable b, Storable c)
         => (a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE zipWith #-}
@@ -996,7 +996,7 @@ zipWith6 :: (Storable a, Storable b, Storable c, Storable d, Storable e,
 {-# INLINE zipWith6 #-}
 zipWith6 = G.zipWith6
 
--- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Storable a, Storable b, Storable c)
          => (Int -> a -> b -> c) -> Vector a -> Vector b -> Vector c
@@ -1045,14 +1045,14 @@ isSameVector (Vector n1 ptr1) (Vector n2 ptr2) = n1 == n2 && ptr1 == ptr2
 -- Monadic zipping
 -- ---------------
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: (Monad m, Storable a, Storable b, Storable c)
          => (a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE zipWithM #-}
 zipWithM = G.zipWithM
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 --
 -- @since 0.12.2.0
@@ -1061,14 +1061,14 @@ izipWithM :: (Monad m, Storable a, Storable b, Storable c)
 {-# INLINE izipWithM #-}
 izipWithM = G.izipWithM
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: (Monad m, Storable a, Storable b)
           => (a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ = G.zipWithM_
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 --
 -- @since 0.12.2.0
@@ -1080,18 +1080,18 @@ izipWithM_ = G.izipWithM_
 -- Filtering
 -- ---------
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate.
 filter :: Storable a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: Storable a => (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(\mathcal{O}(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1102,22 +1102,22 @@ uniq :: (Storable a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq
 
--- | \(O(n)\) Map the values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (Storable a, Storable b) => (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
--- | \(O(n)\) Map the indices/values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Storable a, Storable b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
 
--- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: (Monad m, Storable a) => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1127,7 +1127,7 @@ mapMaybeM
 {-# INLINE mapMaybeM #-}
 mapMaybeM = G.mapMaybeM
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1137,14 +1137,14 @@ imapMaybeM
 {-# INLINE imapMaybeM #-}
 imapMaybeM = G.imapMaybeM
 
--- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
+-- | \(\mathcal{O}(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: Storable a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE takeWhile #-}
 takeWhile = G.takeWhile
 
--- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
+-- | \(\mathcal{O}(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Storable a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
@@ -1153,7 +1153,7 @@ dropWhile = G.dropWhile
 -- Parititioning
 -- -------------
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1161,7 +1161,7 @@ partition :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE partition #-}
 partition = G.partition
 
--- | \(O(n)\) Split the vector into two parts, the first one containing the
+-- | \(\mathcal{O}(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1170,7 +1170,7 @@ partitionWith :: (Storable a, Storable b, Storable c) => (a -> Either b c) -> Ve
 {-# INLINE partitionWith #-}
 partitionWith = G.partitionWith
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1178,19 +1178,19 @@ unstablePartition :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector 
 {-# INLINE unstablePartition #-}
 unstablePartition = G.unstablePartition
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE span #-}
 span = G.span
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that do not
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE break #-}
 break = G.break
 
--- | \(O(n)\) Split a vector into a list of slices, using a predicate function.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices, using a predicate function.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1210,7 +1210,7 @@ groupBy :: Storable a => (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
 
--- | \(O(n)\) Split a vector into a list of slices of the input vector.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices of the input vector.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1234,43 +1234,43 @@ group = G.groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | \(O(n)\) Check if the vector contains an element.
+-- | \(\mathcal{O}(n)\) Check if the vector contains an element.
 elem :: (Storable a, Eq a) => a -> Vector a -> Bool
 {-# INLINE elem #-}
 elem = G.elem
 
 infix 4 `notElem`
--- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
+-- | \(\mathcal{O}(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: (Storable a, Eq a) => a -> Vector a -> Bool
 {-# INLINE notElem #-}
 notElem = G.notElem
 
--- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(\mathcal{O}(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: Storable a => (a -> Bool) -> Vector a -> Maybe a
 {-# INLINE find #-}
 find = G.find
 
--- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: Storable a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
 
--- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
+-- | \(\mathcal{O}(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: Storable a => (a -> Bool) -> Vector a -> Vector Int
 {-# INLINE findIndices #-}
 findIndices = G.findIndices
 
--- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: (Storable a, Eq a) => a -> Vector a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex = G.elemIndex
 
--- | \(O(n)\) Yield the indices of all occurrences of the given element in
+-- | \(\mathcal{O}(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: (Storable a, Eq a) => a -> Vector a -> Vector Int
 {-# INLINE elemIndices #-}
@@ -1279,69 +1279,69 @@ elemIndices = G.elemIndices
 -- Folding
 -- -------
 
--- | \(O(n)\) Left fold.
+-- | \(\mathcal{O}(n)\) Left fold.
 foldl :: Storable b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | \(O(n)\) Left fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors.
 foldl1 :: Storable a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1 #-}
 foldl1 = G.foldl1
 
--- | \(O(n)\) Left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator.
 foldl' :: Storable b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: Storable a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1' #-}
 foldl1' = G.foldl1'
 
--- | \(O(n)\) Right fold.
+-- | \(\mathcal{O}(n)\) Right fold.
 foldr :: Storable a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | \(O(n)\) Right fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors.
 foldr1 :: Storable a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1 #-}
 foldr1 = G.foldr1
 
--- | \(O(n)\) Right fold with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold with a strict accumulator.
 foldr' :: Storable a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: Storable a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1' #-}
 foldr1' = G.foldr1'
 
--- | \(O(n)\) Left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: Storable b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: Storable b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | \(O(n)\) Right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: Storable a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | \(O(n)\) Right fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: Storable a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | \(O(n)\) Map each element of the structure to a monoid and combine
+-- | \(\mathcal{O}(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type class. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1352,7 +1352,7 @@ foldMap :: (Monoid m, Storable a) => (a -> m) -> Vector a -> m
 {-# INLINE foldMap #-}
 foldMap = G.foldMap
 
--- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(\mathcal{O}(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1365,7 +1365,7 @@ foldMap' = G.foldMap'
 -- Specialised folds
 -- -----------------
 
--- | \(O(n)\) Check if all elements satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1380,7 +1380,7 @@ all :: Storable a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE all #-}
 all = G.all
 
--- | \(O(n)\) Check if any element satisfies the predicate.
+-- | \(\mathcal{O}(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1395,7 +1395,7 @@ any :: Storable a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE any #-}
 any = G.any
 
--- | \(O(n)\) Check if all elements are 'True'.
+-- | \(\mathcal{O}(n)\) Check if all elements are 'True'.
 --
 -- ==== __Examples__
 --
@@ -1408,7 +1408,7 @@ and :: Vector Bool -> Bool
 {-# INLINE and #-}
 and = G.and
 
--- | \(O(n)\) Check if any element is 'True'.
+-- | \(\mathcal{O}(n)\) Check if any element is 'True'.
 --
 -- ==== __Examples__
 --
@@ -1421,7 +1421,7 @@ or :: Vector Bool -> Bool
 {-# INLINE or #-}
 or = G.or
 
--- | \(O(n)\) Compute the sum of the elements.
+-- | \(\mathcal{O}(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1434,7 +1434,7 @@ sum :: (Storable a, Num a) => Vector a -> a
 {-# INLINE sum #-}
 sum = G.sum
 
--- | \(O(n)\) Compute the product of the elements.
+-- | \(\mathcal{O}(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1447,7 +1447,7 @@ product :: (Storable a, Num a) => Vector a -> a
 {-# INLINE product #-}
 product = G.product
 
--- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1459,7 +1459,7 @@ maximum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | \(O(n)\) Yield the maximum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1467,14 +1467,14 @@ maximumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
--- | \(O(n)\) Yield the maximum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 maximumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
 
--- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1486,40 +1486,40 @@ minimum :: (Storable a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | \(O(n)\) Yield the minimum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 minimumBy :: Storable a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
 
--- | \(O(n)\) Yield the minimum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 minimumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
 
--- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (Storable a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | \(O(n)\) Yield the index of the maximum element of the vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 maxIndexBy :: Storable a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
 
--- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (Storable a, Ord a) => Vector a -> Int
 {-# INLINE minIndex #-}
 minIndex = G.minIndex
 
--- | \(O(n)\) Yield the index of the minimum element of the vector according to
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 minIndexBy :: Storable a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE minIndexBy #-}
@@ -1528,29 +1528,29 @@ minIndexBy = G.minIndexBy
 -- Monadic folds
 -- -------------
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 foldM :: (Monad m, Storable b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.2.0
 ifoldM :: (Monad m, Storable b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | \(O(n)\) Monadic fold over non-empty vectors.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors.
 fold1M :: (Monad m, Storable a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M #-}
 fold1M = G.fold1M
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 foldM' :: (Monad m, Storable b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 --
 -- @since 0.12.2.0
@@ -1558,17 +1558,17 @@ ifoldM' :: (Monad m, Storable b) => (a -> Int -> b -> m a) -> a -> Vector b -> m
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: (Monad m, Storable a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M' #-}
 fold1M' = G.fold1M'
 
--- | \(O(n)\) Monadic fold that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result.
 foldM_ :: (Monad m, Storable b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ = G.foldM_
 
--- | \(O(n)\) Monadic fold that discards the result using a function applied to
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 --
 -- @since 0.12.2.0
@@ -1576,17 +1576,17 @@ ifoldM_ :: (Monad m, Storable b) => (a -> Int -> b -> m a) -> a -> Vector b -> m
 {-# INLINE ifoldM_ #-}
 ifoldM_ = G.ifoldM_
 
--- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: (Monad m, Storable a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ = G.fold1M_
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: (Monad m, Storable b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ = G.foldM'_
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 --
 -- @since 0.12.2.0
@@ -1595,7 +1595,7 @@ ifoldM'_ :: (Monad m, Storable b)
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ = G.ifoldM'_
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: (Monad m, Storable a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -1604,7 +1604,7 @@ fold1M'_ = G.fold1M'_
 -- Scans
 -- -----
 
--- | \(O(n)\) Left-to-right prescan.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -1619,12 +1619,12 @@ prescanl :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector
 {-# INLINE prescanl #-}
 prescanl = G.prescanl
 
--- | \(O(n)\) Left-to-right prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl' #-}
 prescanl' = G.prescanl'
 
--- | \(O(n)\) Left-to-right postscan.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -1639,12 +1639,12 @@ postscanl :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vecto
 {-# INLINE postscanl #-}
 postscanl = G.postscanl
 
--- | \(O(n)\) Left-to-right postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl' #-}
 postscanl' = G.postscanl'
 
--- | \(O(n)\) Left-to-right scan.
+-- | \(\mathcal{O}(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -1659,26 +1659,26 @@ scanl :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl #-}
 scanl = G.scanl
 
--- | \(O(n)\) Left-to-right scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (Storable a, Storable b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl' #-}
 scanl' = G.scanl'
 
--- | \(O(n)\) Left-to-right scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanl :: (Storable a, Storable b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl #-}
 iscanl = G.iscanl
 
--- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanl' :: (Storable a, Storable b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl' #-}
 iscanl' = G.iscanl'
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -1699,7 +1699,7 @@ scanl1 :: Storable a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1 #-}
 scanl1 = G.scanl1
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1716,7 +1716,7 @@ scanl1' :: Storable a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1' #-}
 scanl1' = G.scanl1'
 
--- | \(O(n)\) Right-to-left prescan.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -1725,46 +1725,46 @@ prescanr :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector
 {-# INLINE prescanr #-}
 prescanr = G.prescanr
 
--- | \(O(n)\) Right-to-left prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr' #-}
 prescanr' = G.prescanr'
 
--- | \(O(n)\) Right-to-left postscan.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan.
 postscanr :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr #-}
 postscanr = G.postscanr
 
--- | \(O(n)\) Right-to-left postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr' #-}
 postscanr' = G.postscanr'
 
--- | \(O(n)\) Right-to-left scan.
+-- | \(\mathcal{O}(n)\) Right-to-left scan.
 scanr :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr #-}
 scanr = G.scanr
 
--- | \(O(n)\) Right-to-left scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (Storable a, Storable b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr' #-}
 scanr' = G.scanr'
 
--- | \(O(n)\) Right-to-left scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanr :: (Storable a, Storable b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr #-}
 iscanr = G.iscanr
 
--- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanr' :: (Storable a, Storable b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr' #-}
 iscanr' = G.iscanr'
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1781,7 +1781,7 @@ scanr1 :: Storable a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanr1 #-}
 scanr1 = G.scanr1
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -1802,7 +1802,7 @@ scanr1' = G.scanr1'
 -- Comparisons
 -- ------------------------
 
--- | \(O(n)\) Check if two vectors are equal using the supplied equality
+-- | \(\mathcal{O}(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 --
 -- @since 0.12.2.0
@@ -1810,7 +1810,7 @@ eqBy :: (Storable a, Storable b) => (a -> b -> Bool) -> Vector a -> Vector b -> 
 {-# INLINE eqBy #-}
 eqBy = G.eqBy
 
--- | \(O(n)\) Compare two vectors using supplied the comparison function for
+-- | \(\mathcal{O}(n)\) Compare two vectors using supplied the comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == compare
@@ -1822,17 +1822,17 @@ cmpBy = G.cmpBy
 -- Conversions - Lists
 -- ------------------------
 
--- | \(O(n)\) Convert a vector to a list.
+-- | \(\mathcal{O}(n)\) Convert a vector to a list.
 toList :: Storable a => Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | \(O(n)\) Convert a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert a list to a vector.
 fromList :: Storable a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -1852,7 +1852,7 @@ fromListN = G.fromListN
 -- Conversions - Unsafe casts
 -- --------------------------
 
--- | \(O(1)\) Unsafely cast a vector from one element type to another.
+-- | \(\mathcal{O}(1)\) Unsafely cast a vector from one element type to another.
 -- This operation just changes the type of the underlying pointer and does not
 -- modify the elements.
 --
@@ -1867,19 +1867,19 @@ unsafeCast (Vector n fp)
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
+-- | \(\mathcal{O}(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze
         :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = G.unsafeFreeze
 
--- | \(O(n)\) Yield an immutable copy of the mutable vector.
+-- | \(\mathcal{O}(n)\) Yield an immutable copy of the mutable vector.
 freeze :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE freeze #-}
 freeze = G.freeze
 
--- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
+-- | \(\mathcal{O}(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -1909,19 +1909,19 @@ unsafeThaw
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw
 
--- | \(O(n)\) Yield a mutable copy of an immutable vector.
+-- | \(\mathcal{O}(n)\) Yield a mutable copy of an immutable vector.
 thaw :: (Storable a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE thaw #-}
 thaw = G.thaw
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy
   :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy = G.unsafeCopy
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
@@ -1930,7 +1930,7 @@ copy = G.copy
 -- Conversions - Raw pointers
 -- --------------------------
 
--- | \(O(1)\) Create a vector from a 'ForeignPtr' with an offset and a length.
+-- | \(\mathcal{O}(1)\) Create a vector from a 'ForeignPtr' with an offset and a length.
 --
 -- The data may not be modified through the pointer afterwards.
 --
@@ -1950,7 +1950,7 @@ unsafeFromForeignPtr fp i n = unsafeFromForeignPtr0 fp' n
   unsafeFromForeignPtr fp 0 n = unsafeFromForeignPtr0 fp n   #-}
 
 
--- | \(O(1)\) Create a vector from a 'ForeignPtr' and a length.
+-- | \(\mathcal{O}(1)\) Create a vector from a 'ForeignPtr' and a length.
 --
 -- It is assumed the pointer points directly to the data (no offset).
 -- Use 'unsafeFromForeignPtr' if you need to specify an offset.
@@ -1962,13 +1962,13 @@ unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
 {-# INLINE unsafeFromForeignPtr0 #-}
 unsafeFromForeignPtr0 fp n = Vector n fp
 
--- | \(O(1)\) Yield the underlying 'ForeignPtr' together with the offset to the
+-- | \(\mathcal{O}(1)\) Yield the underlying 'ForeignPtr' together with the offset to the
 -- data and its length. The data may not be modified through the 'ForeignPtr'.
 unsafeToForeignPtr :: Vector a -> (ForeignPtr a, Int, Int)
 {-# INLINE unsafeToForeignPtr #-}
 unsafeToForeignPtr (Vector n fp) = (fp, 0, n)
 
--- | \(O(1)\) Yield the underlying 'ForeignPtr' together with its length.
+-- | \(\mathcal{O}(1)\) Yield the underlying 'ForeignPtr' together with its length.
 --
 -- You can assume that the pointer points directly to the data (no offset).
 --

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -111,7 +111,7 @@ import Unsafe.Coerce
 
 type role MVector nominal nominal
 
--- | /O(1)/ Unsafely coerce a mutable vector from one element type to another,
+-- | \(O(1)\) Unsafely coerce a mutable vector from one element type to another,
 -- representationally equal type. The operation just changes the type of the
 -- underlying pointer and does not modify the elements.
 --
@@ -307,7 +307,7 @@ drop :: Storable a => Int -> MVector s a -> MVector s a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | /O(1)/ Split the mutable vector into the first @n@ elements
+-- | \(O(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -397,7 +397,7 @@ replicateM :: (PrimMonad m, Storable a) => Int -> m a -> m (MVector (PrimState m
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is negative)
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -406,7 +406,7 @@ generate :: (PrimMonad m, Storable a) => Int -> (Int -> a) -> m (MVector (PrimSt
 {-# INLINE generate #-}
 generate = G.generate
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -644,21 +644,21 @@ nextPermutation = G.nextPermutation
 -- Folds
 -- -----
 
--- | /O(n)/ Apply the monadic action to every element of the vector, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m, Storable a) => (a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector and its index, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
 --
 -- @since 0.12.3.0
 imapM_ :: (PrimMonad m, Storable a) => (Int -> a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector,
+-- | \(O(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -666,7 +666,7 @@ forM_ :: (PrimMonad m, Storable a) => MVector (PrimState m) a -> (a -> m b) -> m
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector
+-- | \(O(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -674,56 +674,56 @@ iforM_ :: (PrimMonad m, Storable a) => MVector (PrimState m) a -> (Int -> a -> m
 {-# INLINE iforM_ #-}
 iforM_ = G.iforM_
 
--- | /O(n)/ Pure left fold.
+-- | \(O(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m, Storable a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | /O(n)/ Pure left fold with strict accumulator.
+-- | \(O(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m, Storable a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | /O(n)/ Pure left fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m, Storable a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | /O(n)/ Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m, Storable a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | /O(n)/ Pure right fold.
+-- | \(O(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m, Storable a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | /O(n)/ Pure right fold with strict accumulator.
+-- | \(O(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m, Storable a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | /O(n)/ Pure right fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m, Storable a) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | /O(n)/ Pure right fold with strict accumulator using a function applied
+-- | \(O(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -731,56 +731,56 @@ ifoldr' :: (PrimMonad m, Storable a) => (Int -> a -> b -> b) -> b -> MVector (Pr
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m, Storable a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m, Storable a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m, Storable a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m, Storable a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | /O(n)/ Monadic right fold.
+-- | \(O(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m, Storable a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM = G.foldrM
 
--- | /O(n)/ Monadic right fold with strict accumulator.
+-- | \(O(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m, Storable a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' = G.foldrM'
 
--- | /O(n)/ Monadic right fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m, Storable a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM #-}
 ifoldrM = G.ifoldrM
 
--- | /O(n)/ Monadic right fold with strict accumulator using a function applied
+-- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -791,7 +791,7 @@ ifoldrM' = G.ifoldrM'
 -- Unsafe conversions
 -- ------------------
 
--- | /O(1)/ Unsafely cast a mutable vector from one element type to another.
+-- | \(O(1)\) Unsafely cast a mutable vector from one element type to another.
 -- The operation just changes the type of the underlying pointer and does not
 -- modify the elements.
 --
@@ -807,7 +807,7 @@ unsafeCast (MVector n fp)
 -- Raw pointers
 -- ------------
 
--- | /O(1)/ Create a mutable vector from a 'ForeignPtr' with an offset and a length.
+-- | \(O(1)\) Create a mutable vector from a 'ForeignPtr' with an offset and a length.
 --
 -- Modifying data through the 'ForeignPtr' afterwards is unsafe if the vector
 -- could have been frozen before the modification.
@@ -828,7 +828,7 @@ unsafeFromForeignPtr fp i n = unsafeFromForeignPtr0 fp' n
   unsafeFromForeignPtr fp 0 n = unsafeFromForeignPtr0 fp n   #-}
 
 
--- | /O(1)/ Create a mutable vector from a 'ForeignPtr' and a length.
+-- | \(O(1)\) Create a mutable vector from a 'ForeignPtr' and a length.
 --
 -- It is assumed that the pointer points directly to the data (no offset).
 -- Use 'unsafeFromForeignPtr' if you need to specify an offset.
@@ -841,14 +841,14 @@ unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
 {-# INLINE unsafeFromForeignPtr0 #-}
 unsafeFromForeignPtr0 fp n = MVector n fp
 
--- | /O(1)/ Yield the underlying 'ForeignPtr' together with the offset to the data
+-- | \(O(1)\) Yield the underlying 'ForeignPtr' together with the offset to the data
 -- and its length. Modifying the data through the 'ForeignPtr' is
 -- unsafe if the vector could have been frozen before the modification.
 unsafeToForeignPtr :: MVector s a -> (ForeignPtr a, Int, Int)
 {-# INLINE unsafeToForeignPtr #-}
 unsafeToForeignPtr (MVector n fp) = (fp, 0, n)
 
--- | /O(1)/ Yield the underlying 'ForeignPtr' together with its length.
+-- | \(O(1)\) Yield the underlying 'ForeignPtr' together with its length.
 --
 -- You can assume that the pointer points directly to the data (no offset).
 --

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -111,7 +111,7 @@ import Unsafe.Coerce
 
 type role MVector nominal nominal
 
--- | \(O(1)\) Unsafely coerce a mutable vector from one element type to another,
+-- | \(\mathcal{O}(1)\) Unsafely coerce a mutable vector from one element type to another,
 -- representationally equal type. The operation just changes the type of the
 -- underlying pointer and does not modify the elements.
 --
@@ -307,7 +307,7 @@ drop :: Storable a => Int -> MVector s a -> MVector s a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | \(O(1)\) Split the mutable vector into the first @n@ elements
+-- | \(\mathcal{O}(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -397,7 +397,7 @@ replicateM :: (PrimMonad m, Storable a) => Int -> m a -> m (MVector (PrimState m
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -406,7 +406,7 @@ generate :: (PrimMonad m, Storable a) => Int -> (Int -> a) -> m (MVector (PrimSt
 {-# INLINE generate #-}
 generate = G.generate
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -644,21 +644,21 @@ nextPermutation = G.nextPermutation
 -- Folds
 -- -----
 
--- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m, Storable a) => (a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector and its index, discarding the results.
 --
 -- @since 0.12.3.0
 imapM_ :: (PrimMonad m, Storable a) => (Int -> a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector,
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -666,7 +666,7 @@ forM_ :: (PrimMonad m, Storable a) => MVector (PrimState m) a -> (a -> m b) -> m
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -674,56 +674,56 @@ iforM_ :: (PrimMonad m, Storable a) => MVector (PrimState m) a -> (Int -> a -> m
 {-# INLINE iforM_ #-}
 iforM_ = G.iforM_
 
--- | \(O(n)\) Pure left fold.
+-- | \(\mathcal{O}(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m, Storable a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | \(O(n)\) Pure left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m, Storable a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | \(O(n)\) Pure left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m, Storable a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m, Storable a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | \(O(n)\) Pure right fold.
+-- | \(\mathcal{O}(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m, Storable a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | \(O(n)\) Pure right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m, Storable a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | \(O(n)\) Pure right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m, Storable a) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | \(O(n)\) Pure right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -731,56 +731,56 @@ ifoldr' :: (PrimMonad m, Storable a) => (Int -> a -> b -> b) -> b -> MVector (Pr
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m, Storable a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m, Storable a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m, Storable a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m, Storable a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | \(O(n)\) Monadic right fold.
+-- | \(\mathcal{O}(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m, Storable a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM = G.foldrM
 
--- | \(O(n)\) Monadic right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m, Storable a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' = G.foldrM'
 
--- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m, Storable a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM #-}
 ifoldrM = G.ifoldrM
 
--- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -791,7 +791,7 @@ ifoldrM' = G.ifoldrM'
 -- Unsafe conversions
 -- ------------------
 
--- | \(O(1)\) Unsafely cast a mutable vector from one element type to another.
+-- | \(\mathcal{O}(1)\) Unsafely cast a mutable vector from one element type to another.
 -- The operation just changes the type of the underlying pointer and does not
 -- modify the elements.
 --
@@ -807,7 +807,7 @@ unsafeCast (MVector n fp)
 -- Raw pointers
 -- ------------
 
--- | \(O(1)\) Create a mutable vector from a 'ForeignPtr' with an offset and a length.
+-- | \(\mathcal{O}(1)\) Create a mutable vector from a 'ForeignPtr' with an offset and a length.
 --
 -- Modifying data through the 'ForeignPtr' afterwards is unsafe if the vector
 -- could have been frozen before the modification.
@@ -828,7 +828,7 @@ unsafeFromForeignPtr fp i n = unsafeFromForeignPtr0 fp' n
   unsafeFromForeignPtr fp 0 n = unsafeFromForeignPtr0 fp n   #-}
 
 
--- | \(O(1)\) Create a mutable vector from a 'ForeignPtr' and a length.
+-- | \(\mathcal{O}(1)\) Create a mutable vector from a 'ForeignPtr' and a length.
 --
 -- It is assumed that the pointer points directly to the data (no offset).
 -- Use 'unsafeFromForeignPtr' if you need to specify an offset.
@@ -841,14 +841,14 @@ unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
 {-# INLINE unsafeFromForeignPtr0 #-}
 unsafeFromForeignPtr0 fp n = MVector n fp
 
--- | \(O(1)\) Yield the underlying 'ForeignPtr' together with the offset to the data
+-- | \(\mathcal{O}(1)\) Yield the underlying 'ForeignPtr' together with the offset to the data
 -- and its length. Modifying the data through the 'ForeignPtr' is
 -- unsafe if the vector could have been frozen before the modification.
 unsafeToForeignPtr :: MVector s a -> (ForeignPtr a, Int, Int)
 {-# INLINE unsafeToForeignPtr #-}
 unsafeToForeignPtr (MVector n fp) = (fp, 0, n)
 
--- | \(O(1)\) Yield the underlying 'ForeignPtr' together with its length.
+-- | \(\mathcal{O}(1)\) Yield the underlying 'ForeignPtr' together with its length.
 --
 -- You can assume that the pointer points directly to the data (no offset).
 --

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -284,12 +284,12 @@ instance (Unbox e) => Exts.IsList (Vector e) where
 -- Length information
 -- ------------------
 
--- | \(O(1)\) Yield the length of the vector.
+-- | \(\mathcal{O}(1)\) Yield the length of the vector.
 length :: Unbox a => Vector a -> Int
 {-# INLINE length #-}
 length = G.length
 
--- | \(O(1)\) Test whether a vector is empty.
+-- | \(\mathcal{O}(1)\) Test whether a vector is empty.
 null :: Unbox a => Vector a -> Bool
 {-# INLINE null #-}
 null = G.null
@@ -297,37 +297,37 @@ null = G.null
 -- Indexing
 -- --------
 
--- | \(O(1)\) Indexing.
+-- | \(\mathcal{O}(1)\) Indexing.
 (!) :: Unbox a => Vector a -> Int -> a
 {-# INLINE (!) #-}
 (!) = (G.!)
 
--- | \(O(1)\) Safe indexing.
+-- | \(\mathcal{O}(1)\) Safe indexing.
 (!?) :: Unbox a => Vector a -> Int -> Maybe a
 {-# INLINE (!?) #-}
 (!?) = (G.!?)
 
--- | \(O(1)\) First element.
+-- | \(\mathcal{O}(1)\) First element.
 head :: Unbox a => Vector a -> a
 {-# INLINE head #-}
 head = G.head
 
--- | \(O(1)\) Last element.
+-- | \(\mathcal{O}(1)\) Last element.
 last :: Unbox a => Vector a -> a
 {-# INLINE last #-}
 last = G.last
 
--- | \(O(1)\) Unsafe indexing without bounds checking.
+-- | \(\mathcal{O}(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Unbox a => Vector a -> Int -> a
 {-# INLINE unsafeIndex #-}
 unsafeIndex = G.unsafeIndex
 
--- | \(O(1)\) First element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Unbox a => Vector a -> a
 {-# INLINE unsafeHead #-}
 unsafeHead = G.unsafeHead
 
--- | \(O(1)\) Last element, without checking if the vector is empty.
+-- | \(\mathcal{O}(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Unbox a => Vector a -> a
 {-# INLINE unsafeLast #-}
 unsafeLast = G.unsafeLast
@@ -335,7 +335,7 @@ unsafeLast = G.unsafeLast
 -- Monadic indexing
 -- ----------------
 
--- | \(O(1)\) Indexing in a monad.
+-- | \(\mathcal{O}(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -357,31 +357,31 @@ indexM :: (Unbox a, Monad m) => Vector a -> Int -> m a
 {-# INLINE indexM #-}
 indexM = G.indexM
 
--- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (Unbox a, Monad m) => Vector a -> m a
 {-# INLINE headM #-}
 headM = G.headM
 
--- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (Unbox a, Monad m) => Vector a -> m a
 {-# INLINE lastM #-}
 lastM = G.lastM
 
--- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(\mathcal{O}(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (Unbox a, Monad m) => Vector a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
 unsafeIndexM = G.unsafeIndexM
 
--- | \(O(1)\) First element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (Unbox a, Monad m) => Vector a -> m a
 {-# INLINE unsafeHeadM #-}
 unsafeHeadM = G.unsafeHeadM
 
--- | \(O(1)\) Last element in a monad, without checking for empty vectors.
+-- | \(\mathcal{O}(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (Unbox a, Monad m) => Vector a -> m a
 {-# INLINE unsafeLastM #-}
@@ -390,7 +390,7 @@ unsafeLastM = G.unsafeLastM
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: Unbox a => Int   -- ^ @i@ starting index
                  -> Int   -- ^ @n@ length
@@ -399,31 +399,31 @@ slice :: Unbox a => Int   -- ^ @i@ starting index
 {-# INLINE slice #-}
 slice = G.slice
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Unbox a => Vector a -> Vector a
 {-# INLINE init #-}
 init = G.init
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Unbox a => Vector a -> Vector a
 {-# INLINE tail #-}
 tail = G.tail
 
--- | \(O(1)\) Yield at the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield at the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Unbox a => Int -> Vector a -> Vector a
 {-# INLINE take #-}
 take = G.take
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Unbox a => Int -> Vector a -> Vector a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -433,7 +433,7 @@ splitAt :: Unbox a => Int -> Vector a -> (Vector a, Vector a)
 {-# INLINE splitAt #-}
 splitAt = G.splitAt
 
--- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -441,7 +441,7 @@ uncons :: Unbox a => Vector a -> Maybe (a, Vector a)
 {-# INLINE uncons #-}
 uncons = G.uncons
 
--- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(\mathcal{O}(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -449,7 +449,7 @@ unsnoc :: Unbox a => Vector a -> Maybe (Vector a, a)
 {-# INLINE unsnoc #-}
 unsnoc = G.unsnoc
 
--- | \(O(1)\) Yield a slice of the vector without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Unbox a => Int   -- ^ @i@ starting index
                        -> Int   -- ^ @n@ length
@@ -458,25 +458,25 @@ unsafeSlice :: Unbox a => Int   -- ^ @i@ starting index
 {-# INLINE unsafeSlice #-}
 unsafeSlice = G.unsafeSlice
 
--- | \(O(1)\) Yield all but the last element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Unbox a => Vector a -> Vector a
 {-# INLINE unsafeInit #-}
 unsafeInit = G.unsafeInit
 
--- | \(O(1)\) Yield all but the first element without copying. The vector may not
+-- | \(\mathcal{O}(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Unbox a => Vector a -> Vector a
 {-# INLINE unsafeTail #-}
 unsafeTail = G.unsafeTail
 
--- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
+-- | \(\mathcal{O}(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Unbox a => Int -> Vector a -> Vector a
 {-# INLINE unsafeTake #-}
 unsafeTake = G.unsafeTake
 
--- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
+-- | \(\mathcal{O}(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Unbox a => Int -> Vector a -> Vector a
 {-# INLINE unsafeDrop #-}
@@ -485,28 +485,28 @@ unsafeDrop = G.unsafeDrop
 -- Initialisation
 -- --------------
 
--- | \(O(1)\) The empty vector.
+-- | \(\mathcal{O}(1)\) The empty vector.
 empty :: Unbox a => Vector a
 {-# INLINE empty #-}
 empty = G.empty
 
--- | \(O(1)\) A vector with exactly one element.
+-- | \(\mathcal{O}(1)\) A vector with exactly one element.
 singleton :: Unbox a => a -> Vector a
 {-# INLINE singleton #-}
 singleton = G.singleton
 
--- | \(O(n)\) A vector of the given length with the same value in each position.
+-- | \(\mathcal{O}(n)\) A vector of the given length with the same value in each position.
 replicate :: Unbox a => Int -> a -> Vector a
 {-# INLINE replicate #-}
 replicate = G.replicate
 
--- | \(O(n)\) Construct a vector of the given length by applying the function to
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Unbox a => Int -> (Int -> a) -> Vector a
 {-# INLINE generate #-}
 generate = G.generate
 
--- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -528,7 +528,7 @@ iterateN = G.iterateN
 -- Unfolding
 -- ---------
 
--- | \(O(n)\) Construct a vector by repeatedly applying the generator function
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -538,7 +538,7 @@ unfoldr :: Unbox a => (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldr #-}
 unfoldr = G.unfoldr
 
--- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -547,7 +547,7 @@ unfoldrN :: Unbox a => Int -> (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldrN #-}
 unfoldrN = G.unfoldrN
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -558,7 +558,7 @@ unfoldrExactN  :: Unbox a => Int -> (b -> (a, b)) -> b -> Vector a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = G.unfoldrExactN
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -566,7 +566,7 @@ unfoldrM :: (Monad m, Unbox a) => (b -> m (Maybe (a, b))) -> b -> m (Vector a)
 {-# INLINE unfoldrM #-}
 unfoldrM = G.unfoldrM
 
--- | \(O(n)\) Construct a vector by repeatedly applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -574,7 +574,7 @@ unfoldrNM :: (Monad m, Unbox a) => Int -> (b -> m (Maybe (a, b))) -> b -> m (Vec
 {-# INLINE unfoldrNM #-}
 unfoldrNM = G.unfoldrNM
 
--- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
+-- | \(\mathcal{O}(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -583,7 +583,7 @@ unfoldrExactNM :: (Monad m, Unbox a) => Int -> (b -> m (a, b)) -> b -> m (Vector
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM = G.unfoldrExactNM
 
--- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -591,7 +591,7 @@ constructN :: Unbox a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
 constructN = G.constructN
 
--- | \(O(n)\) Construct a vector with @n@ elements from right to left by
+-- | \(\mathcal{O}(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -603,7 +603,7 @@ constructrN = G.constructrN
 -- Enumeration
 -- -----------
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -611,7 +611,7 @@ enumFromN :: (Unbox a, Num a) => a -> Int -> Vector a
 {-# INLINE enumFromN #-}
 enumFromN = G.enumFromN
 
--- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(\mathcal{O}(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -619,7 +619,7 @@ enumFromStepN :: (Unbox a, Num a) => a -> a -> Int -> Vector a
 {-# INLINE enumFromStepN #-}
 enumFromStepN = G.enumFromStepN
 
--- | \(O(n)\) Enumerate values from @x@ to @y@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -627,7 +627,7 @@ enumFromTo :: (Unbox a, Enum a) => a -> a -> Vector a
 {-# INLINE enumFromTo #-}
 enumFromTo = G.enumFromTo
 
--- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(\mathcal{O}(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -638,23 +638,23 @@ enumFromThenTo = G.enumFromThenTo
 -- Concatenation
 -- -------------
 
--- | \(O(n)\) Prepend an element.
+-- | \(\mathcal{O}(n)\) Prepend an element.
 cons :: Unbox a => a -> Vector a -> Vector a
 {-# INLINE cons #-}
 cons = G.cons
 
--- | \(O(n)\) Append an element.
+-- | \(\mathcal{O}(n)\) Append an element.
 snoc :: Unbox a => Vector a -> a -> Vector a
 {-# INLINE snoc #-}
 snoc = G.snoc
 
 infixr 5 ++
--- | \(O(m+n)\) Concatenate two vectors.
+-- | \(\mathcal{O}(m+n)\) Concatenate two vectors.
 (++) :: Unbox a => Vector a -> Vector a -> Vector a
 {-# INLINE (++) #-}
 (++) = (G.++)
 
--- | \(O(n)\) Concatenate all vectors in the list.
+-- | \(\mathcal{O}(n)\) Concatenate all vectors in the list.
 concat :: Unbox a => [Vector a] -> Vector a
 {-# INLINE concat #-}
 concat = G.concat
@@ -662,19 +662,19 @@ concat = G.concat
 -- Monadic initialisation
 -- ----------------------
 
--- | \(O(n)\) Execute the monadic action the given number of times and store the
+-- | \(\mathcal{O}(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: (Monad m, Unbox a) => Int -> m a -> m (Vector a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | \(O(n)\) Construct a vector of the given length by applying the monadic
+-- | \(\mathcal{O}(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: (Monad m, Unbox a) => Int -> (Int -> m a) -> m (Vector a)
 {-# INLINE generateM #-}
 generateM = G.generateM
 
--- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(\mathcal{O}(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -703,7 +703,7 @@ createT p = G.createT p
 -- Restricting memory usage
 -- ------------------------
 
--- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
+-- | \(\mathcal{O}(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -720,7 +720,7 @@ force = G.force
 -- Bulk updates
 -- ------------
 
--- | \(O(m+n)\) For each pair @(i,a)@ from the list of idnex/value pairs,
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,a)@ from the list of idnex/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -731,7 +731,7 @@ force = G.force
 {-# INLINE (//) #-}
 (//) = (G.//)
 
--- | \(O(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > update <5,9,2,7> <(2,1),(0,3),(2,8)> = <3,9,8,7>
@@ -743,7 +743,7 @@ update :: Unbox a
 {-# INLINE update #-}
 update = G.update
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -781,7 +781,7 @@ unsafeUpdate_ = G.unsafeUpdate_
 -- Accumulations
 -- -------------
 
--- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -797,7 +797,7 @@ accum :: Unbox a
 {-# INLINE accum #-}
 accum = G.accum
 
--- | \(O(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
+-- | \(\mathcal{O}(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
 -- element @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -813,7 +813,7 @@ accumulate :: (Unbox a, Unbox b)
 {-# INLINE accumulate #-}
 accumulate = G.accumulate
 
--- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
+-- | \(\mathcal{O}(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -855,12 +855,12 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- Permutations
 -- ------------
 
--- | \(O(n)\) Reverse a vector.
+-- | \(\mathcal{O}(n)\) Reverse a vector.
 reverse :: Unbox a => Vector a -> Vector a
 {-# INLINE reverse #-}
 reverse = G.reverse
 
--- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
+-- | \(\mathcal{O}(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -891,7 +891,7 @@ modify p = G.modify p
 -- Indexing
 -- --------
 
--- | \(O(n)\) Pair each element in a vector with its index.
+-- | \(\mathcal{O}(n)\) Pair each element in a vector with its index.
 indexed :: Unbox a => Vector a -> Vector (Int,a)
 {-# INLINE indexed #-}
 indexed = G.indexed
@@ -899,12 +899,12 @@ indexed = G.indexed
 -- Mapping
 -- -------
 
--- | \(O(n)\) Map a function over a vector.
+-- | \(\mathcal{O}(n)\) Map a function over a vector.
 map :: (Unbox a, Unbox b) => (a -> b) -> Vector a -> Vector b
 {-# INLINE map #-}
 map = G.map
 
--- | \(O(n)\) Apply a function to every element of a vector and its index.
+-- | \(\mathcal{O}(n)\) Apply a function to every element of a vector and its index.
 imap :: (Unbox a, Unbox b) => (Int -> a -> b) -> Vector a -> Vector b
 {-# INLINE imap #-}
 imap = G.imap
@@ -917,44 +917,44 @@ concatMap = G.concatMap
 -- Monadic mapping
 -- ---------------
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: (Monad m, Unbox a, Unbox b) => (a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE mapM #-}
 mapM = G.mapM
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 imapM :: (Monad m, Unbox a, Unbox b)
       => (Int -> a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE imapM #-}
 imapM = G.imapM
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: (Monad m, Unbox a) => (a -> m b) -> Vector a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of a vector and its
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 imapM_ :: (Monad m, Unbox a) => (Int -> a -> m b) -> Vector a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Unbox a, Unbox b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM
 
--- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, Unbox a) => Vector a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -962,7 +962,7 @@ iforM :: (Monad m, Unbox a, Unbox b) => Vector a -> (Int -> a -> m b) -> m (Vect
 {-# INLINE iforM #-}
 iforM = G.iforM
 
--- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
+-- | \(\mathcal{O}(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -973,7 +973,7 @@ iforM_ = G.iforM_
 -- Zipping
 -- -------
 
--- | \(O(\min(m,n))\) Zip two vectors with the given function.
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (Unbox a, Unbox b, Unbox c)
         => (a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE zipWith #-}
@@ -1005,7 +1005,7 @@ zipWith6 :: (Unbox a, Unbox b, Unbox c, Unbox d, Unbox e, Unbox f, Unbox g)
 {-# INLINE zipWith6 #-}
 zipWith6 = G.zipWith6
 
--- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
+-- | \(\mathcal{O}(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Unbox a, Unbox b, Unbox c)
          => (Int -> a -> b -> c) -> Vector a -> Vector b -> Vector c
@@ -1042,28 +1042,28 @@ izipWith6 = G.izipWith6
 -- Monadic zipping
 -- ---------------
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: (Monad m, Unbox a, Unbox b, Unbox c)
          => (a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE zipWithM #-}
 zipWithM = G.zipWithM
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 izipWithM :: (Monad m, Unbox a, Unbox b, Unbox c)
           => (Int -> a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE izipWithM #-}
 izipWithM = G.izipWithM
 
--- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: (Monad m, Unbox a, Unbox b)
           => (a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ = G.zipWithM_
 
--- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
+-- | \(\mathcal{O}(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 izipWithM_ :: (Monad m, Unbox a, Unbox b)
            => (Int -> a -> b -> m c) -> Vector a -> Vector b -> m ()
@@ -1073,18 +1073,18 @@ izipWithM_ = G.izipWithM_
 -- Filtering
 -- ---------
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate.
 filter :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: Unbox a => (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(\mathcal{O}(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1098,22 +1098,22 @@ uniq :: (Unbox a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq
 
--- | \(O(n)\) Map the values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (Unbox a, Unbox b) => (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
--- | \(O(n)\) Map the indices/values and collect the 'Just' results.
+-- | \(\mathcal{O}(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Unbox a, Unbox b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
 
--- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
+-- | \(\mathcal{O}(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: (Monad m, Unbox a) => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1121,7 +1121,7 @@ mapMaybeM :: (Monad m, Unbox a, Unbox b) => (a -> m (Maybe b)) -> Vector a -> m 
 {-# INLINE mapMaybeM #-}
 mapMaybeM = G.mapMaybeM
 
--- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
+-- | \(\mathcal{O}(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1129,14 +1129,14 @@ imapMaybeM :: (Monad m, Unbox a, Unbox b) => (Int -> a -> m (Maybe b)) -> Vector
 {-# INLINE imapMaybeM #-}
 imapMaybeM = G.imapMaybeM
 
--- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
+-- | \(\mathcal{O}(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE takeWhile #-}
 takeWhile = G.takeWhile
 
--- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
+-- | \(\mathcal{O}(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
@@ -1145,7 +1145,7 @@ dropWhile = G.dropWhile
 -- Partitioning
 -- -------------
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1153,7 +1153,7 @@ partition :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE partition #-}
 partition = G.partition
 
--- | \(O(n)\) Split the vector into two parts, the first one containing the
+-- | \(\mathcal{O}(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1162,7 +1162,7 @@ partitionWith :: (Unbox a, Unbox b, Unbox c) => (a -> Either b c) -> Vector a ->
 {-# INLINE partitionWith #-}
 partitionWith = G.partitionWith
 
--- | \(O(n)\) Split the vector in two parts, the first one containing those
+-- | \(\mathcal{O}(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1170,19 +1170,19 @@ unstablePartition :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE unstablePartition #-}
 unstablePartition = G.unstablePartition
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE span #-}
 span = G.span
 
--- | \(O(n)\) Split the vector into the longest prefix of elements that do not
+-- | \(\mathcal{O}(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE break #-}
 break = G.break
 
--- | \(O(n)\) Split a vector into a list of slices, using a predicate function.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices, using a predicate function.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1201,7 +1201,7 @@ break = G.break
 groupBy :: Unbox a => (a -> a -> Bool) -> Vector a -> [Vector a]
 groupBy = G.groupBy
 
--- | \(O(n)\) Split a vector into a list of slices of the input vector.
+-- | \(\mathcal{O}(n)\) Split a vector into a list of slices of the input vector.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1224,43 +1224,43 @@ group = G.groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | \(O(n)\) Check if the vector contains an element.
+-- | \(\mathcal{O}(n)\) Check if the vector contains an element.
 elem :: (Unbox a, Eq a) => a -> Vector a -> Bool
 {-# INLINE elem #-}
 elem = G.elem
 
 infix 4 `notElem`
--- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
+-- | \(\mathcal{O}(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: (Unbox a, Eq a) => a -> Vector a -> Bool
 {-# INLINE notElem #-}
 notElem = G.notElem
 
--- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(\mathcal{O}(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: Unbox a => (a -> Bool) -> Vector a -> Maybe a
 {-# INLINE find #-}
 find = G.find
 
--- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: Unbox a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
 
--- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
+-- | \(\mathcal{O}(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: Unbox a => (a -> Bool) -> Vector a -> Vector Int
 {-# INLINE findIndices #-}
 findIndices = G.findIndices
 
--- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
+-- | \(\mathcal{O}(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: (Unbox a, Eq a) => a -> Vector a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex = G.elemIndex
 
--- | \(O(n)\) Yield the indices of all occurrences of the given element in
+-- | \(\mathcal{O}(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: (Unbox a, Eq a) => a -> Vector a -> Vector Int
 {-# INLINE elemIndices #-}
@@ -1269,69 +1269,69 @@ elemIndices = G.elemIndices
 -- Folding
 -- -------
 
--- | \(O(n)\) Left fold.
+-- | \(\mathcal{O}(n)\) Left fold.
 foldl :: Unbox b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | \(O(n)\) Left fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors.
 foldl1 :: Unbox a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1 #-}
 foldl1 = G.foldl1
 
--- | \(O(n)\) Left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator.
 foldl' :: Unbox b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: Unbox a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1' #-}
 foldl1' = G.foldl1'
 
--- | \(O(n)\) Right fold.
+-- | \(\mathcal{O}(n)\) Right fold.
 foldr :: Unbox a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | \(O(n)\) Right fold on non-empty vectors.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors.
 foldr1 :: Unbox a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1 #-}
 foldr1 = G.foldr1
 
--- | \(O(n)\) Right fold with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold with a strict accumulator.
 foldr' :: Unbox a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: Unbox a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1' #-}
 foldr1' = G.foldr1'
 
--- | \(O(n)\) Left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: Unbox b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
+-- | \(\mathcal{O}(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: Unbox b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | \(O(n)\) Right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: Unbox a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | \(O(n)\) Right fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: Unbox a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | \(O(n)\) Map each element of the structure to a monoid and combine
+-- | \(\mathcal{O}(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type cless. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1342,7 +1342,7 @@ foldMap :: (Monoid m, Unbox a) => (a -> m) -> Vector a -> m
 {-# INLINE foldMap #-}
 foldMap = G.foldMap
 
--- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(\mathcal{O}(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1355,7 +1355,7 @@ foldMap' = G.foldMap'
 -- Specialised folds
 -- -----------------
 
--- | \(O(n)\) Check if all elements satisfy the predicate.
+-- | \(\mathcal{O}(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1370,7 +1370,7 @@ all :: Unbox a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE all #-}
 all = G.all
 
--- | \(O(n)\) Check if any element satisfies the predicate.
+-- | \(\mathcal{O}(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1385,7 +1385,7 @@ any :: Unbox a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE any #-}
 any = G.any
 
--- | \(O(n)\) Check if all elements are 'True'.
+-- | \(\mathcal{O}(n)\) Check if all elements are 'True'.
 --
 -- ==== __Examples__
 --
@@ -1398,7 +1398,7 @@ and :: Vector Bool -> Bool
 {-# INLINE and #-}
 and = G.and
 
--- | \(O(n)\) Check if any element is 'True'.
+-- | \(\mathcal{O}(n)\) Check if any element is 'True'.
 --
 -- ==== __Examples__
 --
@@ -1411,7 +1411,7 @@ or :: Vector Bool -> Bool
 {-# INLINE or #-}
 or = G.or
 
--- | \(O(n)\) Compute the sum of the elements.
+-- | \(\mathcal{O}(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1424,7 +1424,7 @@ sum :: (Unbox a, Num a) => Vector a -> a
 {-# INLINE sum #-}
 sum = G.sum
 
--- | \(O(n)\) Compute the product of the elements.
+-- | \(\mathcal{O}(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1437,7 +1437,7 @@ product :: (Unbox a, Num a) => Vector a -> a
 {-# INLINE product #-}
 product = G.product
 
--- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1454,7 +1454,7 @@ maximum :: (Unbox a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | \(O(n)\) Yield the maximum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1471,7 +1471,7 @@ maximumBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
--- | \(O(n)\) Yield the maximum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1486,7 +1486,7 @@ maximumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
 
--- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1503,7 +1503,7 @@ minimum :: (Unbox a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | \(O(n)\) Yield the minimum element of the vector according to the
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 --
@@ -1516,12 +1516,12 @@ minimum = G.minimum
 -- >>> VU.minimumBy (comparing fst) $ VU.fromList [(1,'a'), (1 :: Int,'b')]
 -- (1,'a')
 minimumBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> a
--- | \(O(n)\) Yield the minimum element of the vector according to the given
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector according to the given
 -- comparison function. The vector may not be empty.
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
 
--- | \(O(n)\) Yield the minimum element of the vector by comparing the results
+-- | \(\mathcal{O}(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1536,13 +1536,13 @@ minimumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
 
--- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (Unbox a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | \(O(n)\) Yield the index of the maximum element of the vector
+-- | \(\mathcal{O}(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
@@ -1558,13 +1558,13 @@ maxIndexBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
 
--- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (Unbox a, Ord a) => Vector a -> Int
 {-# INLINE minIndex #-}
 minIndex = G.minIndex
 
--- | \(O(n)\) Yield the index of the minimum element of the vector according to
+-- | \(\mathcal{O}(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1582,66 +1582,66 @@ minIndexBy = G.minIndexBy
 -- Monadic folds
 -- -------------
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 foldM :: (Monad m, Unbox b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 ifoldM :: (Monad m, Unbox b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | \(O(n)\) Monadic fold over non-empty vectors.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors.
 fold1M :: (Monad m, Unbox a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M #-}
 fold1M = G.fold1M
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 foldM' :: (Monad m, Unbox b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldM' :: (Monad m, Unbox b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: (Monad m, Unbox a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M' #-}
 fold1M' = G.fold1M'
 
--- | \(O(n)\) Monadic fold that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result.
 foldM_ :: (Monad m, Unbox b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ = G.foldM_
 
--- | \(O(n)\) Monadic fold that discards the result using a function applied to
+-- | \(\mathcal{O}(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 ifoldM_ :: (Monad m, Unbox b) => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM_ #-}
 ifoldM_ = G.ifoldM_
 
--- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: (Monad m, Unbox a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ = G.fold1M_
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: (Monad m, Unbox b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ = G.foldM'_
 
--- | \(O(n)\) Monadic fold with strict accumulator that discards the result
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 ifoldM'_ :: (Monad m, Unbox b)
          => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ = G.ifoldM'_
 
--- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator
+-- | \(\mathcal{O}(n)\) Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: (Monad m, Unbox a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -1650,7 +1650,7 @@ fold1M'_ = G.fold1M'_
 -- Scans
 -- -----
 
--- | \(O(n)\) Left-to-right prescan.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -1665,12 +1665,12 @@ prescanl :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl #-}
 prescanl = G.prescanl
 
--- | \(O(n)\) Left-to-right prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl' #-}
 prescanl' = G.prescanl'
 
--- | \(O(n)\) Left-to-right postscan.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -1685,12 +1685,12 @@ postscanl :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl #-}
 postscanl = G.postscanl
 
--- | \(O(n)\) Left-to-right postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl' #-}
 postscanl' = G.postscanl'
 
--- | \(O(n)\) Left-to-right scan.
+-- | \(\mathcal{O}(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -1705,26 +1705,26 @@ scanl :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl #-}
 scanl = G.scanl
 
--- | \(O(n)\) Left-to-right scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl' #-}
 scanl' = G.scanl'
 
--- | \(O(n)\) Left-to-right scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanl :: (Unbox a, Unbox b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl #-}
 iscanl = G.iscanl
 
--- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Left-to-right scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanl' :: (Unbox a, Unbox b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl' #-}
 iscanl' = G.iscanl'
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -1745,7 +1745,7 @@ scanl1 :: Unbox a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1 #-}
 scanl1 = G.scanl1
 
--- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(\mathcal{O}(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1762,7 +1762,7 @@ scanl1' :: Unbox a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1' #-}
 scanl1' = G.scanl1'
 
--- | \(O(n)\) Right-to-left prescan.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -1771,46 +1771,46 @@ prescanr :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr #-}
 prescanr = G.prescanr
 
--- | \(O(n)\) Right-to-left prescan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr' #-}
 prescanr' = G.prescanr'
 
--- | \(O(n)\) Right-to-left postscan.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan.
 postscanr :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr #-}
 postscanr = G.postscanr
 
--- | \(O(n)\) Right-to-left postscan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr' #-}
 postscanr' = G.postscanr'
 
--- | \(O(n)\) Right-to-left scan.
+-- | \(\mathcal{O}(n)\) Right-to-left scan.
 scanr :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr #-}
 scanr = G.scanr
 
--- | \(O(n)\) Right-to-left scan with strict accumulator.
+-- | \(\mathcal{O}(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr' #-}
 scanr' = G.scanr'
 
--- | \(O(n)\) Right-to-left scan over a vector with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanr :: (Unbox a, Unbox b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr #-}
 iscanr = G.iscanr
 
--- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
+-- | \(\mathcal{O}(n)\) Right-to-left scan over a vector (strictly) with its index.
 --
 -- @sinqce 0.12.2.0
 iscanr' :: (Unbox a, Unbox b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr' #-}
 iscanr' = G.iscanr'
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1827,7 +1827,7 @@ scanr1 :: Unbox a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanr1 #-}
 scanr1 = G.scanr1
 
--- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
+-- | \(\mathcal{O}(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -1848,7 +1848,7 @@ scanr1' = G.scanr1'
 -- Comparisons
 -- ------------------------
 
--- | \(O(n)\) Check if two vectors are equal using the supplied equality
+-- | \(\mathcal{O}(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 --
 -- @since 0.12.2.0
@@ -1856,7 +1856,7 @@ eqBy :: (Unbox a, Unbox b) => (a -> b -> Bool) -> Vector a -> Vector b -> Bool
 {-# INLINE eqBy #-}
 eqBy = G.eqBy
 
--- | \(O(n)\) Compare two vectors using the supplied comparison function for
+-- | \(\mathcal{O}(n)\) Compare two vectors using the supplied comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == compare
@@ -1868,17 +1868,17 @@ cmpBy = G.cmpBy
 -- Conversions - Lists
 -- ------------------------
 
--- | \(O(n)\) Convert a vector to a list.
+-- | \(\mathcal{O}(n)\) Convert a vector to a list.
 toList :: Unbox a => Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | \(O(n)\) Convert a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert a list to a vector.
 fromList :: Unbox a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
+-- | \(\mathcal{O}(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -1898,18 +1898,18 @@ fromListN = G.fromListN
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
+-- | \(\mathcal{O}(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = G.unsafeFreeze
 
--- | \(O(n)\) Yield an immutable copy of the mutable vector.
+-- | \(\mathcal{O}(n)\) Yield an immutable copy of the mutable vector.
 freeze :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE freeze #-}
 freeze = G.freeze
 
--- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
+-- | \(\mathcal{O}(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -1938,19 +1938,19 @@ unsafeThaw :: (Unbox a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw
 
--- | \(O(n)\) Yield a mutable copy of an immutable vector.
+-- | \(\mathcal{O}(n)\) Yield a mutable copy of an immutable vector.
 thaw :: (Unbox a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE thaw #-}
 thaw = G.thaw
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy
   :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy = G.unsafeCopy
 
--- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
+-- | \(\mathcal{O}(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -284,12 +284,12 @@ instance (Unbox e) => Exts.IsList (Vector e) where
 -- Length information
 -- ------------------
 
--- | /O(1)/ Yield the length of the vector.
+-- | \(O(1)\) Yield the length of the vector.
 length :: Unbox a => Vector a -> Int
 {-# INLINE length #-}
 length = G.length
 
--- | /O(1)/ Test whether a vector is empty.
+-- | \(O(1)\) Test whether a vector is empty.
 null :: Unbox a => Vector a -> Bool
 {-# INLINE null #-}
 null = G.null
@@ -307,27 +307,27 @@ null = G.null
 {-# INLINE (!?) #-}
 (!?) = (G.!?)
 
--- | /O(1)/ First element.
+-- | \(O(1)\) First element.
 head :: Unbox a => Vector a -> a
 {-# INLINE head #-}
 head = G.head
 
--- | /O(1)/ Last element.
+-- | \(O(1)\) Last element.
 last :: Unbox a => Vector a -> a
 {-# INLINE last #-}
 last = G.last
 
--- | /O(1)/ Unsafe indexing without bounds checking.
+-- | \(O(1)\) Unsafe indexing without bounds checking.
 unsafeIndex :: Unbox a => Vector a -> Int -> a
 {-# INLINE unsafeIndex #-}
 unsafeIndex = G.unsafeIndex
 
--- | /O(1)/ First element, without checking if the vector is empty.
+-- | \(O(1)\) First element, without checking if the vector is empty.
 unsafeHead :: Unbox a => Vector a -> a
 {-# INLINE unsafeHead #-}
 unsafeHead = G.unsafeHead
 
--- | /O(1)/ Last element, without checking if the vector is empty.
+-- | \(O(1)\) Last element, without checking if the vector is empty.
 unsafeLast :: Unbox a => Vector a -> a
 {-# INLINE unsafeLast #-}
 unsafeLast = G.unsafeLast
@@ -335,7 +335,7 @@ unsafeLast = G.unsafeLast
 -- Monadic indexing
 -- ----------------
 
--- | /O(1)/ Indexing in a monad.
+-- | \(O(1)\) Indexing in a monad.
 --
 -- The monad allows operations to be strict in the vector when necessary.
 -- Suppose vector copying is implemented like this:
@@ -357,31 +357,31 @@ indexM :: (Unbox a, Monad m) => Vector a -> Int -> m a
 {-# INLINE indexM #-}
 indexM = G.indexM
 
--- | /O(1)/ First element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) First element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 headM :: (Unbox a, Monad m) => Vector a -> m a
 {-# INLINE headM #-}
 headM = G.headM
 
--- | /O(1)/ Last element of a vector in a monad. See 'indexM' for an
+-- | \(O(1)\) Last element of a vector in a monad. See 'indexM' for an
 -- explanation of why this is useful.
 lastM :: (Unbox a, Monad m) => Vector a -> m a
 {-# INLINE lastM #-}
 lastM = G.lastM
 
--- | /O(1)/ Indexing in a monad, without bounds checks. See 'indexM' for an
+-- | \(O(1)\) Indexing in a monad, without bounds checks. See 'indexM' for an
 -- explanation of why this is useful.
 unsafeIndexM :: (Unbox a, Monad m) => Vector a -> Int -> m a
 {-# INLINE unsafeIndexM #-}
 unsafeIndexM = G.unsafeIndexM
 
--- | /O(1)/ First element in a monad, without checking for empty vectors.
+-- | \(O(1)\) First element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeHeadM :: (Unbox a, Monad m) => Vector a -> m a
 {-# INLINE unsafeHeadM #-}
 unsafeHeadM = G.unsafeHeadM
 
--- | /O(1)/ Last element in a monad, without checking for empty vectors.
+-- | \(O(1)\) Last element in a monad, without checking for empty vectors.
 -- See 'indexM' for an explanation of why this is useful.
 unsafeLastM :: (Unbox a, Monad m) => Vector a -> m a
 {-# INLINE unsafeLastM #-}
@@ -390,7 +390,7 @@ unsafeLastM = G.unsafeLastM
 -- Extracting subvectors (slicing)
 -- -------------------------------
 
--- | /O(1)/ Yield a slice of the vector without copying it. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying it. The vector must
 -- contain at least @i+n@ elements.
 slice :: Unbox a => Int   -- ^ @i@ starting index
                  -> Int   -- ^ @n@ length
@@ -399,31 +399,31 @@ slice :: Unbox a => Int   -- ^ @i@ starting index
 {-# INLINE slice #-}
 slice = G.slice
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty.
 init :: Unbox a => Vector a -> Vector a
 {-# INLINE init #-}
 init = G.init
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty.
 tail :: Unbox a => Vector a -> Vector a
 {-# INLINE tail #-}
 tail = G.tail
 
--- | /O(1)/ Yield at the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield at the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case it is returned unchanged.
 take :: Unbox a => Int -> Vector a -> Vector a
 {-# INLINE take #-}
 take = G.take
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector may
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector may
 -- contain less than @n@ elements, in which case an empty vector is returned.
 drop :: Unbox a => Int -> Vector a -> Vector a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | /O(1)/ Yield the first @n@ elements paired with the remainder, without copying.
+-- | \(O(1)\) Yield the first @n@ elements paired with the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
 -- but slightly more efficient.
@@ -433,7 +433,7 @@ splitAt :: Unbox a => Int -> Vector a -> (Vector a, Vector a)
 {-# INLINE splitAt #-}
 splitAt = G.splitAt
 
--- | /O(1)/ Yield the 'head' and 'tail' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'head' and 'tail' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -441,7 +441,7 @@ uncons :: Unbox a => Vector a -> Maybe (a, Vector a)
 {-# INLINE uncons #-}
 uncons = G.uncons
 
--- | /O(1)/ Yield the 'last' and 'init' of the vector, or 'Nothing' if
+-- | \(O(1)\) Yield the 'last' and 'init' of the vector, or 'Nothing' if
 -- the vector is empty.
 --
 -- @since 0.12.2.0
@@ -449,7 +449,7 @@ unsnoc :: Unbox a => Vector a -> Maybe (Vector a, a)
 {-# INLINE unsnoc #-}
 unsnoc = G.unsnoc
 
--- | /O(1)/ Yield a slice of the vector without copying. The vector must
+-- | \(O(1)\) Yield a slice of the vector without copying. The vector must
 -- contain at least @i+n@ elements, but this is not checked.
 unsafeSlice :: Unbox a => Int   -- ^ @i@ starting index
                        -> Int   -- ^ @n@ length
@@ -458,25 +458,25 @@ unsafeSlice :: Unbox a => Int   -- ^ @i@ starting index
 {-# INLINE unsafeSlice #-}
 unsafeSlice = G.unsafeSlice
 
--- | /O(1)/ Yield all but the last element without copying. The vector may not
+-- | \(O(1)\) Yield all but the last element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeInit :: Unbox a => Vector a -> Vector a
 {-# INLINE unsafeInit #-}
 unsafeInit = G.unsafeInit
 
--- | /O(1)/ Yield all but the first element without copying. The vector may not
+-- | \(O(1)\) Yield all but the first element without copying. The vector may not
 -- be empty, but this is not checked.
 unsafeTail :: Unbox a => Vector a -> Vector a
 {-# INLINE unsafeTail #-}
 unsafeTail = G.unsafeTail
 
--- | /O(1)/ Yield the first @n@ elements without copying. The vector must
+-- | \(O(1)\) Yield the first @n@ elements without copying. The vector must
 -- contain at least @n@ elements, but this is not checked.
 unsafeTake :: Unbox a => Int -> Vector a -> Vector a
 {-# INLINE unsafeTake #-}
 unsafeTake = G.unsafeTake
 
--- | /O(1)/ Yield all but the first @n@ elements without copying. The vector
+-- | \(O(1)\) Yield all but the first @n@ elements without copying. The vector
 -- must contain at least @n@ elements, but this is not checked.
 unsafeDrop :: Unbox a => Int -> Vector a -> Vector a
 {-# INLINE unsafeDrop #-}
@@ -485,28 +485,28 @@ unsafeDrop = G.unsafeDrop
 -- Initialisation
 -- --------------
 
--- | /O(1)/ The empty vector.
+-- | \(O(1)\) The empty vector.
 empty :: Unbox a => Vector a
 {-# INLINE empty #-}
 empty = G.empty
 
--- | /O(1)/ A vector with exactly one element.
+-- | \(O(1)\) A vector with exactly one element.
 singleton :: Unbox a => a -> Vector a
 {-# INLINE singleton #-}
 singleton = G.singleton
 
--- | /O(n)/ A vector of the given length with the same value in each position.
+-- | \(O(n)\) A vector of the given length with the same value in each position.
 replicate :: Unbox a => Int -> a -> Vector a
 {-# INLINE replicate #-}
 replicate = G.replicate
 
--- | /O(n)/ Construct a vector of the given length by applying the function to
+-- | \(O(n)\) Construct a vector of the given length by applying the function to
 -- each index.
 generate :: Unbox a => Int -> (Int -> a) -> Vector a
 {-# INLINE generate #-}
 generate = G.generate
 
--- | /O(n)/ Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -528,7 +528,7 @@ iterateN = G.iterateN
 -- Unfolding
 -- ---------
 
--- | /O(n)/ Construct a vector by repeatedly applying the generator function
+-- | \(O(n)\) Construct a vector by repeatedly applying the generator function
 -- to a seed. The generator function yields 'Just' the next element and the
 -- new seed or 'Nothing' if there are no more elements.
 --
@@ -538,7 +538,7 @@ unfoldr :: Unbox a => (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldr #-}
 unfoldr = G.unfoldr
 
--- | /O(n)/ Construct a vector with at most @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with at most @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields 'Just' the
 -- next element and the new seed or 'Nothing' if there are no more elements.
 --
@@ -547,7 +547,7 @@ unfoldrN :: Unbox a => Int -> (b -> Maybe (a, b)) -> b -> Vector a
 {-# INLINE unfoldrN #-}
 unfoldrN = G.unfoldrN
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly applying
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly applying
 -- the generator function to a seed. The generator function yields the
 -- next element and the new seed.
 --
@@ -558,7 +558,7 @@ unfoldrExactN  :: Unbox a => Int -> (b -> (a, b)) -> b -> Vector a
 {-# INLINE unfoldrExactN #-}
 unfoldrExactN = G.unfoldrExactN
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -566,7 +566,7 @@ unfoldrM :: (Monad m, Unbox a) => (b -> m (Maybe (a, b))) -> b -> m (Vector a)
 {-# INLINE unfoldrM #-}
 unfoldrM = G.unfoldrM
 
--- | /O(n)/ Construct a vector by repeatedly applying the monadic
+-- | \(O(n)\) Construct a vector by repeatedly applying the monadic
 -- generator function to a seed. The generator function yields 'Just'
 -- the next element and the new seed or 'Nothing' if there are no more
 -- elements.
@@ -574,7 +574,7 @@ unfoldrNM :: (Monad m, Unbox a) => Int -> (b -> m (Maybe (a, b))) -> b -> m (Vec
 {-# INLINE unfoldrNM #-}
 unfoldrNM = G.unfoldrNM
 
--- | /O(n)/ Construct a vector with exactly @n@ elements by repeatedly
+-- | \(O(n)\) Construct a vector with exactly @n@ elements by repeatedly
 -- applying the monadic generator function to a seed. The generator
 -- function yields the next element and the new seed.
 --
@@ -583,7 +583,7 @@ unfoldrExactNM :: (Monad m, Unbox a) => Int -> (b -> m (a, b)) -> b -> m (Vector
 {-# INLINE unfoldrExactNM #-}
 unfoldrExactNM = G.unfoldrExactNM
 
--- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
+-- | \(O(n)\) Construct a vector with @n@ elements by repeatedly applying the
 -- generator function to the already constructed part of the vector.
 --
 -- > constructN 3 f = let a = f <> ; b = f <a> ; c = f <a,b> in <a,b,c>
@@ -591,7 +591,7 @@ constructN :: Unbox a => Int -> (Vector a -> a) -> Vector a
 {-# INLINE constructN #-}
 constructN = G.constructN
 
--- | /O(n)/ Construct a vector with @n@ elements from right to left by
+-- | \(O(n)\) Construct a vector with @n@ elements from right to left by
 -- repeatedly applying the generator function to the already constructed part
 -- of the vector.
 --
@@ -603,7 +603,7 @@ constructrN = G.constructrN
 -- Enumeration
 -- -----------
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+1@
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+1@
 -- etc. This operation is usually more efficient than 'enumFromTo'.
 --
 -- > enumFromN 5 3 = <5,6,7>
@@ -611,7 +611,7 @@ enumFromN :: (Unbox a, Num a) => a -> Int -> Vector a
 {-# INLINE enumFromN #-}
 enumFromN = G.enumFromN
 
--- | /O(n)/ Yield a vector of the given length, containing the values @x@, @x+y@,
+-- | \(O(n)\) Yield a vector of the given length, containing the values @x@, @x+y@,
 -- @x+y+y@ etc. This operations is usually more efficient than 'enumFromThenTo'.
 --
 -- > enumFromStepN 1 2 5 = <1,3,5,7,9>
@@ -619,7 +619,7 @@ enumFromStepN :: (Unbox a, Num a) => a -> a -> Int -> Vector a
 {-# INLINE enumFromStepN #-}
 enumFromStepN = G.enumFromStepN
 
--- | /O(n)/ Enumerate values from @x@ to @y@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromN' instead.
@@ -627,7 +627,7 @@ enumFromTo :: (Unbox a, Enum a) => a -> a -> Vector a
 {-# INLINE enumFromTo #-}
 enumFromTo = G.enumFromTo
 
--- | /O(n)/ Enumerate values from @x@ to @y@ with a specific step @z@.
+-- | \(O(n)\) Enumerate values from @x@ to @y@ with a specific step @z@.
 --
 -- /WARNING:/ This operation can be very inefficient. If possible, use
 -- 'enumFromStepN' instead.
@@ -638,23 +638,23 @@ enumFromThenTo = G.enumFromThenTo
 -- Concatenation
 -- -------------
 
--- | /O(n)/ Prepend an element.
+-- | \(O(n)\) Prepend an element.
 cons :: Unbox a => a -> Vector a -> Vector a
 {-# INLINE cons #-}
 cons = G.cons
 
--- | /O(n)/ Append an element.
+-- | \(O(n)\) Append an element.
 snoc :: Unbox a => Vector a -> a -> Vector a
 {-# INLINE snoc #-}
 snoc = G.snoc
 
 infixr 5 ++
--- | /O(m+n)/ Concatenate two vectors.
+-- | \(O(m+n)\) Concatenate two vectors.
 (++) :: Unbox a => Vector a -> Vector a -> Vector a
 {-# INLINE (++) #-}
 (++) = (G.++)
 
--- | /O(n)/ Concatenate all vectors in the list.
+-- | \(O(n)\) Concatenate all vectors in the list.
 concat :: Unbox a => [Vector a] -> Vector a
 {-# INLINE concat #-}
 concat = G.concat
@@ -662,19 +662,19 @@ concat = G.concat
 -- Monadic initialisation
 -- ----------------------
 
--- | /O(n)/ Execute the monadic action the given number of times and store the
+-- | \(O(n)\) Execute the monadic action the given number of times and store the
 -- results in a vector.
 replicateM :: (Monad m, Unbox a) => Int -> m a -> m (Vector a)
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | /O(n)/ Construct a vector of the given length by applying the monadic
+-- | \(O(n)\) Construct a vector of the given length by applying the monadic
 -- action to each index.
 generateM :: (Monad m, Unbox a) => Int -> (Int -> m a) -> m (Vector a)
 {-# INLINE generateM #-}
 generateM = G.generateM
 
--- | /O(n)/ Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
+-- | \(O(n)\) Apply the monadic function \(\max(n - 1, 0)\) times to an initial value, producing a vector
 -- of length \(\max(n, 0)\). The 0th element will contain the initial value, which is why there
 -- is one less function application than the number of elements in the produced vector.
 --
@@ -703,7 +703,7 @@ createT p = G.createT p
 -- Restricting memory usage
 -- ------------------------
 
--- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
+-- | \(O(n)\) Yield the argument, but force it not to retain any extra memory,
 -- possibly by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
@@ -720,7 +720,7 @@ force = G.force
 -- Bulk updates
 -- ------------
 
--- | /O(m+n)/ For each pair @(i,a)@ from the list of idnex/value pairs,
+-- | \(O(m+n)\) For each pair @(i,a)@ from the list of idnex/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > <5,9,2,7> // [(2,1),(0,3),(2,8)] = <3,9,8,7>
@@ -731,7 +731,7 @@ force = G.force
 {-# INLINE (//) #-}
 (//) = (G.//)
 
--- | /O(m+n)/ For each pair @(i,a)@ from the vector of index/value pairs,
+-- | \(O(m+n)\) For each pair @(i,a)@ from the vector of index/value pairs,
 -- replace the vector element at position @i@ by @a@.
 --
 -- > update <5,9,2,7> <(2,1),(0,3),(2,8)> = <3,9,8,7>
@@ -743,7 +743,7 @@ update :: Unbox a
 {-# INLINE update #-}
 update = G.update
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @a@ from the value vector, replace the element of the
 -- initial vector at position @i@ by @a@.
 --
@@ -781,7 +781,7 @@ unsafeUpdate_ = G.unsafeUpdate_
 -- Accumulations
 -- -------------
 
--- | /O(m+n)/ For each pair @(i,b)@ from the list, replace the vector element
+-- | \(O(m+n)\) For each pair @(i,b)@ from the list, replace the vector element
 -- @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -797,7 +797,7 @@ accum :: Unbox a
 {-# INLINE accum #-}
 accum = G.accum
 
--- | /O(m+n)/ For each pair @(i,b)@ from the vector of pairs, replace the vector
+-- | \(O(m+n)\) For each pair @(i,b)@ from the vector of pairs, replace the vector
 -- element @a@ at position @i@ by @f a b@.
 --
 -- ==== __Examples__
@@ -813,7 +813,7 @@ accumulate :: (Unbox a, Unbox b)
 {-# INLINE accumulate #-}
 accumulate = G.accumulate
 
--- | /O(m+min(n1,n2))/ For each index @i@ from the index vector and the
+-- | \(O(m+\min(n_1,n_2))\) For each index @i@ from the index vector and the
 -- corresponding value @b@ from the the value vector,
 -- replace the element of the initial vector at
 -- position @i@ by @f a b@.
@@ -855,12 +855,12 @@ unsafeAccumulate_ = G.unsafeAccumulate_
 -- Permutations
 -- ------------
 
--- | /O(n)/ Reverse a vector.
+-- | \(O(n)\) Reverse a vector.
 reverse :: Unbox a => Vector a -> Vector a
 {-# INLINE reverse #-}
 reverse = G.reverse
 
--- | /O(n)/ Yield the vector obtained by replacing each element @i@ of the
+-- | \(O(n)\) Yield the vector obtained by replacing each element @i@ of the
 -- index vector by @xs'!'i@. This is equivalent to @'map' (xs'!') is@, but is
 -- often much more efficient.
 --
@@ -891,7 +891,7 @@ modify p = G.modify p
 -- Indexing
 -- --------
 
--- | /O(n)/ Pair each element in a vector with its index.
+-- | \(O(n)\) Pair each element in a vector with its index.
 indexed :: Unbox a => Vector a -> Vector (Int,a)
 {-# INLINE indexed #-}
 indexed = G.indexed
@@ -899,12 +899,12 @@ indexed = G.indexed
 -- Mapping
 -- -------
 
--- | /O(n)/ Map a function over a vector.
+-- | \(O(n)\) Map a function over a vector.
 map :: (Unbox a, Unbox b) => (a -> b) -> Vector a -> Vector b
 {-# INLINE map #-}
 map = G.map
 
--- | /O(n)/ Apply a function to every element of a vector and its index.
+-- | \(O(n)\) Apply a function to every element of a vector and its index.
 imap :: (Unbox a, Unbox b) => (Int -> a -> b) -> Vector a -> Vector b
 {-# INLINE imap #-}
 imap = G.imap
@@ -917,44 +917,44 @@ concatMap = G.concatMap
 -- Monadic mapping
 -- ---------------
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results.
 mapM :: (Monad m, Unbox a, Unbox b) => (a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE mapM #-}
 mapM = G.mapM
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, yielding a vector of results.
 imapM :: (Monad m, Unbox a, Unbox b)
       => (Int -> a -> m b) -> Vector a -> m (Vector b)
 {-# INLINE imapM #-}
 imapM = G.imapM
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results.
 mapM_ :: (Monad m, Unbox a) => (a -> m b) -> Vector a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | /O(n)/ Apply the monadic action to every element of a vector and its
+-- | \(O(n)\) Apply the monadic action to every element of a vector and its
 -- index, ignoring the results.
 imapM_ :: (Monad m, Unbox a) => (Int -> a -> m b) -> Vector a -> m ()
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | /O(n)/ Apply the monadic action to all elements of the vector, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector, yielding a
 -- vector of results. Equivalent to @flip 'mapM'@.
 forM :: (Monad m, Unbox a, Unbox b) => Vector a -> (a -> m b) -> m (Vector b)
 {-# INLINE forM #-}
 forM = G.forM
 
--- | /O(n)/ Apply the monadic action to all elements of a vector and ignore the
+-- | \(O(n)\) Apply the monadic action to all elements of a vector and ignore the
 -- results. Equivalent to @flip 'mapM_'@.
 forM_ :: (Monad m, Unbox a) => Vector a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices, yielding a
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices, yielding a
 -- vector of results. Equivalent to @'flip' 'imapM'@.
 --
 -- @since 0.12.2.0
@@ -962,7 +962,7 @@ iforM :: (Monad m, Unbox a, Unbox b) => Vector a -> (Int -> a -> m b) -> m (Vect
 {-# INLINE iforM #-}
 iforM = G.iforM
 
--- | /O(n)/ Apply the monadic action to all elements of the vector and their indices
+-- | \(O(n)\) Apply the monadic action to all elements of the vector and their indices
 -- and ignore the results. Equivalent to @'flip' 'imapM_'@.
 --
 -- @since 0.12.2.0
@@ -973,7 +973,7 @@ iforM_ = G.iforM_
 -- Zipping
 -- -------
 
--- | /O(min(m,n))/ Zip two vectors with the given function.
+-- | \(O(\min(m,n))\) Zip two vectors with the given function.
 zipWith :: (Unbox a, Unbox b, Unbox c)
         => (a -> b -> c) -> Vector a -> Vector b -> Vector c
 {-# INLINE zipWith #-}
@@ -1005,7 +1005,7 @@ zipWith6 :: (Unbox a, Unbox b, Unbox c, Unbox d, Unbox e, Unbox f, Unbox g)
 {-# INLINE zipWith6 #-}
 zipWith6 = G.zipWith6
 
--- | /O(min(m,n))/ Zip two vectors with a function that also takes the
+-- | \(O(\min(m,n))\) Zip two vectors with a function that also takes the
 -- elements' indices.
 izipWith :: (Unbox a, Unbox b, Unbox c)
          => (Int -> a -> b -> c) -> Vector a -> Vector b -> Vector c
@@ -1042,28 +1042,28 @@ izipWith6 = G.izipWith6
 -- Monadic zipping
 -- ---------------
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and yield a
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and yield a
 -- vector of results.
 zipWithM :: (Monad m, Unbox a, Unbox b, Unbox c)
          => (a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE zipWithM #-}
 zipWithM = G.zipWithM
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and yield a vector of results.
 izipWithM :: (Monad m, Unbox a, Unbox b, Unbox c)
           => (Int -> a -> b -> m c) -> Vector a -> Vector b -> m (Vector c)
 {-# INLINE izipWithM #-}
 izipWithM = G.izipWithM
 
--- | /O(min(m,n))/ Zip the two vectors with the monadic action and ignore the
+-- | \(O(\min(m,n))\) Zip the two vectors with the monadic action and ignore the
 -- results.
 zipWithM_ :: (Monad m, Unbox a, Unbox b)
           => (a -> b -> m c) -> Vector a -> Vector b -> m ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ = G.zipWithM_
 
--- | /O(min(m,n))/ Zip the two vectors with a monadic action that also takes
+-- | \(O(\min(m,n))\) Zip the two vectors with a monadic action that also takes
 -- the element index and ignore the results.
 izipWithM_ :: (Monad m, Unbox a, Unbox b)
            => (Int -> a -> b -> m c) -> Vector a -> Vector b -> m ()
@@ -1073,18 +1073,18 @@ izipWithM_ = G.izipWithM_
 -- Filtering
 -- ---------
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate.
 filter :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE filter #-}
 filter = G.filter
 
--- | /O(n)/ Drop all elements that do not satisfy the predicate which is applied to
+-- | \(O(n)\) Drop all elements that do not satisfy the predicate which is applied to
 -- the values and their indices.
 ifilter :: Unbox a => (Int -> a -> Bool) -> Vector a -> Vector a
 {-# INLINE ifilter #-}
 ifilter = G.ifilter
 
--- | /O(n)/ Drop repeated adjacent elements. The first element in each group is returned.
+-- | \(O(n)\) Drop repeated adjacent elements. The first element in each group is returned.
 --
 -- ==== __Examples__
 --
@@ -1098,22 +1098,22 @@ uniq :: (Unbox a, Eq a) => Vector a -> Vector a
 {-# INLINE uniq #-}
 uniq = G.uniq
 
--- | /O(n)/ Map the values and collect the 'Just' results.
+-- | \(O(n)\) Map the values and collect the 'Just' results.
 mapMaybe :: (Unbox a, Unbox b) => (a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE mapMaybe #-}
 mapMaybe = G.mapMaybe
 
--- | /O(n)/ Map the indices/values and collect the 'Just' results.
+-- | \(O(n)\) Map the indices/values and collect the 'Just' results.
 imapMaybe :: (Unbox a, Unbox b) => (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
 
--- | /O(n)/ Drop all elements that do not satisfy the monadic predicate.
+-- | \(O(n)\) Drop all elements that do not satisfy the monadic predicate.
 filterM :: (Monad m, Unbox a) => (a -> m Bool) -> Vector a -> m (Vector a)
 {-# INLINE filterM #-}
 filterM = G.filterM
 
--- | /O(n)/ Apply the monadic function to each element of the vector and
+-- | \(O(n)\) Apply the monadic function to each element of the vector and
 -- discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1121,7 +1121,7 @@ mapMaybeM :: (Monad m, Unbox a, Unbox b) => (a -> m (Maybe b)) -> Vector a -> m 
 {-# INLINE mapMaybeM #-}
 mapMaybeM = G.mapMaybeM
 
--- | /O(n)/ Apply the monadic function to each element of the vector and its index.
+-- | \(O(n)\) Apply the monadic function to each element of the vector and its index.
 -- Discard elements returning 'Nothing'.
 --
 -- @since 0.12.2.0
@@ -1129,14 +1129,14 @@ imapMaybeM :: (Monad m, Unbox a, Unbox b) => (Int -> a -> m (Maybe b)) -> Vector
 {-# INLINE imapMaybeM #-}
 imapMaybeM = G.imapMaybeM
 
--- | /O(n)/ Yield the longest prefix of elements satisfying the predicate.
+-- | \(O(n)\) Yield the longest prefix of elements satisfying the predicate.
 -- The current implementation is not copy-free, unless the result vector is
 -- fused away.
 takeWhile :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE takeWhile #-}
 takeWhile = G.takeWhile
 
--- | /O(n)/ Drop the longest prefix of elements that satisfy the predicate
+-- | \(O(n)\) Drop the longest prefix of elements that satisfy the predicate
 -- without copying.
 dropWhile :: Unbox a => (a -> Bool) -> Vector a -> Vector a
 {-# INLINE dropWhile #-}
@@ -1145,7 +1145,7 @@ dropWhile = G.dropWhile
 -- Partitioning
 -- -------------
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't. The
 -- relative order of the elements is preserved at the cost of a sometimes
 -- reduced performance compared to 'unstablePartition'.
@@ -1153,7 +1153,7 @@ partition :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE partition #-}
 partition = G.partition
 
--- | /O(n)/ Split the vector into two parts, the first one containing the
+-- | \(O(n)\) Split the vector into two parts, the first one containing the
 -- @`Left`@ elements and the second containing the @`Right`@ elements.
 -- The relative order of the elements is preserved.
 --
@@ -1162,7 +1162,7 @@ partitionWith :: (Unbox a, Unbox b, Unbox c) => (a -> Either b c) -> Vector a ->
 {-# INLINE partitionWith #-}
 partitionWith = G.partitionWith
 
--- | /O(n)/ Split the vector in two parts, the first one containing those
+-- | \(O(n)\) Split the vector in two parts, the first one containing those
 -- elements that satisfy the predicate and the second one those that don't.
 -- The order of the elements is not preserved, but the operation is often
 -- faster than 'partition'.
@@ -1170,19 +1170,19 @@ unstablePartition :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE unstablePartition #-}
 unstablePartition = G.unstablePartition
 
--- | /O(n)/ Split the vector into the longest prefix of elements that satisfy
+-- | \(O(n)\) Split the vector into the longest prefix of elements that satisfy
 -- the predicate and the rest without copying.
 span :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE span #-}
 span = G.span
 
--- | /O(n)/ Split the vector into the longest prefix of elements that do not
+-- | \(O(n)\) Split the vector into the longest prefix of elements that do not
 -- satisfy the predicate and the rest without copying.
 break :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE break #-}
 break = G.break
 
--- | /O(n)/ Split a vector into a list of slices, using a predicate function.
+-- | \(O(n)\) Split a vector into a list of slices, using a predicate function.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements, as determined by the equality
@@ -1201,7 +1201,7 @@ break = G.break
 groupBy :: Unbox a => (a -> a -> Bool) -> Vector a -> [Vector a]
 groupBy = G.groupBy
 
--- | /O(n)/ Split a vector into a list of slices of the input vector.
+-- | \(O(n)\) Split a vector into a list of slices of the input vector.
 --
 -- The concatenation of this list of slices is equal to the argument vector,
 -- and each slice contains only equal elements.
@@ -1224,43 +1224,43 @@ group = G.groupBy (==)
 -- ---------
 
 infix 4 `elem`
--- | /O(n)/ Check if the vector contains an element.
+-- | \(O(n)\) Check if the vector contains an element.
 elem :: (Unbox a, Eq a) => a -> Vector a -> Bool
 {-# INLINE elem #-}
 elem = G.elem
 
 infix 4 `notElem`
--- | /O(n)/ Check if the vector does not contain an element (inverse of 'elem').
+-- | \(O(n)\) Check if the vector does not contain an element (inverse of 'elem').
 notElem :: (Unbox a, Eq a) => a -> Vector a -> Bool
 {-# INLINE notElem #-}
 notElem = G.notElem
 
--- | /O(n)/ Yield 'Just' the first element matching the predicate or 'Nothing'
+-- | \(O(n)\) Yield 'Just' the first element matching the predicate or 'Nothing'
 -- if no such element exists.
 find :: Unbox a => (a -> Bool) -> Vector a -> Maybe a
 {-# INLINE find #-}
 find = G.find
 
--- | /O(n)/ Yield 'Just' the index of the first element matching the predicate
+-- | \(O(n)\) Yield 'Just' the index of the first element matching the predicate
 -- or 'Nothing' if no such element exists.
 findIndex :: Unbox a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
 
--- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
+-- | \(O(n)\) Yield the indices of elements satisfying the predicate in ascending
 -- order.
 findIndices :: Unbox a => (a -> Bool) -> Vector a -> Vector Int
 {-# INLINE findIndices #-}
 findIndices = G.findIndices
 
--- | /O(n)/ Yield 'Just' the index of the first occurrence of the given element or
+-- | \(O(n)\) Yield 'Just' the index of the first occurrence of the given element or
 -- 'Nothing' if the vector does not contain the element. This is a specialised
 -- version of 'findIndex'.
 elemIndex :: (Unbox a, Eq a) => a -> Vector a -> Maybe Int
 {-# INLINE elemIndex #-}
 elemIndex = G.elemIndex
 
--- | /O(n)/ Yield the indices of all occurrences of the given element in
+-- | \(O(n)\) Yield the indices of all occurrences of the given element in
 -- ascending order. This is a specialised version of 'findIndices'.
 elemIndices :: (Unbox a, Eq a) => a -> Vector a -> Vector Int
 {-# INLINE elemIndices #-}
@@ -1269,69 +1269,69 @@ elemIndices = G.elemIndices
 -- Folding
 -- -------
 
--- | /O(n)/ Left fold.
+-- | \(O(n)\) Left fold.
 foldl :: Unbox b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | /O(n)/ Left fold on non-empty vectors.
+-- | \(O(n)\) Left fold on non-empty vectors.
 foldl1 :: Unbox a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1 #-}
 foldl1 = G.foldl1
 
--- | /O(n)/ Left fold with strict accumulator.
+-- | \(O(n)\) Left fold with strict accumulator.
 foldl' :: Unbox b => (a -> b -> a) -> a -> Vector b -> a
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | /O(n)/ Left fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Left fold on non-empty vectors with strict accumulator.
 foldl1' :: Unbox a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldl1' #-}
 foldl1' = G.foldl1'
 
--- | /O(n)/ Right fold.
+-- | \(O(n)\) Right fold.
 foldr :: Unbox a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | /O(n)/ Right fold on non-empty vectors.
+-- | \(O(n)\) Right fold on non-empty vectors.
 foldr1 :: Unbox a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1 #-}
 foldr1 = G.foldr1
 
--- | /O(n)/ Right fold with a strict accumulator.
+-- | \(O(n)\) Right fold with a strict accumulator.
 foldr' :: Unbox a => (a -> b -> b) -> b -> Vector a -> b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | /O(n)/ Right fold on non-empty vectors with strict accumulator.
+-- | \(O(n)\) Right fold on non-empty vectors with strict accumulator.
 foldr1' :: Unbox a => (a -> a -> a) -> Vector a -> a
 {-# INLINE foldr1' #-}
 foldr1' = G.foldr1'
 
--- | /O(n)/ Left fold using a function applied to each element and its index.
+-- | \(O(n)\) Left fold using a function applied to each element and its index.
 ifoldl :: Unbox b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | /O(n)/ Left fold with strict accumulator using a function applied to each element
+-- | \(O(n)\) Left fold with strict accumulator using a function applied to each element
 -- and its index.
 ifoldl' :: Unbox b => (a -> Int -> b -> a) -> a -> Vector b -> a
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | /O(n)/ Right fold using a function applied to each element and its index.
+-- | \(O(n)\) Right fold using a function applied to each element and its index.
 ifoldr :: Unbox a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | /O(n)/ Right fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Right fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldr' :: Unbox a => (Int -> a -> b -> b) -> b -> Vector a -> b
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | /O(n)/ Map each element of the structure to a monoid and combine
+-- | \(O(n)\) Map each element of the structure to a monoid and combine
 -- the results. It uses the same implementation as the corresponding method
 -- of the 'Foldable' type cless. Note that it's implemented in terms of 'foldr'
 -- and won't fuse with functions that traverse the vector from left to
@@ -1342,7 +1342,7 @@ foldMap :: (Monoid m, Unbox a) => (a -> m) -> Vector a -> m
 {-# INLINE foldMap #-}
 foldMap = G.foldMap
 
--- | /O(n)/ Like 'foldMap', but strict in the accumulator. It uses the same
+-- | \(O(n)\) Like 'foldMap', but strict in the accumulator. It uses the same
 -- implementation as the corresponding method of the 'Foldable' type class.
 -- Note that it's implemented in terms of 'foldl'', so it fuses in most
 -- contexts.
@@ -1355,7 +1355,7 @@ foldMap' = G.foldMap'
 -- Specialised folds
 -- -----------------
 
--- | /O(n)/ Check if all elements satisfy the predicate.
+-- | \(O(n)\) Check if all elements satisfy the predicate.
 --
 -- ==== __Examples__
 --
@@ -1370,7 +1370,7 @@ all :: Unbox a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE all #-}
 all = G.all
 
--- | /O(n)/ Check if any element satisfies the predicate.
+-- | \(O(n)\) Check if any element satisfies the predicate.
 --
 -- ==== __Examples__
 --
@@ -1385,7 +1385,7 @@ any :: Unbox a => (a -> Bool) -> Vector a -> Bool
 {-# INLINE any #-}
 any = G.any
 
--- | /O(n)/ Check if all elements are 'True'.
+-- | \(O(n)\) Check if all elements are 'True'.
 --
 -- ==== __Examples__
 --
@@ -1398,7 +1398,7 @@ and :: Vector Bool -> Bool
 {-# INLINE and #-}
 and = G.and
 
--- | /O(n)/ Check if any element is 'True'.
+-- | \(O(n)\) Check if any element is 'True'.
 --
 -- ==== __Examples__
 --
@@ -1411,7 +1411,7 @@ or :: Vector Bool -> Bool
 {-# INLINE or #-}
 or = G.or
 
--- | /O(n)/ Compute the sum of the elements.
+-- | \(O(n)\) Compute the sum of the elements.
 --
 -- ==== __Examples__
 --
@@ -1424,7 +1424,7 @@ sum :: (Unbox a, Num a) => Vector a -> a
 {-# INLINE sum #-}
 sum = G.sum
 
--- | /O(n)/ Compute the product of the elements.
+-- | \(O(n)\) Compute the product of the elements.
 --
 -- ==== __Examples__
 --
@@ -1437,7 +1437,7 @@ product :: (Unbox a, Num a) => Vector a -> a
 {-# INLINE product #-}
 product = G.product
 
--- | /O(n)/ Yield the maximum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the maximum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1454,7 +1454,7 @@ maximum :: (Unbox a, Ord a) => Vector a -> a
 {-# INLINE maximum #-}
 maximum = G.maximum
 
--- | /O(n)/ Yield the maximum element of the vector according to the
+-- | \(O(n)\) Yield the maximum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins. This behavior is different from
 -- 'Data.List.maximumBy' which returns the last tie.
@@ -1471,7 +1471,7 @@ maximumBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> a
 {-# INLINE maximumBy #-}
 maximumBy = G.maximumBy
 
--- | /O(n)/ Yield the maximum element of the vector by comparing the results
+-- | \(O(n)\) Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1486,7 +1486,7 @@ maximumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
 
--- | /O(n)/ Yield the minimum element of the vector. The vector may not be
+-- | \(O(n)\) Yield the minimum element of the vector. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
 -- ==== __Examples__
@@ -1503,7 +1503,7 @@ minimum :: (Unbox a, Ord a) => Vector a -> a
 {-# INLINE minimum #-}
 minimum = G.minimum
 
--- | /O(n)/ Yield the minimum element of the vector according to the
+-- | \(O(n)\) Yield the minimum element of the vector according to the
 -- given comparison function. The vector may not be empty. In case of
 -- a tie, the first occurrence wins.
 --
@@ -1516,12 +1516,12 @@ minimum = G.minimum
 -- >>> VU.minimumBy (comparing fst) $ VU.fromList [(1,'a'), (1 :: Int,'b')]
 -- (1,'a')
 minimumBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> a
--- | /O(n)/ Yield the minimum element of the vector according to the given
+-- | \(O(n)\) Yield the minimum element of the vector according to the given
 -- comparison function. The vector may not be empty.
 {-# INLINE minimumBy #-}
 minimumBy = G.minimumBy
 
--- | /O(n)/ Yield the minimum element of the vector by comparing the results
+-- | \(O(n)\) Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
 --
@@ -1536,13 +1536,13 @@ minimumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn
 
--- | /O(n)/ Yield the index of the maximum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector. The vector
 -- may not be empty.
 maxIndex :: (Unbox a, Ord a) => Vector a -> Int
 {-# INLINE maxIndex #-}
 maxIndex = G.maxIndex
 
--- | /O(n)/ Yield the index of the maximum element of the vector
+-- | \(O(n)\) Yield the index of the maximum element of the vector
 -- according to the given comparison function. The vector may not be
 -- empty. In case of a tie, the first occurrence wins.
 --
@@ -1558,13 +1558,13 @@ maxIndexBy :: Unbox a => (a -> a -> Ordering) -> Vector a -> Int
 {-# INLINE maxIndexBy #-}
 maxIndexBy = G.maxIndexBy
 
--- | /O(n)/ Yield the index of the minimum element of the vector. The vector
+-- | \(O(n)\) Yield the index of the minimum element of the vector. The vector
 -- may not be empty.
 minIndex :: (Unbox a, Ord a) => Vector a -> Int
 {-# INLINE minIndex #-}
 minIndex = G.minIndex
 
--- | /O(n)/ Yield the index of the minimum element of the vector according to
+-- | \(O(n)\) Yield the index of the minimum element of the vector according to
 -- the given comparison function. The vector may not be empty.
 --
 -- ==== __Examples__
@@ -1582,66 +1582,66 @@ minIndexBy = G.minIndexBy
 -- Monadic folds
 -- -------------
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 foldM :: (Monad m, Unbox b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 ifoldM :: (Monad m, Unbox b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | /O(n)/ Monadic fold over non-empty vectors.
+-- | \(O(n)\) Monadic fold over non-empty vectors.
 fold1M :: (Monad m, Unbox a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M #-}
 fold1M = G.fold1M
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 foldM' :: (Monad m, Unbox b) => (a -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each
 -- element and its index.
 ifoldM' :: (Monad m, Unbox b) => (a -> Int -> b -> m a) -> a -> Vector b -> m a
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator.
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator.
 fold1M' :: (Monad m, Unbox a) => (a -> a -> m a) -> Vector a -> m a
 {-# INLINE fold1M' #-}
 fold1M' = G.fold1M'
 
--- | /O(n)/ Monadic fold that discards the result.
+-- | \(O(n)\) Monadic fold that discards the result.
 foldM_ :: (Monad m, Unbox b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM_ #-}
 foldM_ = G.foldM_
 
--- | /O(n)/ Monadic fold that discards the result using a function applied to
+-- | \(O(n)\) Monadic fold that discards the result using a function applied to
 -- each element and its index.
 ifoldM_ :: (Monad m, Unbox b) => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM_ #-}
 ifoldM_ = G.ifoldM_
 
--- | /O(n)/ Monadic fold over non-empty vectors that discards the result.
+-- | \(O(n)\) Monadic fold over non-empty vectors that discards the result.
 fold1M_ :: (Monad m, Unbox a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M_ #-}
 fold1M_ = G.fold1M_
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result.
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result.
 foldM'_ :: (Monad m, Unbox b) => (a -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE foldM'_ #-}
 foldM'_ = G.foldM'_
 
--- | /O(n)/ Monadic fold with strict accumulator that discards the result
+-- | \(O(n)\) Monadic fold with strict accumulator that discards the result
 -- using a function applied to each element and its index.
 ifoldM'_ :: (Monad m, Unbox b)
          => (a -> Int -> b -> m a) -> a -> Vector b -> m ()
 {-# INLINE ifoldM'_ #-}
 ifoldM'_ = G.ifoldM'_
 
--- | /O(n)/ Monadic fold over non-empty vectors with strict accumulator
+-- | \(O(n)\) Monadic fold over non-empty vectors with strict accumulator
 -- that discards the result.
 fold1M'_ :: (Monad m, Unbox a) => (a -> a -> m a) -> Vector a -> m ()
 {-# INLINE fold1M'_ #-}
@@ -1650,7 +1650,7 @@ fold1M'_ = G.fold1M'_
 -- Scans
 -- -----
 
--- | /O(n)/ Left-to-right prescan.
+-- | \(O(n)\) Left-to-right prescan.
 --
 -- @
 -- prescanl f z = 'init' . 'scanl' f z
@@ -1665,12 +1665,12 @@ prescanl :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl #-}
 prescanl = G.prescanl
 
--- | /O(n)/ Left-to-right prescan with strict accumulator.
+-- | \(O(n)\) Left-to-right prescan with strict accumulator.
 prescanl' :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE prescanl' #-}
 prescanl' = G.prescanl'
 
--- | /O(n)/ Left-to-right postscan.
+-- | \(O(n)\) Left-to-right postscan.
 --
 -- @
 -- postscanl f z = 'tail' . 'scanl' f z
@@ -1685,12 +1685,12 @@ postscanl :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl #-}
 postscanl = G.postscanl
 
--- | /O(n)/ Left-to-right postscan with strict accumulator.
+-- | \(O(n)\) Left-to-right postscan with strict accumulator.
 postscanl' :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE postscanl' #-}
 postscanl' = G.postscanl'
 
--- | /O(n)/ Left-to-right scan.
+-- | \(O(n)\) Left-to-right scan.
 --
 -- > scanl f z <x1,...,xn> = <y1,...,y(n+1)>
 -- >   where y1 = z
@@ -1705,26 +1705,26 @@ scanl :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl #-}
 scanl = G.scanl
 
--- | /O(n)/ Left-to-right scan with strict accumulator.
+-- | \(O(n)\) Left-to-right scan with strict accumulator.
 scanl' :: (Unbox a, Unbox b) => (a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE scanl' #-}
 scanl' = G.scanl'
 
--- | /O(n)/ Left-to-right scan over a vector with its index.
+-- | \(O(n)\) Left-to-right scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanl :: (Unbox a, Unbox b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl #-}
 iscanl = G.iscanl
 
--- | /O(n)/ Left-to-right scan over a vector (strictly) with its index.
+-- | \(O(n)\) Left-to-right scan over a vector (strictly) with its index.
 --
 -- @since 0.12.2.0
 iscanl' :: (Unbox a, Unbox b) => (Int -> a -> b -> a) -> a -> Vector b -> Vector a
 {-# INLINE iscanl' #-}
 iscanl' = G.iscanl'
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector.
 --
 -- > scanl f <x1,...,xn> = <y1,...,yn>
 -- >   where y1 = x1
@@ -1745,7 +1745,7 @@ scanl1 :: Unbox a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1 #-}
 scanl1 = G.scanl1
 
--- | /O(n)/ Initial-value free left-to-right scan over a vector with a strict accumulator.
+-- | \(O(n)\) Initial-value free left-to-right scan over a vector with a strict accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1762,7 +1762,7 @@ scanl1' :: Unbox a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanl1' #-}
 scanl1' = G.scanl1'
 
--- | /O(n)/ Right-to-left prescan.
+-- | \(O(n)\) Right-to-left prescan.
 --
 -- @
 -- prescanr f z = 'reverse' . 'prescanl' (flip f) z . 'reverse'
@@ -1771,46 +1771,46 @@ prescanr :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr #-}
 prescanr = G.prescanr
 
--- | /O(n)/ Right-to-left prescan with strict accumulator.
+-- | \(O(n)\) Right-to-left prescan with strict accumulator.
 prescanr' :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE prescanr' #-}
 prescanr' = G.prescanr'
 
--- | /O(n)/ Right-to-left postscan.
+-- | \(O(n)\) Right-to-left postscan.
 postscanr :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr #-}
 postscanr = G.postscanr
 
--- | /O(n)/ Right-to-left postscan with strict accumulator.
+-- | \(O(n)\) Right-to-left postscan with strict accumulator.
 postscanr' :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE postscanr' #-}
 postscanr' = G.postscanr'
 
--- | /O(n)/ Right-to-left scan.
+-- | \(O(n)\) Right-to-left scan.
 scanr :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr #-}
 scanr = G.scanr
 
--- | /O(n)/ Right-to-left scan with strict accumulator.
+-- | \(O(n)\) Right-to-left scan with strict accumulator.
 scanr' :: (Unbox a, Unbox b) => (a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE scanr' #-}
 scanr' = G.scanr'
 
--- | /O(n)/ Right-to-left scan over a vector with its index.
+-- | \(O(n)\) Right-to-left scan over a vector with its index.
 --
 -- @since 0.12.2.0
 iscanr :: (Unbox a, Unbox b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr #-}
 iscanr = G.iscanr
 
--- | /O(n)/ Right-to-left scan over a vector (strictly) with its index.
+-- | \(O(n)\) Right-to-left scan over a vector (strictly) with its index.
 --
 -- @sinqce 0.12.2.0
 iscanr' :: (Unbox a, Unbox b) => (Int -> a -> b -> b) -> b -> Vector a -> Vector b
 {-# INLINE iscanr' #-}
 iscanr' = G.iscanr'
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector.
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
 -- results in an error; instead it produces an empty vector.
@@ -1827,7 +1827,7 @@ scanr1 :: Unbox a => (a -> a -> a) -> Vector a -> Vector a
 {-# INLINE scanr1 #-}
 scanr1 = G.scanr1
 
--- | /O(n)/ Right-to-left, initial-value free scan over a vector with a strict
+-- | \(O(n)\) Right-to-left, initial-value free scan over a vector with a strict
 -- accumulator.
 --
 -- Note: Since 0.13, application of this to an empty vector no longer
@@ -1848,7 +1848,7 @@ scanr1' = G.scanr1'
 -- Comparisons
 -- ------------------------
 
--- | /O(n)/ Check if two vectors are equal using the supplied equality
+-- | \(O(n)\) Check if two vectors are equal using the supplied equality
 -- predicate.
 --
 -- @since 0.12.2.0
@@ -1856,7 +1856,7 @@ eqBy :: (Unbox a, Unbox b) => (a -> b -> Bool) -> Vector a -> Vector b -> Bool
 {-# INLINE eqBy #-}
 eqBy = G.eqBy
 
--- | /O(n)/ Compare two vectors using the supplied comparison function for
+-- | \(O(n)\) Compare two vectors using the supplied comparison function for
 -- vector elements. Comparison works the same as for lists.
 --
 -- > cmpBy compare == compare
@@ -1868,17 +1868,17 @@ cmpBy = G.cmpBy
 -- Conversions - Lists
 -- ------------------------
 
--- | /O(n)/ Convert a vector to a list.
+-- | \(O(n)\) Convert a vector to a list.
 toList :: Unbox a => Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | /O(n)/ Convert a list to a vector.
+-- | \(O(n)\) Convert a list to a vector.
 fromList :: Unbox a => [a] -> Vector a
 {-# INLINE fromList #-}
 fromList = G.fromList
 
--- | /O(n)/ Convert the first @n@ elements of a list to a vector.
+-- | \(O(n)\) Convert the first @n@ elements of a list to a vector.
 --
 -- @
 -- fromListN n xs = 'fromList' ('take' n xs)
@@ -1898,18 +1898,18 @@ fromListN = G.fromListN
 -- Conversions - Mutable vectors
 -- -----------------------------
 
--- | /O(1)/ Unsafely convert a mutable vector to an immutable one without
+-- | \(O(1)\) Unsafely convert a mutable vector to an immutable one without
 -- copying. The mutable vector may not be used after this operation.
 unsafeFreeze :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE unsafeFreeze #-}
 unsafeFreeze = G.unsafeFreeze
 
--- | /O(n)/ Yield an immutable copy of the mutable vector.
+-- | \(O(n)\) Yield an immutable copy of the mutable vector.
 freeze :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> m (Vector a)
 {-# INLINE freeze #-}
 freeze = G.freeze
 
--- | /O(1)/ Unsafely convert an immutable vector to a mutable one
+-- | \(O(1)\) Unsafely convert an immutable vector to a mutable one
 -- without copying. Note that this is a very dangerous function and
 -- generally it's only safe to read from the resulting vector. In this
 -- case, the immutable vector could be used safely as well.
@@ -1938,19 +1938,19 @@ unsafeThaw :: (Unbox a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE unsafeThaw #-}
 unsafeThaw = G.unsafeThaw
 
--- | /O(n)/ Yield a mutable copy of an immutable vector.
+-- | \(O(n)\) Yield a mutable copy of an immutable vector.
 thaw :: (Unbox a, PrimMonad m) => Vector a -> m (MVector (PrimState m) a)
 {-# INLINE thaw #-}
 thaw = G.thaw
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length. This is not checked.
 unsafeCopy
   :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE unsafeCopy #-}
 unsafeCopy = G.unsafeCopy
 
--- | /O(n)/ Copy an immutable vector into a mutable one. The two vectors must
+-- | \(O(n)\) Copy an immutable vector into a mutable one. The two vectors must
 -- have the same length.
 copy :: (Unbox a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -297,12 +297,12 @@ null = G.null
 -- Indexing
 -- --------
 
--- | O(1) Indexing.
+-- | \(O(1)\) Indexing.
 (!) :: Unbox a => Vector a -> Int -> a
 {-# INLINE (!) #-}
 (!) = (G.!)
 
--- | O(1) Safe indexing.
+-- | \(O(1)\) Safe indexing.
 (!?) :: Unbox a => Vector a -> Int -> Maybe a
 {-# INLINE (!?) #-}
 (!?) = (G.!?)

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -115,7 +115,7 @@ drop :: Unbox a => Int -> MVector s a -> MVector s a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | \(O(1)\) Split the mutable vector into the first @n@ elements
+-- | \(\mathcal{O}(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -205,7 +205,7 @@ replicateM :: (PrimMonad m, Unbox a) => Int -> m a -> m (MVector (PrimState m) a
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -214,7 +214,7 @@ generate :: (PrimMonad m, Unbox a) => Int -> (Int -> a) -> m (MVector (PrimState
 {-# INLINE generate #-}
 generate = G.generate
 
--- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
+-- | \(\mathcal{O}(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -450,14 +450,14 @@ nextPermutation = G.nextPermutation
 -- Folds
 -- -----
 
--- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m, Unbox a) => (a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector and its index,
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector and its index,
 -- discarding the results.
 --
 -- @since 0.12.3.0
@@ -465,7 +465,7 @@ imapM_ :: (PrimMonad m, Unbox a) => (Int -> a -> m b) -> MVector (PrimState m) a
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector,
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -473,7 +473,7 @@ forM_ :: (PrimMonad m, Unbox a) => MVector (PrimState m) a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | \(O(n)\) Apply the monadic action to every element of the vector
+-- | \(\mathcal{O}(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -481,56 +481,56 @@ iforM_ :: (PrimMonad m, Unbox a) => MVector (PrimState m) a -> (Int -> a -> m b)
 {-# INLINE iforM_ #-}
 iforM_ = G.iforM_
 
--- | \(O(n)\) Pure left fold.
+-- | \(\mathcal{O}(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m, Unbox a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | \(O(n)\) Pure left fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m, Unbox a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | \(O(n)\) Pure left fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m, Unbox a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m, Unbox a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | \(O(n)\) Pure right fold.
+-- | \(\mathcal{O}(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m, Unbox a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | \(O(n)\) Pure right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m, Unbox a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | \(O(n)\) Pure right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m, Unbox a) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | \(O(n)\) Pure right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -538,56 +538,56 @@ ifoldr' :: (PrimMonad m, Unbox a) => (Int -> a -> b -> b) -> b -> MVector (PrimS
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | \(O(n)\) Monadic fold.
+-- | \(\mathcal{O}(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m, Unbox a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | \(O(n)\) Monadic fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m, Unbox a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | \(O(n)\) Monadic fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m, Unbox a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m, Unbox a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | \(O(n)\) Monadic right fold.
+-- | \(\mathcal{O}(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m, Unbox a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM = G.foldrM
 
--- | \(O(n)\) Monadic right fold with strict accumulator.
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m, Unbox a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' = G.foldrM'
 
--- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
+-- | \(\mathcal{O}(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m, Unbox a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM #-}
 ifoldrM = G.ifoldrM
 
--- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
+-- | \(\mathcal{O}(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -115,7 +115,7 @@ drop :: Unbox a => Int -> MVector s a -> MVector s a
 {-# INLINE drop #-}
 drop = G.drop
 
--- | /O(1)/ Split the mutable vector into the first @n@ elements
+-- | \(O(1)\) Split the mutable vector into the first @n@ elements
 -- and the remainder, without copying.
 --
 -- Note that @'splitAt' n v@ is equivalent to @('take' n v, 'drop' n v)@,
@@ -205,7 +205,7 @@ replicateM :: (PrimMonad m, Unbox a) => Int -> m a -> m (MVector (PrimState m) a
 {-# INLINE replicateM #-}
 replicateM = G.replicateM
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is negative)
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is negative)
 -- and fill it with the results of applying the function to each index.
 -- Iteration starts at index 0.
 --
@@ -214,7 +214,7 @@ generate :: (PrimMonad m, Unbox a) => Int -> (Int -> a) -> m (MVector (PrimState
 {-# INLINE generate #-}
 generate = G.generate
 
--- | /O(n)/ Create a mutable vector of the given length (0 if the length is
+-- | \(O(n)\) Create a mutable vector of the given length (0 if the length is
 -- negative) and fill it with the results of applying the monadic function to each
 -- index. Iteration starts at index 0.
 --
@@ -450,14 +450,14 @@ nextPermutation = G.nextPermutation
 -- Folds
 -- -----
 
--- | /O(n)/ Apply the monadic action to every element of the vector, discarding the results.
+-- | \(O(n)\) Apply the monadic action to every element of the vector, discarding the results.
 --
 -- @since 0.12.3.0
 mapM_ :: (PrimMonad m, Unbox a) => (a -> m b) -> MVector (PrimState m) a -> m ()
 {-# INLINE mapM_ #-}
 mapM_ = G.mapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector and its index,
+-- | \(O(n)\) Apply the monadic action to every element of the vector and its index,
 -- discarding the results.
 --
 -- @since 0.12.3.0
@@ -465,7 +465,7 @@ imapM_ :: (PrimMonad m, Unbox a) => (Int -> a -> m b) -> MVector (PrimState m) a
 {-# INLINE imapM_ #-}
 imapM_ = G.imapM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector,
+-- | \(O(n)\) Apply the monadic action to every element of the vector,
 -- discarding the results. It's the same as @flip mapM_@.
 --
 -- @since 0.12.3.0
@@ -473,7 +473,7 @@ forM_ :: (PrimMonad m, Unbox a) => MVector (PrimState m) a -> (a -> m b) -> m ()
 {-# INLINE forM_ #-}
 forM_ = G.forM_
 
--- | /O(n)/ Apply the monadic action to every element of the vector
+-- | \(O(n)\) Apply the monadic action to every element of the vector
 -- and its index, discarding the results. It's the same as @flip imapM_@.
 --
 -- @since 0.12.3.0
@@ -481,56 +481,56 @@ iforM_ :: (PrimMonad m, Unbox a) => MVector (PrimState m) a -> (Int -> a -> m b)
 {-# INLINE iforM_ #-}
 iforM_ = G.iforM_
 
--- | /O(n)/ Pure left fold.
+-- | \(O(n)\) Pure left fold.
 --
 -- @since 0.12.3.0
 foldl :: (PrimMonad m, Unbox a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl #-}
 foldl = G.foldl
 
--- | /O(n)/ Pure left fold with strict accumulator.
+-- | \(O(n)\) Pure left fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldl' :: (PrimMonad m, Unbox a) => (b -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldl' #-}
 foldl' = G.foldl'
 
--- | /O(n)/ Pure left fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl :: (PrimMonad m, Unbox a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl #-}
 ifoldl = G.ifoldl
 
--- | /O(n)/ Pure left fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Pure left fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldl' :: (PrimMonad m, Unbox a) => (b -> Int -> a -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldl' #-}
 ifoldl' = G.ifoldl'
 
--- | /O(n)/ Pure right fold.
+-- | \(O(n)\) Pure right fold.
 --
 -- @since 0.12.3.0
 foldr :: (PrimMonad m, Unbox a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr #-}
 foldr = G.foldr
 
--- | /O(n)/ Pure right fold with strict accumulator.
+-- | \(O(n)\) Pure right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldr' :: (PrimMonad m, Unbox a) => (a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldr' #-}
 foldr' = G.foldr'
 
--- | /O(n)/ Pure right fold using a function applied to each element and its index.
+-- | \(O(n)\) Pure right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldr :: (PrimMonad m, Unbox a) => (Int -> a -> b -> b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldr #-}
 ifoldr = G.ifoldr
 
--- | /O(n)/ Pure right fold with strict accumulator using a function applied
+-- | \(O(n)\) Pure right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0
@@ -538,56 +538,56 @@ ifoldr' :: (PrimMonad m, Unbox a) => (Int -> a -> b -> b) -> b -> MVector (PrimS
 {-# INLINE ifoldr' #-}
 ifoldr' = G.ifoldr'
 
--- | /O(n)/ Monadic fold.
+-- | \(O(n)\) Monadic fold.
 --
 -- @since 0.12.3.0
 foldM :: (PrimMonad m, Unbox a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM #-}
 foldM = G.foldM
 
--- | /O(n)/ Monadic fold with strict accumulator.
+-- | \(O(n)\) Monadic fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldM' :: (PrimMonad m, Unbox a) => (b -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldM' #-}
 foldM' = G.foldM'
 
--- | /O(n)/ Monadic fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM :: (PrimMonad m, Unbox a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM #-}
 ifoldM = G.ifoldM
 
--- | /O(n)/ Monadic fold with strict accumulator using a function applied to each element and its index.
+-- | \(O(n)\) Monadic fold with strict accumulator using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldM' :: (PrimMonad m, Unbox a) => (b -> Int -> a -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldM' #-}
 ifoldM' = G.ifoldM'
 
--- | /O(n)/ Monadic right fold.
+-- | \(O(n)\) Monadic right fold.
 --
 -- @since 0.12.3.0
 foldrM :: (PrimMonad m, Unbox a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM #-}
 foldrM = G.foldrM
 
--- | /O(n)/ Monadic right fold with strict accumulator.
+-- | \(O(n)\) Monadic right fold with strict accumulator.
 --
 -- @since 0.12.3.0
 foldrM' :: (PrimMonad m, Unbox a) => (a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE foldrM' #-}
 foldrM' = G.foldrM'
 
--- | /O(n)/ Monadic right fold using a function applied to each element and its index.
+-- | \(O(n)\) Monadic right fold using a function applied to each element and its index.
 --
 -- @since 0.12.3.0
 ifoldrM :: (PrimMonad m, Unbox a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM #-}
 ifoldrM = G.ifoldrM
 
--- | /O(n)/ Monadic right fold with strict accumulator using a function applied
+-- | \(O(n)\) Monadic right fold with strict accumulator using a function applied
 -- to each element and its index.
 --
 -- @since 0.12.3.0


### PR DESCRIPTION
I did the following changes, via search & replace:
* `/O(1)/` -> `\(O(1)\)`
* `/O(n)/` -> `\(O(n)\)`
* `/O(m+n)/` -> `\(O(m+n)\)`
* `/O(min(m,n))/` -> `\(O(\min(m,n))\)`
* `/O(m+min(n1,n2))/` -> `\(O(m+\min(n_1,n_2))\)`

Additionally i formatted complexities that previously had no formatting and some manual changes (see the second commit).