### PR TITLE
Make `Size` fields strict

### DIFF
--- a/vector/src/Data/Vector/Fusion/Bundle/Size.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Size.hs
@@ -20,9 +20,9 @@ module Data.Vector.Fusion.Bundle.Size (
 import Data.Vector.Fusion.Util ( delay_inline )
 
 -- | Size hint
-data Size = Exact !Int         -- ^ Exact size
-          | Max   !Int         -- ^ Upper bound on the size
-          | Unknown            -- ^ Unknown size
+data Size = Exact {-# UNPACK #-} !Int -- ^ Exact size
+          | Max   {-# UNPACK #-} !Int -- ^ Upper bound on the size
+          | Unknown                   -- ^ Unknown size
         deriving( Eq, Show )
 
 instance Num Size where

--- a/vector/src/Data/Vector/Fusion/Bundle/Size.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Size.hs
@@ -20,8 +20,8 @@ module Data.Vector.Fusion.Bundle.Size (
 import Data.Vector.Fusion.Util ( delay_inline )
 
 -- | Size hint
-data Size = Exact Int          -- ^ Exact size
-          | Max   Int          -- ^ Upper bound on the size
+data Size = Exact !Int         -- ^ Exact size
+          | Max   !Int         -- ^ Upper bound on the size
           | Unknown            -- ^ Unknown size
         deriving( Eq, Show )
 


### PR DESCRIPTION
Closes #452.

See https://github.com/haskell/vector/issues/452#issuecomment-1429856958 for a benchmark comparison (although note that the benchmark results vary quite a bit). Maybe I'm missing something and there's a reason the fields aren't strict, but it doesn't look that way to me.