### PR TITLE
Optimize replicateM and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ jobs:
           - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.6.5"  }
           - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.8.4"  }
           - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.10.7" }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.0.1"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.2.3"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.0.2"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.2.8"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.4.6"  }
+          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.6.2"  }
           # Win
           - { cabal: "3.6", os: windows-latest, ghc: "8.4.4"  }
           # OOM when building tests
@@ -39,7 +41,10 @@ jobs:
           - { cabal: "3.6", os: macOS-latest,   ghc: "8.6.5"  }
           - { cabal: "3.6", os: macOS-latest,   ghc: "8.8.4"  }
           - { cabal: "3.6", os: macOS-latest,   ghc: "8.10.7" }
-          - { cabal: "3.6", os: macOS-latest,   ghc: "9.0.1"  }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "9.0.2"  }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "9.2.8"  }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "9.4.6"  }
+          - { cabal: "3.6", os: macOS-latest,   ghc: "9.6.2"  }
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,18 @@ jobs:
       matrix:
         include:
           # Linux
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.0.2"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.2.2"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.4.4"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.6.5"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.8.4"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "8.10.7" }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.0.2"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.2.8"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.4.6"  }
-          - { cabal: "3.6", os: ubuntu-latest,  ghc: "9.6.2"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.0.2"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.2.2"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.4.4"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.6.5"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.8.4"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.10.7" }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.0.2"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.2.8"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.4.6"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.6.2"  }
           # Win
-          - { cabal: "3.6", os: windows-latest, ghc: "8.4.4"  }
+          - { cabal: "3.10", os: windows-latest, ghc: "8.4.4"  }
           # OOM when building tests
           # - { cabal: "3.6", os: windows-latest, ghc: "8.6.5"  }
           # - { cabal: "3.6", os: windows-latest, ghc: "8.8.4"  }
@@ -37,14 +37,14 @@ jobs:
           # Too flaky:
           # - { cabal: "3.6", os: windows-latest,  ghc: "9.0.1"  }
           # MacOS
-          - { cabal: "3.6", os: macOS-latest,   ghc: "8.4.4"  }
-          - { cabal: "3.6", os: macOS-latest,   ghc: "8.6.5"  }
-          - { cabal: "3.6", os: macOS-latest,   ghc: "8.8.4"  }
-          - { cabal: "3.6", os: macOS-latest,   ghc: "8.10.7" }
-          - { cabal: "3.6", os: macOS-latest,   ghc: "9.0.2"  }
-          - { cabal: "3.6", os: macOS-latest,   ghc: "9.2.8"  }
-          - { cabal: "3.6", os: macOS-latest,   ghc: "9.4.6"  }
-          - { cabal: "3.6", os: macOS-latest,   ghc: "9.6.2"  }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "8.4.4"  }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "8.6.5"  }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "8.8.4"  }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "8.10.7" }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "9.0.2"  }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "9.2.8"  }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "9.4.6"  }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "9.6.2"  }
       fail-fast: false
 
     steps:

--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -24,8 +24,10 @@ Tested-With:
   GHC == 8.6.5,
   GHC == 8.8.4,
   GHC == 8.10.4,
-  GHC == 9.0.1,
-  GHC == 9.2.3
+  GHC == 9.0.2,
+  GHC == 9.2.8,
+  GHC == 9.4.6,
+  GHC == 9.6.2
 
 Cabal-Version:  >=1.10
 Build-Type:     Simple

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -507,14 +507,7 @@ generate n f = stToPrim $ generateM n (return . f)
 -- @since 0.12.3.0
 generateM :: (PrimMonad m, MVector v a) => Int -> (Int -> m a) -> m (v (PrimState m) a)
 {-# INLINE generateM #-}
-generateM n f
-  | n <= 0    = new 0
-  | otherwise = do
-      vec <- new n
-      let loop i | i >= n    = return vec
-                 | otherwise = do unsafeWrite vec i =<< f i
-                                  loop (i + 1)
-      loop 0
+generateM n f = munstream (MBundle.generateM n f)
 
 -- | Create a copy of a mutable vector.
 clone :: (PrimMonad m, MVector v a) => v (PrimState m) a -> m (v (PrimState m) a)

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -1029,7 +1029,8 @@ izipWith6 = G.izipWith6
 -- | Checks whether two values are the same vector: they have same length
 -- and share the same buffer.
 --
--- >>> let xs = fromList [0/0::Double] in isSameVector xs xs
+-- >>> import qualified Data.Vector.Storable as VS
+-- >>> let xs = VS.fromList [0/0::Double] in VS.isSameVector xs xs
 -- True
 isSameVector :: (Storable a) => Vector a -> Vector a -> Bool
 {-# INLINE isSameVector #-}

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -304,6 +304,7 @@ idU = id
 -- >>> :set -XTypeFamilies -XStandaloneDeriving -XDerivingVia
 -- >>> :set -XMultiParamTypeClasses -XTypeOperators -XFlexibleInstances
 -- >>> import qualified Data.Vector.Unboxed         as VU
+-- >>> import qualified Data.Vector.Unboxed.Mutable as MVU
 -- >>> import qualified Data.Vector.Generic         as VG
 -- >>> import qualified Data.Vector.Generic.Mutable as VGM
 -- >>> :{
@@ -316,8 +317,8 @@ idU = id
 --   {-# INLINE fromURepr #-}
 -- newtype instance VU.MVector s (Foo a) = MV_Foo (VU.MVector s (Int, a))
 -- newtype instance VU.Vector    (Foo a) = V_Foo  (VU.Vector    (Int, a))
--- deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => VGM.MVector MVector (Foo a)
--- deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => VG.Vector  Vector  (Foo a)
+-- deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => VGM.MVector MVU.MVector (Foo a)
+-- deriving via (Foo a `VU.As` (Int, a)) instance VU.Unbox a => VG.Vector   VU.Vector   (Foo a)
 -- instance VU.Unbox a => VU.Unbox (Foo a)
 -- :}
 --
@@ -325,8 +326,8 @@ idU = id
 -- It's also possible to use generic-based instance for 'IsoUnbox'
 -- which should work for all product types.
 --
--- >>> :set -XTypeFamilies -XStandaloneDeriving -XDerivingVia -XDeriveGeneric
--- >>> :set -XMultiParamTypeClasses -XTypeOperators -XFlexibleInstances
+-- >>> :set -XMultiParamTypeClasses -XTypeOperators -XFlexibleInstances -XDeriveGeneric
+-- >>> :set -XDerivingVia
 -- >>> import qualified Data.Vector.Unboxed         as VU
 -- >>> import qualified Data.Vector.Generic         as VG
 -- >>> import qualified Data.Vector.Generic.Mutable as VGM

--- a/vector/tests/Tests/Bundle.hs
+++ b/vector/tests/Tests/Bundle.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeOperators #-}
 module Tests.Bundle ( tests ) where
 
 import Boilerplater

--- a/vector/tests/Tests/Vector/Property.hs
+++ b/vector/tests/Tests/Vector/Property.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeOperators #-}
 module Tests.Vector.Property
   ( CommonContext
   , VanillaContext

--- a/vector/tests/Utilities.hs
+++ b/vector/tests/Utilities.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeOperators #-}
 module Utilities where
 
 import Test.QuickCheck

--- a/vector/tests/Utilities.hs
+++ b/vector/tests/Utilities.hs
@@ -6,6 +6,7 @@ module Utilities where
 import Test.QuickCheck
 
 import Data.Foldable
+import Data.Bifunctor
 import qualified Data.Vector as DV
 import qualified Data.Vector.Generic as DVG
 import qualified Data.Vector.Primitive as DVP
@@ -123,10 +124,6 @@ instance TestData Double where
 
   equal x y = property (x == y || (isNaN x && isNaN y))
 
-bimapEither :: (a -> b) -> (c -> d) -> Either a c -> Either b d
-bimapEither f _ (Left a) = Left (f a)
-bimapEither _ g (Right c) = Right (g c)
-
 -- Functorish models
 -- All of these need UndecidableInstances although they are actually well founded. Oh well.
 instance (Eq a, TestData a) => TestData (Maybe a) where
@@ -136,8 +133,8 @@ instance (Eq a, TestData a) => TestData (Maybe a) where
 
 instance (Eq a, TestData a, Eq b, TestData b) => TestData (Either a b) where
   type Model (Either a b) = Either (Model a) (Model b)
-  model = bimapEither model model
-  unmodel = bimapEither unmodel unmodel
+  model = bimap model model
+  unmodel = bimap unmodel unmodel
 
 instance (Eq a, TestData a) => TestData [a] where
   type Model [a] = [Model a]

--- a/vector/tests/doctests.hs
+++ b/vector/tests/doctests.hs
@@ -1,4 +1,38 @@
 import Test.DocTest (doctest)
 
+-- Doctests are weirdly fragile. For example running tests for module
+-- A (D.V.Unboxed.Base) could cause tests in unrelated woudle B
+-- (D.V.Storable) to start failing with weird errors.
+--
+-- In order to avoid this one would want to run doctests with
+-- per-module granularity but this cause another sort of problems!
+-- When we load only single module and use import doctests then some
+-- data types may come from built library and some from ghci session.
+--
+-- This could be remedied by running doctests for groups of modules.
+-- This _is_ convoluted setup but doctests now works for GHC9.4
 main :: IO ()
-main = doctest [ "-Iinclude" , "-Iinternal" , "-XHaskell2010" , "src/Data" ]
+main = mapM_ run modGroups
+  where
+    run mods = do
+      mapM_ putStrLn mods
+      doctest $ ["-Iinclude", "-Iinternal", "-XHaskell2010"] ++ mods
+    --
+    modGroups =
+      [ [ "src/Data/Vector/Storable/Mutable.hs"
+        , "src/Data/Vector/Storable.hs"
+        ]
+      , [ "src/Data/Vector.hs"
+        , "src/Data/Vector/Mutable.hs"
+        ]
+      , [ "src/Data/Vector/Generic.hs"
+        , "src/Data/Vector/Generic/Mutable.hs"
+        ]
+      , [ "src/Data/Vector/Primitive.hs"
+        , "src/Data/Vector/Primitive/Mutable.hs"
+        ]
+      , [ "src/Data/Vector/Unboxed.hs"
+        , "src/Data/Vector/Unboxed/Mutable.hs"
+        , "src/Data/Vector/Unboxed/Base.hs"
+        ]
+      ]

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -45,8 +45,11 @@ Tested-With:
   GHC == 8.6.5,
   GHC == 8.8.4,
   GHC == 8.10.7,
-  GHC == 9.0.1,
-  GHC == 9.2.3
+  GHC == 9.0.2,
+  GHC == 9.2.8,
+  GHC == 9.4.6,
+  GHC == 9.6.2
+  
 
 Cabal-Version:  >= 1.10
 Build-Type:     Simple


### PR DESCRIPTION
This PR turn out to be a bit of kitchen sink

1. Use existing `munstream` instead of hand-rolled loop in `replicateM` for mutable vectors. It also avoid double initialization of buffer with `new` (noticed by @dmalkr) 
2. Small cleanups in test suite: add default value for `TestEq` and default implementation for `equals` method of `TestData`  type class. 
3. Then I noticed that we only test GHC up to 9.2 on CI. I've update CI config