### PR TITLE
Add `unsafeToArray` function for getting the underlying boxed `Array`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,28 +18,28 @@ jobs:
       matrix:
         include:
           # Linux
-          - { cabal: "3.4", os: ubuntu-latest,  ghc: "8.0.2"  }
-          - { cabal: "3.4", os: ubuntu-latest,  ghc: "8.2.2"  }
-          - { cabal: "3.4", os: ubuntu-latest,  ghc: "8.4.4"  }
-          - { cabal: "3.4", os: ubuntu-latest,  ghc: "8.6.5"  }
-          - { cabal: "3.4", os: ubuntu-latest,  ghc: "8.8.4"  }
-          - { cabal: "3.4", os: ubuntu-latest,  ghc: "8.10.7" }
-          - { cabal: "3.4", os: ubuntu-latest,  ghc: "9.0.1"  }
-          - { cabal: "3.4", os: ubuntu-latest,  ghc: "9.2.1"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.0.2"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.2.2"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.4.4"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.6.5"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.8.4"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.10.7" }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.0.1"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.2.1"  }
           # Win
-          - { cabal: "3.2", os: windows-latest, ghc: "8.4.4"  }
-          - { cabal: "3.2", os: windows-latest, ghc: "8.6.5"  }
+          - { cabal: "3.6", os: windows-latest, ghc: "8.4.4"  }
           # OOM when building tests
-          # - { cabal: "3.4", os: windows-latest, ghc: "8.8.4"  }
-          # - { cabal: "3.4", os: windows-latest, ghc: "8.10.4" }
+          # - { cabal: "3.6", os: windows-latest, ghc: "8.6.5"  }
+          # - { cabal: "3.6", os: windows-latest, ghc: "8.8.4"  }
+          # - { cabal: "3.6", os: windows-latest, ghc: "8.10.4" }
           # Too flaky:
-          # - { cabal: "3.4", os: windows-latest,  ghc: "9.0.1"  }
+          # - { cabal: "3.6", os: windows-latest,  ghc: "9.0.1"  }
           # MacOS
-          - { cabal: "3.2", os: macOS-latest,   ghc: "8.4.4"  }
-          - { cabal: "3.2", os: macOS-latest,   ghc: "8.6.5"  }
-          - { cabal: "3.2", os: macOS-latest,   ghc: "8.8.4"  }
-          - { cabal: "3.2", os: macOS-latest,   ghc: "8.10.7" }
-          - { cabal: "3.4", os: macOS-latest,   ghc: "9.0.1"  }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "8.4.4"  }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "8.6.5"  }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "8.8.4"  }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "8.10.7" }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "9.0.1"  }
       fail-fast: false
 
     steps:

--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -47,6 +47,8 @@
 * Add `groupBy` and `group` for `Data.Vector.Generic` and the specialized
   version in `Data.Vector`, `Data.Vector.Unboxed`, `Data.Vector.Storable` and
   `Data.Vector.Primitive`.
+* Add `toArraySlice` and `unsafeFromArraySlice` functions for conversion to and
+  from the underlying boxed `Array`.
 
 # Changes in version 0.12.3.1
 

--- a/vector/tests/Tests/Vector/UnitTests.hs
+++ b/vector/tests/Tests/Vector/UnitTests.hs
@@ -91,6 +91,8 @@ tests =
   , testGroup "Data.Vector"
     [ testCase "MonadFix" checkMonadFix
     , testCase "toFromArray" toFromArray
+    , testCase "toFromArraySlice" toFromArraySlice
+    , testCase "toFromArraySliceUnsafe" toFromArraySliceUnsafe
     , testCase "toFromMutableArray" toFromMutableArray
     ]
   ]
@@ -201,6 +203,22 @@ toFromArray :: Assertion
 toFromArray =
   mkArrayRoundtrip $ \name v ->
     assertEqual name v $ Boxed.fromArray (Boxed.toArray v)
+
+toFromArraySlice :: Assertion
+toFromArraySlice =
+  mkArrayRoundtrip $ \name v ->
+    case Boxed.toArraySlice v of
+      (arr, off, n) ->
+        assertEqual name v $
+        Boxed.take n (Boxed.drop off (Boxed.fromArray arr))
+
+toFromArraySliceUnsafe :: Assertion
+toFromArraySliceUnsafe =
+  mkArrayRoundtrip $ \name v ->
+    case Boxed.toArraySlice v of
+      (arr, off, n) ->
+        assertEqual name v $
+        Boxed.unsafeFromArraySlice arr off n
 
 toFromMutableArray :: Assertion
 toFromMutableArray = mkArrayRoundtrip assetRoundtrip


### PR DESCRIPTION
#245 requested access to `Vector` constructor. There are a few other requests like that, see this https://github.com/haskell/vector/issues/357#issue-787733102

However, there is a universal agreement that ability to construct a very unsafe Vector with a regular type constructor is unsettling to say the least. See this: https://github.com/haskell/vector/issues/245#issuecomment-492753908 and this https://github.com/haskell/vector/issues/49#issuecomment-62709758 Let's be honest, creating an `Internal` module just for constructors is not going to happen and separating all unsafe functions into `Unsafe` module is lost cause too, see #361

The next best thing we can do, I think, is to create a couple of `unsafe*` functions that let users create/access underlying buffers in the unsafe way, similar to `unsafeToForeignPtr`.

This PR implements what I suggest, but only for immutable boxed vector. Mutable vector constructor have been exported since inception, so might as well leave it be.