### PR TITLE
Allow GHC 9.8

### DIFF
--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -43,8 +43,8 @@ Library
   Hs-Source-Dirs:
         src
 
-  Build-Depends: base >= 4.9 && < 4.19
-               , ghc-prim >= 0.2 && < 0.11
+  Build-Depends: base >= 4.9 && < 4.20
+               , ghc-prim >= 0.2 && < 0.12
 
 source-repository head
   type:     git

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -139,7 +139,7 @@ Library
   Install-Includes:
         vector.h
 
-  Build-Depends: base >= 4.9 && < 4.19
+  Build-Depends: base >= 4.9 && < 4.20
                , primitive >= 0.6.4.0 && < 0.9
                , deepseq >= 1.1 && < 1.6
                , vector-stream >= 0.1 && < 0.2
@@ -272,7 +272,7 @@ test-suite vector-doctest
     buildable: True
   build-depends:
         base      -any
-      , doctest   >=0.15 && <0.22
+      , doctest   >=0.15 && <0.23
       , primitive >= 0.6.4.0 && < 0.9
       , vector    -any
 


### PR DESCRIPTION
Tested locally with GHC 9.8.1-alpha1. I made corresponding revisions:
* https://hackage.haskell.org/package/vector-0.13.0.0/revisions/
* https://hackage.haskell.org/package/vector-stream-0.1.0.0/revisions/