### PR TITLE
Optimize Mutable.nextPermutation and add {next/prev}permutation(By)

### DIFF
--- a/vector/benchlib/Bench/Vector/Algo/NextPermutation.hs
+++ b/vector/benchlib/Bench/Vector/Algo/NextPermutation.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+module Bench.Vector.Algo.NextPermutation (generatePermTests) where
+
+import qualified Data.Vector.Unboxed as V
+import qualified Data.Vector.Unboxed.Mutable as M
+import qualified Data.Vector.Generic.Mutable as G
+import System.Random.Stateful
+    ( StatefulGen, UniformRange(uniformRM) )
+
+-- | Generate a list of benchmarks for permutation algorithms.
+-- The list contains pairs of benchmark names and corresponding actions.
+-- The actions are to be executed by the benchmarking framework.
+-- 
+-- The list contains the following benchmarks:
+-- - @(next|prev)Permutation@ on a small vector repeated until the end of the permutation cycle
+-- - Bijective versions of @(next|prev)Permutation@ on a vector of size @n@, repeated @n@ times
+--  - ascending permutation
+--  - descending permutation
+--  - random permutation
+-- - Baseline for bijective versions: just copying a vector of size @n@. Note that the tests for
+--   bijective versions begins with copying a vector.
+generatePermTests :: StatefulGen g IO => g -> Int -> IO [(String, IO ())]
+generatePermTests gen useSize = do
+  let !k = useSizeToPermLen useSize
+  let !vasc = V.generate useSize id
+      !vdesc = V.generate useSize (useSize-1-)
+  !vrnd <- randomPermutationWith gen useSize
+  return
+    [ ("nextPermutation (small vector, until end)", loopPermutations k)
+    , ("nextPermutationBijective (ascending perm of size n, n times)", repeatNextPermutation vasc useSize)
+    , ("nextPermutationBijective (descending perm of size n, n times)", repeatNextPermutation vdesc useSize)
+    , ("nextPermutationBijective (random perm of size n, n times)", repeatNextPermutation vrnd useSize)
+    , ("prevPermutation (small vector, until end)", loopRevPermutations k)
+    , ("prevPermutationBijective (ascending perm of size n, n times)", repeatPrevPermutation vasc useSize)
+    , ("prevPermutationBijective (descending perm of size n, n times)", repeatPrevPermutation vdesc useSize)
+    , ("prevPermutationBijective (random perm of size n, n times)", repeatPrevPermutation vrnd useSize)
+    , ("baseline for *Bijective (just copying the vector of size n)", V.thaw vrnd >> return ())
+    ]
+
+-- | Given a PRNG and a length @n@, generate a random permutation of @[0..n-1]@.
+randomPermutationWith :: (StatefulGen g IO) => g -> Int -> IO (V.Vector Int)
+randomPermutationWith gen n = do
+  v <- M.generate n id
+  V.forM_ (V.generate (n-1) id) $ \ !i -> do
+    j <- uniformRM (i,n-1) gen
+    M.swap v i j
+  V.unsafeFreeze v
+
+-- | Given @useSize@ benchmark option, compute the largest @n <= 12@ such that @n! <= useSize@.
+-- Repeat-nextPermutation-until-end benchmark will use @n@ as the length of the vector.
+-- Note that 12 is the largest @n@ such that @n!@ can be represented as an 'Int32'.
+useSizeToPermLen :: Int -> Int
+useSizeToPermLen us = case V.findIndex (> max 0 us) $ V.scanl' (*) 1 $ V.generate 12 (+1) of
+    Just i -> i-1
+    Nothing -> 12
+
+-- | A bijective version of @G.nextPermutation@ that reverses the vector
+-- if it is already in descending order.
+-- "Bijective" here means that the function forms a cycle over all permutations
+-- of the vector's elements.
+--
+-- This has a nice property that should be benchmarked: 
+-- this function takes amortized constant time each call,
+-- if successively called either Omega(n) times on a single vector having distinct elements,
+-- or arbitrary times on a single vector initially in strictly ascending order.
+nextPermutationBijective :: (G.MVector v a, Ord a) => v G.RealWorld a -> IO Bool
+nextPermutationBijective v = do
+  res <- G.nextPermutation v
+  if res then return True else G.reverse v >> return False
+
+-- | A bijective version of @G.prevPermutation@ that reverses the vector
+-- if it is already in ascending order.
+-- "Bijective" here means that the function forms a cycle over all permutations
+-- of the vector's elements.
+--
+-- This has a nice property that should be benchmarked:
+-- this function takes amortized constant time each call,
+-- if successively called either Omega(n) times on a single vector having distinct elements,
+-- or arbitrary times on a single vector initially in strictly descending order.
+prevPermutationBijective :: (G.MVector v a, Ord a) => v G.RealWorld a -> IO Bool
+prevPermutationBijective v = do
+  res <- G.prevPermutation v
+  if res then return True else G.reverse v >> return False
+
+-- | Repeat @nextPermutation@ on @[0..n-1]@ until the end.
+loopPermutations :: Int -> IO ()
+loopPermutations n = do
+  v <- M.generate n id
+  let loop = do
+        res <- M.nextPermutation v
+        if res then loop else return ()
+  loop
+
+-- | Repeat @prevPermutation@ on @[n-1,n-2..0]@ until the end.
+loopRevPermutations :: Int -> IO ()
+loopRevPermutations n = do
+  v <- M.generate n (n-1-)
+  let loop = do
+        res <- M.prevPermutation v
+        if res then loop else return ()
+  loop
+
+-- | Repeat @nextPermutationBijective@ on a given vector given times.
+repeatNextPermutation :: V.Vector Int -> Int -> IO ()
+repeatNextPermutation !v !n = do
+  !mv <- V.thaw v
+  let loop !i | i <= 0 = return ()
+      loop !i = do
+        _ <- nextPermutationBijective mv
+        loop (i-1)
+  loop n
+
+-- | Repeat @prevPermutationBijective@ on a given vector given times.
+repeatPrevPermutation :: V.Vector Int -> Int -> IO ()
+repeatPrevPermutation !v !n = do
+  !mv <- V.thaw v
+  let loop !i | i <= 0 = return ()
+      loop !i = do
+        _ <- prevPermutationBijective mv
+        loop (i-1)
+  loop n

--- a/vector/benchmarks/Main.hs
+++ b/vector/benchmarks/Main.hs
@@ -1,16 +1,17 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Bench.Vector.Algo.MutableSet (mutableSet)
-import Bench.Vector.Algo.ListRank   (listRank)
-import Bench.Vector.Algo.Rootfix    (rootfix)
-import Bench.Vector.Algo.Leaffix    (leaffix)
-import Bench.Vector.Algo.AwShCC     (awshcc)
-import Bench.Vector.Algo.HybCC      (hybcc)
-import Bench.Vector.Algo.Quickhull  (quickhull)
-import Bench.Vector.Algo.Spectral   (spectral)
-import Bench.Vector.Algo.Tridiag    (tridiag)
-import Bench.Vector.Algo.FindIndexR (findIndexR, findIndexR_naive, findIndexR_manual)
+import Bench.Vector.Algo.MutableSet      (mutableSet)
+import Bench.Vector.Algo.ListRank        (listRank)
+import Bench.Vector.Algo.Rootfix         (rootfix)
+import Bench.Vector.Algo.Leaffix         (leaffix)
+import Bench.Vector.Algo.AwShCC          (awshcc)
+import Bench.Vector.Algo.HybCC           (hybcc)
+import Bench.Vector.Algo.Quickhull       (quickhull)
+import Bench.Vector.Algo.Spectral        (spectral)
+import Bench.Vector.Algo.Tridiag         (tridiag)
+import Bench.Vector.Algo.FindIndexR      (findIndexR, findIndexR_naive, findIndexR_manual)
+import Bench.Vector.Algo.NextPermutation (generatePermTests)
 
 import Bench.Vector.TestData.ParenTree (parenTree)
 import Bench.Vector.TestData.Graph     (randomGraph)
@@ -50,6 +51,7 @@ main = do
   !ds <- randomVector useSize
   !sp <- randomVector (floor $ sqrt $ fromIntegral useSize)
   vi <- MV.new useSize
+  permTests <- generatePermTests gen useSize
 
   defaultMainWithIngredients ingredients $ bgroup "All"
     [ bench "listRank"   $ whnf listRank useSize
@@ -66,4 +68,5 @@ main = do
     , bench "findIndexR_manual" $ whnf findIndexR_manual ((<indexFindThreshold), as)
     , bench "minimumOn"  $ whnf (U.minimumOn (\x -> x*x*x)) as
     , bench "maximumOn"  $ whnf (U.maximumOn (\x -> x*x*x)) as
+    , bgroup "(next|prev)Permutation" $ map (\(name, act) -> bench name $ whnfIO act) permTests
     ]

--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -1,3 +1,13 @@
+# Changes in version 0.13.2.0
+
+ * We had some improvements on `*.Mutable.{next,prev}Permutation{,By}`
+   [#498](https://github.com/haskell/vector/pull/498):
+   * Add `*.Mutable.prevPermutation{,By}` and `*.Mutable.nextPermutationBy`
+   * Improve time performance. We may now expect good specialization supported by inlining.
+     The implementation has also been algorithmically updated: in the previous implementation
+     the full enumeration of all the permutations of `[1..n]` took Omega(n*n!), but it now takes O(n!).
+   * Add tests for `{next,prev}Permutation`
+
 # Changes in version 0.13.1.0
 
  * Specialized variants of `findIndexR` are reexported for all vector

--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -7,6 +7,7 @@
      The implementation has also been algorithmically updated: in the previous implementation
      the full enumeration of all the permutations of `[1..n]` took Omega(n*n!), but it now takes O(n!).
    * Add tests for `{next,prev}Permutation`
+   * Add benchmarks for `{next,prev}Permutation`
 
 # Changes in version 0.13.1.0
 

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -1227,7 +1227,9 @@ a given permutation. It changes the given permutation in-place.
 -}
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
 nextPermutation :: (PrimMonad m,Ord e,MVector v e) => v (PrimState m) e -> m Bool
 nextPermutation v
     | dim < 2 = return False

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -1217,35 +1217,41 @@ partitionWithUnknown f s
 
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
 nextPermutation :: (PrimMonad m, Ord e, MVector v e) => v (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = nextPermutationByLt (<)
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
+--
+-- @since 0.13.2.0
 nextPermutationBy :: (PrimMonad m, MVector v e) => (e -> e -> Ordering) -> v (PrimState m) e -> m Bool
 {-# INLINE nextPermutationBy #-}
 nextPermutationBy cmp = nextPermutationByLt (\x y -> cmp x y == LT)
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutation :: (PrimMonad m, Ord e, MVector v e) => v (PrimState m) e -> m Bool
 {-# INLINE prevPermutation #-}
 prevPermutation = nextPermutationByLt (>)
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutationBy :: (PrimMonad m, MVector v e) => (e -> e -> Ordering) -> v (PrimState m) e -> m Bool
 {-# INLINE prevPermutationBy #-}
 prevPermutationBy cmp = nextPermutationByLt (\x y -> cmp x y == GT)

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -1275,6 +1275,7 @@ time complexity of O(n) on the best case.
 -- will not get updated, as opposed to the behavior of the C++ function 
 -- @std::next_permutation@.
 nextPermutationByLt :: (PrimMonad m, MVector v e) => (e -> e -> Bool) -> v (PrimState m) e -> m Bool
+{-# INLINE nextPermutationByLt #-}
 nextPermutationByLt lt v
   | dim < 2 = return False
   | otherwise = stToPrim $ do

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -58,7 +58,8 @@ module Data.Vector.Generic.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
-  nextPermutation,
+  nextPermutation, nextPermutationBy,
+  prevPermutation, prevPermutationBy,
 
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
@@ -91,9 +92,9 @@ import           Data.Vector.Internal.Check
 import Control.Monad.Primitive ( PrimMonad(..), RealWorld, stToPrim )
 
 import Prelude
-  ( Ord, Monad, Bool(..), Int, Maybe(..), Either(..)
+  ( Ord, Monad, Bool(..), Int, Maybe(..), Either(..), Ordering(..)
   , return, otherwise, flip, const, seq, min, max, not, pure
-  , (>>=), (+), (-), (<), (<=), (>=), (==), (/=), (.), ($), (=<<), (>>), (<$>) )
+  , (>>=), (+), (-), (<), (<=), (>), (>=), (==), (/=), (.), ($), (=<<), (>>), (<$>) )
 import Data.Bits ( Bits(shiftR) )
 
 #include "vector.h"
@@ -1223,6 +1224,31 @@ nextPermutation :: (PrimMonad m, Ord e, MVector v e) => v (PrimState m) e -> m B
 {-# INLINE nextPermutation #-}
 nextPermutation = nextPermutationByLt (<)
 
+-- | Compute the (lexicographically) next permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+nextPermutationBy :: (PrimMonad m, MVector v e) => (e -> e -> Ordering) -> v (PrimState m) e -> m Bool
+{-# INLINE nextPermutationBy #-}
+nextPermutationBy cmp = nextPermutationByLt (\x y -> cmp x y == LT)
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutation :: (PrimMonad m, Ord e, MVector v e) => v (PrimState m) e -> m Bool
+{-# INLINE prevPermutation #-}
+prevPermutation = nextPermutationByLt (>)
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutationBy :: (PrimMonad m, MVector v e) => (e -> e -> Ordering) -> v (PrimState m) e -> m Bool
+{-# INLINE prevPermutationBy #-}
+prevPermutationBy cmp = nextPermutationByLt (\x y -> cmp x y == GT)
 
 {-
 http://en.wikipedia.org/wiki/Permutation#Algorithms_to_generate_permutations

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -574,7 +574,9 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
 nextPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -58,7 +58,8 @@ module Data.Vector.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
-  nextPermutation,
+  nextPermutation, nextPermutationBy,
+  prevPermutation, prevPermutationBy,
 
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
@@ -580,6 +581,32 @@ unsafeMove = G.unsafeMove
 nextPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
+
+-- | Compute the (lexicographically) next permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+nextPermutationBy :: PrimMonad m => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE nextPermutationBy #-}
+nextPermutationBy = G.nextPermutationBy
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutation #-}
+prevPermutation = G.prevPermutation
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutationBy :: PrimMonad m => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutationBy #-}
+prevPermutationBy = G.prevPermutationBy
 
 -- Folds
 -- -----

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -575,35 +575,41 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
 nextPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
+--
+-- @since 0.13.2.0
 nextPermutationBy :: PrimMonad m => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutationBy #-}
 nextPermutationBy = G.nextPermutationBy
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutation #-}
 prevPermutation = G.prevPermutation
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutationBy :: PrimMonad m => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutationBy #-}
 prevPermutationBy = G.prevPermutationBy

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -57,7 +57,8 @@ module Data.Vector.Primitive.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
-  nextPermutation,
+  nextPermutation, nextPermutationBy,
+  prevPermutation, prevPermutationBy,
 
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
@@ -83,7 +84,7 @@ import Control.DeepSeq ( NFData(rnf)
                        )
 
 import Prelude
-  ( Ord, Bool, Int, Maybe
+  ( Ord, Bool, Int, Maybe, Ordering(..)
   , otherwise, error, undefined, div, show, maxBound
   , (+), (*), (<), (>), (>=), (==), (&&), (||), ($), (++) )
 
@@ -546,6 +547,32 @@ unsafeMove = G.unsafeMove
 nextPermutation :: (PrimMonad m,Ord e,Prim e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
+
+-- | Compute the (lexicographically) next permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+nextPermutationBy :: (PrimMonad m,Prim e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE nextPermutationBy #-}
+nextPermutationBy = G.nextPermutationBy
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutation :: (PrimMonad m,Ord e,Prim e) => MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutation #-}
+prevPermutation = G.prevPermutation
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutationBy :: (PrimMonad m,Prim e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutationBy #-}
+prevPermutationBy = G.prevPermutationBy
 
 -- Folds
 -- -----

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -540,7 +540,9 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
 nextPermutation :: (PrimMonad m,Ord e,Prim e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -541,35 +541,41 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
 nextPermutation :: (PrimMonad m,Ord e,Prim e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
+--
+-- @since 0.13.2.0
 nextPermutationBy :: (PrimMonad m,Prim e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutationBy #-}
 nextPermutationBy = G.nextPermutationBy
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutation :: (PrimMonad m,Ord e,Prim e) => MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutation #-}
 prevPermutation = G.prevPermutation
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutationBy :: (PrimMonad m,Prim e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutationBy #-}
 prevPermutationBy = G.prevPermutationBy

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -58,7 +58,8 @@ module Data.Vector.Storable.Mutable(
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
-  nextPermutation,
+  nextPermutation, nextPermutationBy,
+  prevPermutation, prevPermutationBy,
 
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
@@ -101,7 +102,7 @@ import GHC.Word (Word8, Word16, Word32, Word64)
 import GHC.Ptr (Ptr(..))
 
 import Prelude
-  ( Ord, Bool, Maybe, IO
+  ( Ord, Bool, Maybe, IO, Ordering(..)
   , return, otherwise, error, undefined, max, div, quot, maxBound, show
   , (-), (*), (<), (>), (>=), (==), (&&), (||), (.), ($), (++) )
 
@@ -647,6 +648,32 @@ unsafeMove = G.unsafeMove
 nextPermutation :: (PrimMonad m, Storable e, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
+
+-- | Compute the (lexicographically) next permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+nextPermutationBy :: (PrimMonad m, Storable e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE nextPermutationBy #-}
+nextPermutationBy = G.nextPermutationBy
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutation :: (PrimMonad m, Storable e, Ord e) => MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutation #-}
+prevPermutation = G.prevPermutation
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutationBy :: (PrimMonad m, Storable e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutationBy #-}
+prevPermutationBy = G.prevPermutationBy
 
 -- Folds
 -- -----

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -641,7 +641,9 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
 nextPermutation :: (PrimMonad m, Storable e, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -642,35 +642,41 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
 nextPermutation :: (PrimMonad m, Storable e, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
+--
+-- @since 0.13.2.0
 nextPermutationBy :: (PrimMonad m, Storable e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutationBy #-}
 nextPermutationBy = G.nextPermutationBy
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutation :: (PrimMonad m, Storable e, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutation #-}
 prevPermutation = G.prevPermutation
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutationBy :: (PrimMonad m, Storable e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutationBy #-}
 prevPermutationBy = G.prevPermutationBy

--- a/vector/src/Data/Vector/Strict/Mutable.hs
+++ b/vector/src/Data/Vector/Strict/Mutable.hs
@@ -62,7 +62,8 @@ module Data.Vector.Strict.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
-  nextPermutation,
+  nextPermutation, nextPermutationBy,
+  prevPermutation, prevPermutationBy,
 
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
@@ -82,7 +83,7 @@ import           Data.Primitive.Array
 import           Control.Monad.Primitive
 
 import Prelude
-  ( Ord, Monad(..), Bool, Int, Maybe
+  ( Ord, Monad(..), Bool, Int, Maybe, Ordering(..)
   , return, ($), (<$>) )
 
 import Data.Typeable ( Typeable )
@@ -562,6 +563,32 @@ unsafeMove = G.unsafeMove
 nextPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
+
+-- | Compute the (lexicographically) next permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+nextPermutationBy :: (PrimMonad m) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE nextPermutationBy #-}
+nextPermutationBy = G.nextPermutationBy
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutation #-}
+prevPermutation = G.prevPermutation
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutationBy :: (PrimMonad m) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutationBy #-}
+prevPermutationBy = G.prevPermutationBy
 
 
 -- Folds

--- a/vector/src/Data/Vector/Strict/Mutable.hs
+++ b/vector/src/Data/Vector/Strict/Mutable.hs
@@ -555,9 +555,9 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
 --
 -- @since 0.13.2.0
 nextPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
@@ -566,27 +566,33 @@ nextPermutation = G.nextPermutation
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
-nextPermutationBy :: (PrimMonad m) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
+--
+-- @since 0.13.2.0
+nextPermutationBy :: PrimMonad m => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutationBy #-}
 nextPermutationBy = G.nextPermutationBy
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutation #-}
 prevPermutation = G.prevPermutation
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
-prevPermutationBy :: (PrimMonad m) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
+prevPermutationBy :: PrimMonad m => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutationBy #-}
 prevPermutationBy = G.prevPermutationBy
 

--- a/vector/src/Data/Vector/Strict/Mutable.hs
+++ b/vector/src/Data/Vector/Strict/Mutable.hs
@@ -554,12 +554,15 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
 --
 -- @since 0.13.2.0
 nextPermutation :: (PrimMonad m, Ord e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
+
 
 -- Folds
 -- -----

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -443,7 +443,9 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
 nextPermutation :: (PrimMonad m,Ord e,Unbox e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -444,35 +444,41 @@ unsafeMove = G.unsafeMove
 -- -----------------
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
 nextPermutation :: (PrimMonad m,Ord e,Unbox e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly descending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::next_permutation@.
+--
+-- @since 0.13.2.0
 nextPermutationBy :: (PrimMonad m,Unbox e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutationBy #-}
 nextPermutationBy = G.nextPermutationBy
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutation :: (PrimMonad m,Ord e,Unbox e) => MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutation #-}
 prevPermutation = G.prevPermutation
 
 -- | Compute the (lexicographically) previous permutation of the given vector in-place,
 -- using the provided comparison function.
--- Returns False when the input is the last permutation; in this case the vector
--- will not get updated, as opposed to the behavior of the C++ function 
--- @std::next_permutation@.
+-- Returns False when the input is the last item in the enumeration, i.e., if it is in
+-- weakly ascending order. In this case the vector will not get updated,
+-- as opposed to the behavior of the C++ function @std::prev_permutation@.
+--
+-- @since 0.13.2.0
 prevPermutationBy :: (PrimMonad m,Unbox e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
 {-# INLINE prevPermutationBy #-}
 prevPermutationBy = G.prevPermutationBy

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -57,7 +57,8 @@ module Data.Vector.Unboxed.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
-  nextPermutation,
+  nextPermutation, nextPermutationBy,
+  prevPermutation, prevPermutationBy,
 
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
@@ -70,7 +71,7 @@ import qualified Data.Vector.Generic.Mutable as G
 import Data.Vector.Fusion.Util ( delayed_min )
 import Control.Monad.Primitive
 
-import Prelude ( Ord, Bool, Int, Maybe )
+import Prelude ( Ord, Bool, Int, Maybe, Ordering(..) )
 
 -- don't import an unused Data.Vector.Internal.Check
 #define NOT_VECTOR_MODULE
@@ -449,6 +450,32 @@ unsafeMove = G.unsafeMove
 nextPermutation :: (PrimMonad m,Ord e,Unbox e) => MVector (PrimState m) e -> m Bool
 {-# INLINE nextPermutation #-}
 nextPermutation = G.nextPermutation
+
+-- | Compute the (lexicographically) next permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+nextPermutationBy :: (PrimMonad m,Unbox e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE nextPermutationBy #-}
+nextPermutationBy = G.nextPermutationBy
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutation :: (PrimMonad m,Ord e,Unbox e) => MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutation #-}
+prevPermutation = G.prevPermutation
+
+-- | Compute the (lexicographically) previous permutation of the given vector in-place,
+-- using the provided comparison function.
+-- Returns False when the input is the last permutation; in this case the vector
+-- will not get updated, as opposed to the behavior of the C++ function 
+-- @std::next_permutation@.
+prevPermutationBy :: (PrimMonad m,Unbox e) => (e -> e -> Ordering) -> MVector (PrimState m) e -> m Bool
+{-# INLINE prevPermutationBy #-}
+prevPermutationBy = G.prevPermutationBy
 
 -- Folds
 -- -----

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -286,6 +286,7 @@ library benchmarks-O2
         Bench.Vector.Algo.Spectral
         Bench.Vector.Algo.Tridiag
         Bench.Vector.Algo.FindIndexR
+        Bench.Vector.Algo.NextPermutation
         Bench.Vector.TestData.ParenTree
         Bench.Vector.TestData.Graph
         Bench.Vector.Tasty


### PR DESCRIPTION
This implements some optimization of `nextPermutation` from `Data.Vector.Generic.Mutable`, and supercedes #497. The main content of this re-implementation is the following two points:
  
1. Wrapping the whole implementation in `stToPrim`. This allows the compiler to optimize the code better.
2. When finding the rightmost increasing pair v[k]<v[k+1], we now search from the right, instead of from the left. This allows us to abort the search as soon as we find such a pair, giving average-case constant performance, instead of best-case linear in the previous implementation.

Also, this adds some clarification on doc comments; `nextPermutation` does not update the source vector when the given vector is the last permutation.

---

### Update

This also adds the following API:
```haskell
Data.Vector.*.Mutable.nextPermutationBy :: Constraint => (e -> e -> Ordering) -> v (PrimState m) a -> m Bool
Data.Vector.*.Mutable.prevPermutation :: (Constraint, Ord e) => v (PrimState m) a -> m Bool
Data.Vector.*.Mutable.prevPermutationBy :: Constraint => (e -> e -> Ordering) -> v (PrimState m) a -> m Bool
```