### PR TITLE
Export `findIndexR` from the non-generic vector modules

### DIFF
--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -125,7 +125,7 @@ module Data.Vector (
   partition, unstablePartition, partitionWith, span, break, groupBy, group,
 
   -- ** Searching
-  elem, notElem, find, findIndex, findIndices, elemIndex, elemIndices,
+  elem, notElem, find, findIndex, findIndexR, findIndices, elemIndex, elemIndices,
 
   -- * Folding
   foldl, foldl1, foldl', foldl1', foldr, foldr1, foldr', foldr1',
@@ -1476,6 +1476,14 @@ find = G.find
 findIndex :: (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
+
+-- | /O(n)/ Yield 'Just' the index of the /last/ element matching the predicate
+-- or 'Nothing' if no such element exists.
+--
+-- Does not fuse.
+findIndexR :: (a -> Bool) -> Vector a -> Maybe Int
+{-# INLINE findIndexR #-}
+findIndexR = G.findIndexR
 
 -- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
 -- order.

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -1620,6 +1620,8 @@ findIndex f = Bundle.findIndex f . stream
 -- | /O(n)/ Yield 'Just' the index of the /last/ element matching the predicate
 -- or 'Nothing' if no such element exists.
 --
+-- Does not fuse.
+--
 -- @since 0.12.2.0
 findIndexR :: Vector v a => (a -> Bool) -> v a -> Maybe Int
 {-# INLINE findIndexR #-}

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -110,7 +110,7 @@ module Data.Vector.Primitive (
   partition, unstablePartition, partitionWith, span, break, groupBy, group,
 
   -- ** Searching
-  elem, notElem, find, findIndex, findIndices, elemIndex, elemIndices,
+  elem, notElem, find, findIndex, findIndexR, findIndices, elemIndex, elemIndices,
 
   -- * Folding
   foldl, foldl1, foldl', foldl1', foldr, foldr1, foldr', foldr1',
@@ -1232,6 +1232,14 @@ find = G.find
 findIndex :: Prim a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
+
+-- | /O(n)/ Yield 'Just' the index of the /last/ element matching the predicate
+-- or 'Nothing' if no such element exists.
+--
+-- Does not fuse.
+findIndexR :: Prim a => (a -> Bool) -> Vector a -> Maybe Int
+{-# INLINE findIndexR #-}
+findIndexR = G.findIndexR
 
 -- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
 -- order.

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -107,7 +107,7 @@ module Data.Vector.Storable (
   partition, unstablePartition, partitionWith, span, break, groupBy, group,
 
   -- ** Searching
-  elem, notElem, find, findIndex, findIndices, elemIndex, elemIndices,
+  elem, notElem, find, findIndex, findIndexR, findIndices, elemIndex, elemIndices,
 
   -- * Folding
   foldl, foldl1, foldl', foldl1', foldr, foldr1, foldr', foldr1',
@@ -1254,6 +1254,14 @@ find = G.find
 findIndex :: Storable a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
+
+-- | /O(n)/ Yield 'Just' the index of the /last/ element matching the predicate
+-- or 'Nothing' if no such element exists.
+--
+-- Does not fuse.
+findIndexR :: Storable a => (a -> Bool) -> Vector a -> Maybe Int
+{-# INLINE findIndexR #-}
+findIndexR = G.findIndexR
 
 -- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
 -- order.

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -152,7 +152,7 @@ module Data.Vector.Unboxed (
   partition, unstablePartition, partitionWith, span, break, groupBy, group,
 
   -- ** Searching
-  elem, notElem, find, findIndex, findIndices, elemIndex, elemIndices,
+  elem, notElem, find, findIndex, findIndexR, findIndices, elemIndex, elemIndices,
 
   -- * Folding
   foldl, foldl1, foldl', foldl1', foldr, foldr1, foldr', foldr1',
@@ -1243,6 +1243,14 @@ find = G.find
 findIndex :: Unbox a => (a -> Bool) -> Vector a -> Maybe Int
 {-# INLINE findIndex #-}
 findIndex = G.findIndex
+
+-- | /O(n)/ Yield 'Just' the index of the /last/ element matching the predicate
+-- or 'Nothing' if no such element exists.
+--
+-- Does not fuse.
+findIndexR :: Unbox a => (a -> Bool) -> Vector a -> Maybe Int
+{-# INLINE findIndexR #-}
+findIndexR = G.findIndexR
 
 -- | /O(n)/ Yield the indices of elements satisfying the predicate in ascending
 -- order.


### PR DESCRIPTION
`findIndexR` was only in the generic module and could be missed.

This PR adds type-restricted versions of  `findIndexR` to the non-generic vector modules (plain `Vector`, `Primitive`, `Storable` and `Unboxed`). It also adds `Does not fuse.` sentences to their documents.

Related: #172
