### PR TITLE
Support for GHC-9.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,22 @@ jobs:
       matrix:
         include:
           # Linux
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.0.2"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.2.2"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.4.4"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.6.5"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.8.4"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "8.10.7" }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.0.2"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.2.8"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.4.8"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.6.5"  }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.6.5",
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.0.2"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.2.2"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.4.4"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.6.5"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.8.4"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.10.7" }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.0.2"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.2.8"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.4.8"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.6.6"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.6.6",
               flags: "-fUnsafeChecks -fInternalChecks" }
-          - { cabal: "3.10", os: ubuntu-22.04,  ghc: "9.8.2"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.8.2"  }
+          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.10.1"  }
           # Win
-          - { cabal: "3.10", os: windows-latest, ghc: "8.4.4"  }
+          - { cabal: "3.12", os: windows-latest, ghc: "8.4.4"  }
           # OOM when building tests
           # - { cabal: "3.6", os: windows-latest, ghc: "8.6.5"  }
           # - { cabal: "3.6", os: windows-latest, ghc: "8.8.4"  }
@@ -40,15 +41,16 @@ jobs:
           # Too flaky:
           # - { cabal: "3.6", os: windows-latest,  ghc: "9.0.1"  }
           # MacOS
-          - { cabal: "3.10", os: macOS-13,       ghc: "8.4.4"  }
-          - { cabal: "3.10", os: macOS-13,       ghc: "8.6.5"  }
-          - { cabal: "3.10", os: macOS-13,       ghc: "8.8.4"  }
-          - { cabal: "3.10", os: macOS-13,       ghc: "8.10.7" }
-          - { cabal: "3.10", os: macOS-13,       ghc: "9.0.2"  }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "9.2.8"  }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "9.4.8"  }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "9.6.5"  }
-          - { cabal: "3.10", os: macOS-latest,   ghc: "9.8.2"  }
+          - { cabal: "3.12", os: macOS-13,       ghc: "8.4.4"  }
+          - { cabal: "3.12", os: macOS-13,       ghc: "8.6.5"  }
+          - { cabal: "3.12", os: macOS-13,       ghc: "8.8.4"  }
+          - { cabal: "3.12", os: macOS-13,       ghc: "8.10.7" }
+          - { cabal: "3.12", os: macOS-13,       ghc: "9.0.2"  }
+          - { cabal: "3.12", os: macOS-latest,   ghc: "9.2.8"  }
+          - { cabal: "3.12", os: macOS-latest,   ghc: "9.4.8"  }
+          - { cabal: "3.12", os: macOS-latest,   ghc: "9.6.6"  }
+          - { cabal: "3.12", os: macOS-latest,   ghc: "9.8.2"  }
+          - { cabal: "3.12", os: macOS-latest,   ghc: "9.10.1"  }
       fail-fast: false
 
     steps:

--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -49,7 +49,7 @@ Library
   Hs-Source-Dirs:
         src
 
-  Build-Depends: base >= 4.9 && < 4.21
+  Build-Depends: base >= 4.9 && < 4.22
                , ghc-prim >= 0.2 && < 0.12
 
 source-repository head

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -160,7 +160,7 @@ Library
   Install-Includes:
         vector.h
 
-  Build-Depends: base >= 4.9 && < 4.21
+  Build-Depends: base >= 4.9 && < 4.22
                , primitive >= 0.6.4.0 && < 0.10
                , deepseq >= 1.1 && < 1.6
                , vector-stream >= 0.1 && < 0.2


### PR DESCRIPTION
Relax upper bound on base. Tested locally with GHC-9.12

Also updates  CI while we're at it

Fix #509