### PR TITLE
Workaround for overwriting of .ddump-timing in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,19 @@ jobs:
       matrix:
         include:
           # Linux
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.0.2"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.2.2"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.4.4"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.6.5"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.8.4"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "8.10.7" }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.0.2"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.2.8"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.4.8"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.6.5"  }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.6.5",
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.0.2"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.2.2"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.4.4"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.6.5"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.8.4"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.10.7" }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.0.2"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.2.8"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.4.8"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.6.5"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.6.5",
               flags: "-fUnsafeChecks -fInternalChecks" }
-          - { cabal: "3.10", os: ubuntu-latest,  ghc: "9.8.2"  }
+          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.8.2"  }
           # Win
           - { cabal: "3.10", os: windows-latest, ghc: "8.4.4"  }
           # OOM when building tests
@@ -73,7 +73,7 @@ jobs:
       run: |
         sudo apt-get install -y libpapi-dev
         echo FLAG_PAPI=-fBenchPAPI >> "$GITHUB_ENV"
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-22.04'
     # ----------------
     - name: Versions
       run: |

--- a/vector/tests/Utilities.hs
+++ b/vector/tests/Utilities.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -208,7 +208,7 @@ common tests-common
     Tests.Vector.UnitTests
     Utilities
 
-  default-extensions: CPP,
+  default-extensions:
               ScopedTypeVariables,
               PatternGuards,
               MultiParamTypeClasses,


### PR DESCRIPTION
    Enable CPP per module in tests
    
    This is workaround for problem of benchmarking build time.
    When package is compiled with GHC flags `-ddump-timings -ddump-to-file`
    *.dump-timings files corresponding to modules with enabled CPP gets overwritten
    at link time.
    
    Timing for Utilities still get lost but its contribution is small anyway
    and we're able to keep timings for other modules
    
    Note that libraries are not affected by this problem.


Also unbreak CI which stopped working after upgrading ubuntu-latest to 24.04