### PR TITLE
A desirable Boxed instance for Unboxed

### DIFF
--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -132,15 +132,12 @@ module Data.Vector.Unboxed (
   -- ** Zipping
   zipWith, zipWith3, zipWith4, zipWith5, zipWith6,
   izipWith, izipWith3, izipWith4, izipWith5, izipWith6,
-  -- *** Zipping tuples
-  -- $zip
   zip, zip3, zip4, zip5, zip6,
 
   -- ** Monadic zipping
   zipWithM, izipWithM, zipWithM_, izipWithM_,
 
   -- ** Unzipping
-  -- $unzip
   unzip, unzip3, unzip4, unzip5, unzip6,
 
   -- * Working with predicates
@@ -201,7 +198,14 @@ module Data.Vector.Unboxed (
   -- ** Deriving via
   UnboxViaPrim(..),
   As(..),
-  IsoUnbox(..)
+  IsoUnbox(..),
+
+  -- *** /Lazy/ boxing
+  DoNotUnboxLazy(..),
+
+  -- *** /Strict/ boxing
+  DoNotUnboxStrict(..),
+  DoNotUnboxNormalForm(..)
 ) where
 
 import Data.Vector.Unboxed.Base
@@ -972,26 +976,6 @@ iforM_ = G.iforM_
 
 -- Zipping
 -- -------
-
--- $zip
---
--- Following functions could be used to construct vector of tuples
--- from tuple of vectors. This operation is done in /O(1)/ time and
--- will share underlying buffers.
---
--- Note that variants from "Data.Vector.Generic" doesn't have this
--- property.
-
--- $unzip
---
--- Following functions could be used to access underlying
--- representation of array of tuples. They convert array to tuple of
--- arrays. This operation is done in /O(1)/ time and will share
--- underlying buffers.
---
--- Note that variants from "Data.Vector.Generic" doesn't have this
--- property.
-
 
 -- | /O(min(m,n))/ Zip two vectors with the given function.
 zipWith :: (Unbox a, Unbox b, Unbox c)
@@ -1951,12 +1935,12 @@ toList :: Unbox a => Vector a -> [a]
 {-# INLINE toList #-}
 toList = G.toList
 
--- | /O(n)/ Convert a list to a vector. During the operation, the 
--- vector’s capacity will be doubling until the list's contents are 
--- in the vector. Depending on the list’s size, up to half of the vector’s 
--- capacity might be empty. If you’d rather avoid this, you can use 
--- 'fromListN', which will provide the exact space the list requires but will 
--- prevent list fusion, or @'force' . 'fromList'@, which will create the 
+-- | /O(n)/ Convert a list to a vector. During the operation, the
+-- vector’s capacity will be doubling until the list's contents are
+-- in the vector. Depending on the list’s size, up to half of the vector’s
+-- capacity might be empty. If you’d rather avoid this, you can use
+-- 'fromListN', which will provide the exact space the list requires but will
+-- prevent list fusion, or @'force' . 'fromList'@, which will create the
 -- vector and then copy it without the superfluous space.
 --
 -- @since 0.3


### PR DESCRIPTION
This PR contains a proof of concept for `Unbox` instances of "boxed" data-types by way of the newly added `AsBoxedStrictly` and `AsBoxedLazily` newtypes. This PR is intended to address issue #503.

The `AsBoxedStrictly` newtype imposes new strictness semantics on the underlying type, ensuring the wrapped value is always reduced to normal form. This invariant requires an `NFData` instance for the underlying type. Furthermore, it requires the use of a "smart constructor" which evaluates the wrapped value to normal form, since a new-type cannot have strictness annotations. Hence there are `makeBoxedStrictly` and `grabBoxedStrictly` exposed from the `Data.Vector.Unboxed` module to construct and deconstruct `AsBoxedStrictly` values, respectively.

The `AsBoxedLazily` new-type is much simpler since it preserves the strictness semantics of the underlying data-type unaltered.

Here are two example usages of the newtypes as a proof of concept:

### **Strict usage**

```
data Foo a = Foo Int a
  deriving (Eq, Ord, Show)

instance NFData a => VU.IsoUnbox (Foo a) (Int, AsBoxedStrictly a) where
  toURepr (Foo i a) = (i, makeBoxedStrictly a)
  fromURepr (i, a) = Foo i $ grabBoxedStrictly a
  {-# INLINE toURepr #-}
  {-# INLINE fromURepr #-}
  
newtype instance VU.MVector s (Foo a) = MV_Foo (VU.MVector s (Int, AsBoxedStrictly a))

newtype instance VU.Vector    (Foo a) = V_Foo  (VU.Vector    (Int, AsBoxedStrictly a))

deriving via (Foo a `VU.As` (Int, AsBoxedStrictly a)) instance NFData a => VGM.MVector VUM.MVector (Foo a)

deriving via (Foo a `VU.As` (Int, AsBoxedStrictly a)) instance NFData a => VG.Vector   VU.Vector   (Foo a)

instance NFData a => VU.Unbox (Foo a)
```

In `GHCi`
```
import qualified Data.Vector.Unboxed as VU
VU.fromListN 3 [ Foo 4 "Hello", Foo 8 "there", Foo 16 "sailor" ]
[Foo 4 "Hello",Foo 8 "there",Foo 16 "sailor"]
```


### **Lazy usage**

```
data Bar a = Bar Int a
  deriving (Eq, Ord, Show)

instance VU.IsoUnbox (Bar a) (Int, AsBoxedLazily a) where
  toURepr (Bar i a) = (i, AsBoxedLazily a)
  fromURepr (i, AsBoxedLazily a) = Bar i a
  {-# INLINE toURepr #-}
  {-# INLINE fromURepr #-}
  
newtype instance VU.MVector s (Bar a) = MV_Bar (VU.MVector s (Int, AsBoxedLazily a))

newtype instance VU.Vector    (Bar a) = V_Bar  (VU.Vector    (Int, AsBoxedLazily a))

deriving via (Bar a `VU.As` (Int, AsBoxedLazily a)) instance VGM.MVector VUM.MVector (Bar a)

deriving via (Bar a `VU.As` (Int, AsBoxedLazily a)) instance VG.Vector   VU.Vector   (Bar a)

instance VU.Unbox (Bar a)
```

In `GHCi`
```
import qualified Data.Vector.Unboxed as VU
VU.fromListN 3 [ Bar 3 "Bye", Bar 2 "for", Bar 1 "now" ]
[Bar 3 "Bye",Bar 2 "for",Bar 1 "now"]
```

### *Nota Bene*

Since this is a proof of concept, all types and functions names are subject to change after the appropriate level of ["bike-shedding"](https://en.wiktionary.org/wiki/bikeshedding) has occurred. Commentary is welcomed and encouraged.