### PR TITLE
Prepare vector 0.13.0.0 release

### DIFF
--- a/vector-stream/LICENSE
+++ b/vector-stream/LICENSE
@@ -1,4 +1,7 @@
 Copyright (c) 2008-2012, Roman Leshchinskiy
+              2020-2022, Alexey Kuleshevich
+              2020-2022, Aleksey Khudyakov
+              2020-2022, Andrew Lelechenko
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/vector-stream/src/Data/Stream/Monadic.hs
+++ b/vector-stream/src/Data/Stream/Monadic.hs
@@ -10,9 +10,12 @@
 -- |
 -- Module      : Data.Stream.Monadic
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -6,6 +6,9 @@ License-File:   LICENSE
 Author:         Roman Leshchinskiy <rl@cse.unsw.edu.au>
 Maintainer:     Haskell Libraries Team <libraries@haskell.org>
 Copyright:      (c) Roman Leshchinskiy 2008-2012
+                    Alexey Kuleshevich 2020-2022,
+                    Aleksey Khudyakov 2020-2022,
+                    Andrew Lelechenko 2020-2022
 Homepage:       https://github.com/haskell/vector
 Bug-Reports:    https://github.com/haskell/vector/issues
 Category:       Data, Data Structures

--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -20,8 +20,9 @@ Tested-With:
   GHC == 8.4.4,
   GHC == 8.6.5,
   GHC == 8.8.4,
-  GHC == 8.10.4
-  GHC == 9.0.1
+  GHC == 8.10.4,
+  GHC == 9.0.1,
+  GHC == 9.2.3
 
 Cabal-Version:  >=1.10
 Build-Type:     Simple

--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -46,3 +46,4 @@ Library
 source-repository head
   type:     git
   location: https://github.com/haskell/vector.git
+  subdir:   vector-stream

--- a/vector/LICENSE
+++ b/vector/LICENSE
@@ -1,4 +1,7 @@
 Copyright (c) 2008-2012, Roman Leshchinskiy
+              2020-2022, Alexey Kuleshevich
+              2020-2022, Aleksey Khudyakov
+              2020-2022, Andrew Lelechenko
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -1,40 +1,45 @@
 # Changes in version 0.13.0.0
 
- * Methods of type classes `Data.Vector.Generic.Mutable.MVector` and
-   `Data.Vector.Generic.Vector` use concrete monads (ST,etc) being
-   polymorphic. This allows use of GND and deriving via to define
-   instances. Rest of API is unchanged and most existing instances should
-   compiler fine with new definitions.
  * `mkType` from `Data.Vector.Generic` is deprecated in favor of
    `Data.Data.mkNoRepType`
  * The role signatures on several `Vector` types were too permissive, so they
    have been tightened up:
    * The role signature for `Data.Vector.Mutable.MVector` is now
      `type role MVector nominal representational` (previously, both arguments
-     were `phantom`).
+     were `phantom`). [#224](https://github.com/haskell/vector/pull/224)
    * The role signature for `Data.Vector.Primitive.Vector` is now
      `type role Vector nominal` (previously, it was `phantom`).
      The role signature for `Data.Vector.Primitive.Mutable.MVector` is now
      `type role MVector nominal nominal` (previously, both arguments were
-     `phantom`).
+     `phantom`). [#316](https://github.com/haskell/vector/pull/316)
    * The role signature for `Data.Vector.Storable.Vector` is now
      `type role Vector nominal` (previous, it was `phantom`), and the signature
      for `Data.Vector.Storable.Mutable.MVector` is now
      `type role MVector nominal nominal` (previous, both arguments were
-     `phantom`).
+     `phantom`). [#235](https://github.com/haskell/vector/pull/235)
 
      We pick `nominal` for the role of the last argument instead of
-     `representational` since the internal structure of a `Storable` vector
-     is determined by the `Storable` instance of the element type, and it is
-     not guaranteed that the `Storable` instances between two
-     representationally equal types will preserve this internal structure.
-     One consequence of this choice is that it is no longer possible to
-     `coerce` between `Storable.Vector a` and `Storable.Vector b` if `a` and
-     `b` are nominally distinct but representationally equal types. We now
-     provide `unsafeCoerce{M}Vector` functions in
-     `Data.Vector.Storable{.Mutable}` to allow this (the onus is on the user
-     to ensure that no `Storable` invariants are broken when using these
-     functions).
+     `representational` since the internal structure of a `Storable` vector is
+     determined by the `Storable` instance of the element type, and it is not
+     guaranteed that the `Storable` instances between two representationally
+     equal types will preserve this internal structure.  One consequence of this
+     choice is that it is no longer possible to `coerce` between
+     `Storable.Vector a` and `Storable.Vector b` if `a` and `b` are nominally
+     distinct but representationally equal types. We now provide
+     `unsafeCoerce{M}Vector` and `unsafeCast` functions to allow this (the onus
+     is on the user to ensure that no `Storable` invariants are broken when
+     using these functions).
+ * Methods of type classes `Data.Vector.Generic.Mutable.MVector` and
+   `Data.Vector.Generic.Vector` use concrete monads (`ST`, etc) istead of being
+   polymorphic (`PrimMonad`, etc). [#335](https://github.com/haskell/vector/pull/335).
+   This makes it possible to derive `Unbox` with:
+   * `GeneralizedNewtypeDeriving`
+   * via `UnboxViaPrim` and `Prim` instance
+   * via `As` and `IsoUnbox` instance: [#378](https://github.com/haskell/vector/pull/378)
+ * Add `MonadFix` instance for boxed vectors: [#312](https://github.com/haskell/vector/pull/312)
+ * Re-export `PrimMonad` and `RealWorld` from mutable vectors:
+   [#320](https://github.com/haskell/vector/pull/320)
+ * Add `maximumOn` and `minimumOn`: [#356](https://github.com/haskell/vector/pull/356)
  * The functions `scanl1`, `scanl1'`, `scanr1`, and `scanr1'` for immutable
    vectors are now defined when given empty vectors as arguments,
    in which case they return empty vectors. This new behavior is consistent
@@ -42,21 +47,27 @@
    Prior to this change, applying an empty vector to any of those functions
    resulted in an error. This change was introduced in:
    [#382](https://github.com/haskell/vector/pull/382)
-* Remove redundant `Storable` constraints on to/from `ForeignPtr` conversions
-* Add `unsafeCast` to `Primitive` vectors
-* Add `groupBy` and `group` for `Data.Vector.Generic` and the specialized
-  version in `Data.Vector`, `Data.Vector.Unboxed`, `Data.Vector.Storable` and
-  `Data.Vector.Primitive`.
-* Add `toArraySlice` and `unsafeFromArraySlice` functions for conversion to and
-  from the underlying boxed `Array`.
+ * Change allocation strategy for `unfoldrN`: [#387](https://github.com/haskell/vector/pull/387)
+ * Remove `CPP` driven error reporting in favor of `HasCallStack`:
+   [#397](https://github.com/haskell/vector/pull/397)
+ * Remove redundant `Storable` constraints on to/from `ForeignPtr` conversions:
+   [#394](https://github.com/haskell/vector/pull/394)
+ * Add `unsafeCast` to `Primitive` vectors: [#401](https://github.com/haskell/vector/pull/401)
+ * Make `(!?)` operator strict: [#402](https://github.com/haskell/vector/pull/402)
+ * Add `readMaybe`: [#425](https://github.com/haskell/vector/pull/425)
+ * Add `groupBy` and `group` for `Data.Vector.Generic` and the specialized
+   version in `Data.Vector`, `Data.Vector.Unboxed`, `Data.Vector.Storable` and
+   `Data.Vector.Primitive`. [#427](https://github.com/haskell/vector/pull/427)
+ * Add `toArraySlice` and `unsafeFromArraySlice` functions for conversion to and
+   from the underlying boxed `Array`: [#434](https://github.com/haskell/vector/pull/434)
 
 # Changes in version 0.12.3.1
 
-* Bugfix for ghcjs and `Double` memset for `Storable` vector:
-  [#410](https://github.com/haskell/vector/issues/410)
-* Avoid haddock bug: [#383](https://github.com/haskell/vector/issues/383)
-* Improve haddock and doctests
-* Disable problematic tests with -boundschecks [#407](https://github.com/haskell/vector/pull/407)
+ * Bugfix for ghcjs and `Double` memset for `Storable` vector:
+   [#410](https://github.com/haskell/vector/issues/410)
+ * Avoid haddock bug: [#383](https://github.com/haskell/vector/issues/383)
+ * Improve haddock and doctests
+ * Disable problematic tests with -boundschecks [#407](https://github.com/haskell/vector/pull/407)
 
 # Changes in version 0.12.3.0
 

--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -1716,6 +1716,8 @@ maximumBy = G.maximumBy
 -- (2,'a')
 -- >>> V.maximumOn fst $ V.fromList [(1,'a'), (1,'b')]
 -- (1,'a')
+--
+-- @since 0.13.0.0
 maximumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
@@ -1764,6 +1766,8 @@ minimumBy = G.minimumBy
 -- (1,'b')
 -- >>> V.minimumOn fst $ V.fromList [(1,'a'), (1,'b')]
 -- (1,'a')
+--
+-- @since 0.13.0.0
 minimumOn :: Ord b => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn

--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -9,9 +9,12 @@
 -- |
 -- Module      : Data.Vector
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Fusion/Bundle.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle.hs
@@ -5,9 +5,12 @@
 -- |
 -- Module      : Data.Vector.Fusion.Bundle
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -10,9 +10,12 @@
 -- |
 -- Module      : Data.Vector.Fusion.Bundle.Monadic
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Fusion/Bundle/Size.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Size.hs
@@ -1,9 +1,12 @@
 -- |
 -- Module      : Data.Vector.Fusion.Bundle.Size
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : portable
 --

--- a/vector/src/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Stream/Monadic.hs
@@ -1,9 +1,12 @@
 -- |
 -- Module      : Data.Vector.Fusion.Stream.Monadic
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Fusion/Util.hs
+++ b/vector/src/Data/Vector/Fusion/Util.hs
@@ -1,9 +1,12 @@
 -- |
 -- Module      : Data.Vector.Fusion.Util
 -- Copyright   : (c) Roman Leshchinskiy 2009
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : portable
 --

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -8,9 +8,12 @@
 -- |
 -- Module      : Data.Vector.Generic
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -1876,6 +1876,8 @@ maximumBy cmpr = Bundle.foldl1' maxBy . stream
 -- (2,'a')
 -- >>> V.maximumOn fst $ V.fromList [(1,'a'), (1,'b')]
 -- (1,'a')
+--
+-- @since 0.13.0.0
 maximumOn :: (Ord b, Vector v a) => (a -> b) -> v a -> a
 {-# INLINE maximumOn #-}
 maximumOn f = fst . Bundle.foldl1' maxBy . Bundle.map (\a -> (a, f a)) . stream
@@ -1934,6 +1936,8 @@ minimumBy cmpr = Bundle.foldl1' minBy . stream
 -- (1,'b')
 -- >>> V.minimumOn fst $ V.fromList [(1,'a'), (1,'b')]
 -- (1,'a')
+--
+-- @since 0.13.0.0
 minimumOn :: (Ord b, Vector v a) => (a -> b) -> v a -> a
 {-# INLINE minimumOn #-}
 minimumOn f = fst . Bundle.foldl1' minBy . Bundle.map (\a -> (a, f a)) . stream

--- a/vector/src/Data/Vector/Generic/Base.hs
+++ b/vector/src/Data/Vector/Generic/Base.hs
@@ -10,9 +10,12 @@
 -- |
 -- Module      : Data.Vector.Generic.Base
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -7,9 +7,12 @@
 -- |
 -- Module      : Data.Vector.Generic.Mutable
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Generic/Mutable/Base.hs
+++ b/vector/src/Data/Vector/Generic/Mutable/Base.hs
@@ -5,9 +5,12 @@
 -- |
 -- Module      : Data.Vector.Generic.Mutable.Base
 -- Copyright   : (c) Roman Leshchinskiy 2008-2011
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Generic/New.hs
+++ b/vector/src/Data/Vector/Generic/New.hs
@@ -5,9 +5,12 @@
 -- |
 -- Module      : Data.Vector.Generic.New
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Internal/Check.hs
+++ b/vector/src/Data/Vector/Internal/Check.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
+{-# OPTIONS_HADDOCK hide #-}
 
 -- |
 -- Module      : Data.Vector.Internal.Check

--- a/vector/src/Data/Vector/Internal/Check.hs
+++ b/vector/src/Data/Vector/Internal/Check.hs
@@ -22,8 +22,7 @@ module Data.Vector.Internal.Check (
   inRange
 ) where
 
-import GHC.Base( Int(..) )
-import GHC.Prim( Int# )
+import GHC.Exts (Int(..), Int#)
 import Prelude hiding( error, (&&), (||), not )
 import qualified Prelude as P
 import GHC.Stack (HasCallStack)

--- a/vector/src/Data/Vector/Internal/Check.hs
+++ b/vector/src/Data/Vector/Internal/Check.hs
@@ -5,9 +5,12 @@
 -- |
 -- Module      : Data.Vector.Internal.Check
 -- Copyright   : (c) Roman Leshchinskiy 2009
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -8,9 +8,12 @@
 -- |
 -- Module      : Data.Vector.Mutable
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -1426,6 +1426,8 @@ maximumBy = G.maximumBy
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
+--
+-- @since 0.13.0.0
 maximumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
@@ -1452,6 +1454,8 @@ minimumBy = G.minimumBy
 -- | /O(n)/ Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
+--
+-- @since 0.13.0.0
 minimumOn :: (Ord b, Prim a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -9,9 +9,12 @@
 -- |
 -- Module      : Data.Vector.Primitive
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -7,9 +7,12 @@
 -- |
 -- Module      : Data.Vector.Primitive.Mutable
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -9,9 +9,12 @@
 -- |
 -- Module      : Data.Vector.Storable
 -- Copyright   : (c) Roman Leshchinskiy 2009-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -1473,6 +1473,8 @@ maximumBy = G.maximumBy
 -- | /O(n)/ Yield the maximum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
+--
+-- @since 0.13.0.0
 maximumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
@@ -1499,6 +1501,8 @@ minimumBy = G.minimumBy
 -- | /O(n)/ Yield the minimum element of the vector by comparing the results
 -- of a key function on each element. In case of a tie, the first occurrence
 -- wins. The vector may not be empty.
+--
+-- @since 0.13.0.0
 minimumOn :: (Ord b, Storable a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn

--- a/vector/src/Data/Vector/Storable/Internal.hs
+++ b/vector/src/Data/Vector/Storable/Internal.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-
+{-# OPTIONS_HADDOCK hide #-}
 -- |
 -- Module      : Data.Vector.Storable.Internal
 -- Copyright   : (c) Roman Leshchinskiy 2009-2010

--- a/vector/src/Data/Vector/Storable/Internal.hs
+++ b/vector/src/Data/Vector/Storable/Internal.hs
@@ -3,9 +3,12 @@
 -- |
 -- Module      : Data.Vector.Storable.Internal
 -- Copyright   : (c) Roman Leshchinskiy 2009-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -8,9 +8,12 @@
 -- |
 -- Module      : Data.Vector.Storable.Mutable
 -- Copyright   : (c) Roman Leshchinskiy 2009-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -1485,6 +1485,8 @@ maximumBy = G.maximumBy
 -- (2,'a')
 -- >>> VU.maximumOn fst $ VU.fromList [(1,'a'), (1 :: Int,'b')]
 -- (1,'a')
+--
+-- @since 0.13.0.0
 maximumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE maximumOn #-}
 maximumOn = G.maximumOn
@@ -1535,6 +1537,8 @@ minimumBy = G.minimumBy
 -- (1,'b')
 -- >>> VU.minimumOn fst $ VU.fromList [(1,'a'), (1 :: Int,'b')]
 -- (1,'a')
+--
+-- @since 0.13.0.0
 minimumOn :: (Ord b, Unbox a) => (a -> b) -> Vector a -> a
 {-# INLINE minimumOn #-}
 minimumOn = G.minimumOn

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -4,9 +4,12 @@
 -- |
 -- Module      : Data.Vector.Unboxed
 -- Copyright   : (c) Roman Leshchinskiy 2009-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -214,6 +214,8 @@ instance G.Vector Vector () where
 -- >>> deriving via (U.UnboxViaPrim Int) instance M.MVector MVector Foo
 -- >>> deriving via (U.UnboxViaPrim Int) instance G.Vector  Vector  Foo
 -- >>> instance Unbox Foo
+--
+-- @since 0.13.0.0
 newtype UnboxViaPrim a = UnboxViaPrim a
 
 newtype instance MVector s (UnboxViaPrim a) = MV_UnboxViaPrim (P.MVector s a)
@@ -278,6 +280,7 @@ instance P.Prim a => G.Vector Vector (UnboxViaPrim a) where
 -- instance VU.IsoUnbox (Foo a) (Sum Int, Product a)
 -- :}
 --
+-- @since 0.13.0.0
 class IsoUnbox a b where
   -- | Convert value into it representation in unboxed vector.
   toURepr   :: a -> b
@@ -338,6 +341,7 @@ idU = id
 -- instance VU.Unbox a => VU.Unbox (Bar a)
 -- :}
 --
+-- @since 0.13.0.0
 newtype As (a :: Type) (b :: Type) = As a
 
 newtype instance MVector s (As a b) = MV_UnboxAs (MVector s b)

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -14,9 +14,12 @@
 -- |
 -- Module      : Data.Vector.Unboxed.Base
 -- Copyright   : (c) Roman Leshchinskiy 2009-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -3,9 +3,12 @@
 -- |
 -- Module      : Data.Vector.Unboxed.Mutable
 -- Copyright   : (c) Roman Leshchinskiy 2009-2010
+--                   Alexey Kuleshevich 2020-2022
+--                   Aleksey Khudyakov 2020-2022
+--                   Andrew Lelechenko 2020-2022
 -- License     : BSD-style
 --
--- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Maintainer  : Haskell Libraries Team <libraries@haskell.org>
 -- Stability   : experimental
 -- Portability : non-portable
 --

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -137,7 +137,6 @@ Library
 
   Build-Depends: base >= 4.9 && < 4.17
                , primitive >= 0.6.4.0 && < 0.8
-               , ghc-prim >= 0.2 && < 0.9
                , deepseq >= 1.1 && < 1.5
                , vector-stream >= 0.1 && < 0.2
 

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -1,5 +1,5 @@
 Name:           vector
-Version:        0.13.0.1
+Version:        0.13.0.0
 -- don't forget to update the changelog file!
 License:        BSD3
 License-File:   LICENSE
@@ -41,7 +41,8 @@ Tested-With:
   GHC == 8.6.5,
   GHC == 8.8.4,
   GHC == 8.10.7,
-  GHC == 9.0.1
+  GHC == 9.0.1,
+  GHC == 9.2.3
 
 Cabal-Version:  >= 1.10
 Build-Type:     Simple
@@ -275,8 +276,6 @@ test-suite vector-doctest
 test-suite vector-inspection
   type:             exitcode-stdio-1.0
   hs-source-dirs:   tests-inspect
-  -- -O1 is used here on purpose. We expect that fusion works for -O1
-  -- as well
   Ghc-Options:      -Wall
   main-is:          main.hs
   default-language: Haskell2010

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -5,7 +5,11 @@ License:        BSD3
 License-File:   LICENSE
 Author:         Roman Leshchinskiy <rl@cse.unsw.edu.au>
 Maintainer:     Haskell Libraries Team <libraries@haskell.org>
-Copyright:      (c) Roman Leshchinskiy 2008-2012
+Copyright:      (c) Roman Leshchinskiy 2008-2012,
+                    Alexey Kuleshevich 2020-2022,
+                    Aleksey Khudyakov 2020-2022,
+                    Andrew Lelechenko 2020-2022
+
 Homepage:       https://github.com/haskell/vector
 Bug-Reports:    https://github.com/haskell/vector/issues
 Category:       Data, Data Structures

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -160,7 +160,7 @@ Library
 source-repository head
   type:     git
   location: https://github.com/haskell/vector.git
-
+  subdir:   vector
 
 
 test-suite vector-tests-O0


### PR DESCRIPTION
This is all non-semantic changes that do preliminary cleanup for the next major release. Whatever is in this PR will be the next 0.13.0.0 release as soon as it gets merged. In a nutshell it includes some housekeeping:

* Ensure changelog is correct and has links to issues
* Adds since pragmas
* Sets version to `0.13.0.0` instead of `0.13.0.1`, since `x.x.0.0`  was always an initial major version for vector.
* Updated LICENSE, cabal files and haddock with latest maintainers and fixes maintainer's email, since Roman has not been a maintainer for over a decade.

Fixes #422 and #357