### PR TITLE
make `nextPermutation` faster

### DIFF
--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -1231,7 +1231,7 @@ a given permutation. It changes the given permutation in-place.
 nextPermutation :: (PrimMonad m,Ord e,MVector v e) => v (PrimState m) e -> m Bool
 nextPermutation v
     | dim < 2 = return False
-    | otherwise = do
+    | otherwise = stToPrim $ do
         val <- unsafeRead v 0
         (k,l) <- loop val (-1) 0 val 1
         if k < 0
@@ -1243,8 +1243,7 @@ nextPermutation v
               | i == dim = return (k,l)
               | otherwise  = do
                   cur <- unsafeRead v i
-                  -- TODO: make tuple unboxed
-                  let (kval',k') = if prev < cur then (prev,i-1) else (kval,k)
+                  let (!kval',!k') = if prev < cur then (prev,i-1) else (kval,k)
                       l' = if kval' < cur then i else l
                   loop kval' k' l' cur (i+1)
           dim = length v


### PR DESCRIPTION
This PR makes `nextPermutation` like 10 times faster, resolving the `TODO` from 2014:

```diff
-                  -- TODO: make tuple unboxed
-                  let (kval',k') = if prev < cur then (prev,i-1) else (kval,k)
+                  let (!kval',!k') = if prev < cur then (prev,i-1) else (kval,k)
```

Let's do it! 

Edit: `stToPrim` (suggested by @gksato) makes it even faster. With `stToPrim`, the bangs are not needed for the speed, but I preferred explicit strict evaluation.

---

If anyone is interested, here's my AtCoder submissions for a simple speed comparsion:

- `GM.nextPermutation`: [time limit exceed](https://atcoder.jp/contests/abc363/submissions/55826926)
- `GM.nextPermutation` with tuples unboxed: [accepted (281 ms in the worst case)](https://atcoder.jp/contests/abc363/submissions/55826726)
- `GM.nextPermutation` with `stToPrim` and with tuples unboxed: [accepted (231 ms in the worst case)](https://atcoder.jp/contests/abc363/submissions/55834799)
