### PR TITLE
Discover faster implementation for `findIndexR`.

### DIFF
--- a/vector/benchmarks/Algo/FindIndexR.hs
+++ b/vector/benchmarks/Algo/FindIndexR.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 module Algo.FindIndexR (findIndexR, findIndexR_naive, findIndexR_manual)
 where
 
@@ -18,7 +20,9 @@ findIndexR_naive (pred, v) = fmap (V.length v - 1 -)
 findIndexR_manual :: (Double -> Bool, Vector Double) -> Maybe Int
 {-# NOINLINE findIndexR_manual #-}
 findIndexR_manual (pred, v) = go $ V.length v - 1
- where go i | i < 0                     = Nothing
-            | pred (V.unsafeIndex v i)  = Just i
-            | otherwise                 = go $ i-1
+ where go i | i < 0           = Nothing
+            | x `seq` pred x  = Just i
+            | otherwise       = go $ i-1
+         where
+           x = V.unsafeIndex v i
 

--- a/vector/benchmarks/Main.hs
+++ b/vector/benchmarks/Main.hs
@@ -77,9 +77,15 @@ main = do
     , bench "spectral"   $ whnf spectral sp
     , bench "tridiag"    $ whnf tridiag (as,bs,cs,ds)
     , bench "mutableSet" $ nfIO $ mutableSet vi
-    , bench "findIndexR" $ whnf findIndexR ((<indexFindThreshold), as)
-    , bench "findIndexR_naïve" $ whnf findIndexR_naive ((<indexFindThreshold), as)
-    , bench "findIndexR_manual" $ whnf findIndexR_manual ((<indexFindThreshold), as)
+    , bench "findIndexR" $ nf findIndexR ((<indexFindThreshold), as)
+    , bench "findIndexR_naïve" $ nf findIndexR_naive ((<indexFindThreshold), as)
+    , bench "findIndexR_manual" $ nf findIndexR_manual ((<indexFindThreshold), as)
+    , env (pure (U.filter (>indexFindThreshold) as)) $ \asNone ->
+        bench "findIndexR (none)" $ nf findIndexR ((<indexFindThreshold), asNone)
+    , env (pure (U.filter (>indexFindThreshold) as)) $ \asNone ->
+        bench "findIndexR_naïve (none)" $ nf findIndexR_naive ((<indexFindThreshold), asNone)
+    , env (pure (U.filter (>indexFindThreshold) as)) $ \asNone ->
+        bench "findIndexR_manual (none)" $ nf findIndexR_manual ((<indexFindThreshold), asNone)
     , bench "minimumOn"  $ whnf (U.minimumOn (\x -> x*x*x)) as
     , bench "maximumOn"  $ whnf (U.maximumOn (\x -> x*x*x)) as
     ]


### PR DESCRIPTION
Currently it is only in the benchmarks, but we should change the actual implementation as well. This commit also adds a benchmark for `findIndexR` that has to iterate the whole vector

```
Benchmark algorithms: RUNNING...
All
  findIndexR:               OK (0.18s)
    134  μs ±  11 μs
  findIndexR_naïve:         OK (0.48s)
    72.6 ms ± 4.4 ms
  findIndexR_manual:        OK (0.23s)
    110  μs ± 5.5 μs
  findIndexR (none):        OK (0.15s)
    4.92 ms ± 416 μs
  findIndexR_naïve (none):  OK (0.54s)
    77.1 ms ± 6.7 ms
  findIndexR_manual (none): OK (0.13s)
    4.05 ms ± 358 μs
```

This is the version from master:
```
Benchmark algorithms: RUNNING...
All                 
  findIndexR:        OK (0.18s)
    136  μs ±  11 μs
  findIndexR_naïve:  OK (0.47s)
    69.8 ms ± 6.5 ms
  findIndexR_manual: OK (0.23s)
    221  μs ±  11 μs
```