### PR TITLE
CI: bump to GHC 9.6.5; fix to macos-13 for GHC < 9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.0.2"  }
           - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.2.8"  }
           - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.4.8"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.6.4"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.6.4",
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.6.5"  }
+          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.6.5",
               flags: "-fUnsafeChecks -fInternalChecks" }
           - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.8.2"  }
           # Win
@@ -40,14 +40,14 @@ jobs:
           # Too flaky:
           # - { cabal: "3.6", os: windows-latest,  ghc: "9.0.1"  }
           # MacOS
-          - { cabal: "3.10", os: macOS-latest,   ghc: "8.4.4"  }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "8.6.5"  }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "8.8.4"  }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "8.10.7" }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "9.0.2"  }
+          - { cabal: "3.10", os: macOS-13,       ghc: "8.4.4"  }
+          - { cabal: "3.10", os: macOS-13,       ghc: "8.6.5"  }
+          - { cabal: "3.10", os: macOS-13,       ghc: "8.8.4"  }
+          - { cabal: "3.10", os: macOS-13,       ghc: "8.10.7" }
+          - { cabal: "3.10", os: macOS-13,       ghc: "9.0.2"  }
           - { cabal: "3.10", os: macOS-latest,   ghc: "9.2.8"  }
           - { cabal: "3.10", os: macOS-latest,   ghc: "9.4.8"  }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "9.6.4"  }
+          - { cabal: "3.10", os: macOS-latest,   ghc: "9.6.5"  }
           - { cabal: "3.10", os: macOS-latest,   ghc: "9.8.2"  }
       fail-fast: false
 


### PR DESCRIPTION
macos-latest does not support GHC < 9.2
