### PR TITLE
Allow base-4.20 for GHC 9.10

### DIFF
--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -49,7 +49,7 @@ Library
   Hs-Source-Dirs:
         src
 
-  Build-Depends: base >= 4.9 && < 4.20
+  Build-Depends: base >= 4.9 && < 4.21
                , ghc-prim >= 0.2 && < 0.12
 
 source-repository head

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -159,7 +159,7 @@ Library
   Install-Includes:
         vector.h
 
-  Build-Depends: base >= 4.9 && < 4.20
+  Build-Depends: base >= 4.9 && < 4.21
                , primitive >= 0.6.4.0 && < 0.10
                , deepseq >= 1.1 && < 1.6
                , vector-stream >= 0.1 && < 0.2


### PR DESCRIPTION
Tested with
```
cabal test -w ghc-9.10.0.20240313 all --allow-newer='tagged:template-haskell,splitmix:base,primitive:base,doctest:ghc,hsc2hs:base,hsc2hs:filepath,ghc-paths:Cabal'
```