### PR TITLE
Fix doctests for GHC 8.10 and 9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.8.4"  }
           - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.10.7" }
           - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.0.1"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.2.1"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.2.3"  }
           # Win
           - { cabal: "3.6", os: windows-latest, ghc: "8.4.4"  }
           # OOM when building tests

--- a/vector/tests/doctests.hs
+++ b/vector/tests/doctests.hs
@@ -1,4 +1,4 @@
 import Test.DocTest (doctest)
 
 main :: IO ()
-main = doctest ["-Iinclude", "-Iinternal", "src/Data"]
+main = doctest [ "-Iinclude" , "-Iinternal" , "-XHaskell2010" , "src/Data" ]

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -257,12 +257,14 @@ test-suite vector-doctest
     buildable: False
   -- GHC 8.10 fails to run doctests for some reason
   if impl(ghc >= 8.10) && impl(ghc < 8.11)
-    buildable: True
+    buildable: False
   -- GHC 9.0 fails to run doctests for some reason too
   if impl(ghc >= 9.0) && impl(ghc < 9.1)
-    buildable: True
+    buildable: False
   -- And GHC 9.2 too
-  if impl(ghc >= 9.2) && impl(ghc < 9.3)
+  if impl(ghc >= 9.2) && impl(ghc < 9.2.3)
+    buildable: False
+  if impl(ghc >= 9.2.3) && impl(ghc < 9.3)
     buildable: True
   build-depends:
         base      -any

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -257,13 +257,13 @@ test-suite vector-doctest
     buildable: False
   -- GHC 8.10 fails to run doctests for some reason
   if impl(ghc >= 8.10) && impl(ghc < 8.11)
-    buildable: False
+    buildable: True
   -- GHC 9.0 fails to run doctests for some reason too
   if impl(ghc >= 9.0) && impl(ghc < 9.1)
-    buildable: False
+    buildable: True
   -- And GHC 9.2 too
   if impl(ghc >= 9.2) && impl(ghc < 9.3)
-    buildable: False
+    buildable: True
   build-depends:
         base      -any
       , doctest   >=0.15 && <0.21


### PR DESCRIPTION
Fix doctests to work for later versions of GHC. The cabal file specifies
the default language to be Haskell2010 but doctest seems to not pickup
this configuration. We fix this by passing this in as a command line
argument to doctest.

Relates to github issue https://github.com/haskell/vector/issues/370