### PR TITLE
Allow deepseq-1.5

### DIFF
--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -141,7 +141,7 @@ Library
 
   Build-Depends: base >= 4.9 && < 4.19
                , primitive >= 0.6.4.0 && < 0.9
-               , deepseq >= 1.1 && < 1.5
+               , deepseq >= 1.1 && < 1.6
                , vector-stream >= 0.1 && < 0.2
 
   Ghc-Options: -O2 -Wall


### PR DESCRIPTION
It's a bit challenging to test at the moment: I had to build against a patched version of `primitive`, which does not depend on `template-haskell`.