### PR TITLE
Update documentation for unboxed vector

### DIFF
--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -132,12 +132,15 @@ module Data.Vector.Unboxed (
   -- ** Zipping
   zipWith, zipWith3, zipWith4, zipWith5, zipWith6,
   izipWith, izipWith3, izipWith4, izipWith5, izipWith6,
+  -- *** Zipping tuples
+  -- $zip
   zip, zip3, zip4, zip5, zip6,
 
   -- ** Monadic zipping
   zipWithM, izipWithM, zipWithM_, izipWithM_,
 
   -- ** Unzipping
+  -- $unzip
   unzip, unzip3, unzip4, unzip5, unzip6,
 
   -- * Working with predicates
@@ -976,6 +979,26 @@ iforM_ = G.iforM_
 
 -- Zipping
 -- -------
+
+-- $zip
+--
+-- Following functions could be used to construct vector of tuples
+-- from tuple of vectors. This operation is done in /O(1)/ time and
+-- will share underlying buffers.
+--
+-- Note that variants from "Data.Vector.Generic" doesn't have this
+-- property.
+
+-- $unzip
+--
+-- Following functions could be used to access underlying
+-- representation of array of tuples. They convert array to tuple of
+-- arrays. This operation is done in /O(1)/ time and will share
+-- underlying buffers.
+--
+-- Note that variants from "Data.Vector.Generic" doesn't have this
+-- property.
+
 
 -- | /O(min(m,n))/ Zip two vectors with the given function.
 zipWith :: (Unbox a, Unbox b, Unbox c)

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -1027,9 +1027,6 @@ instance NFData a => G.Vector Vector (DoNotUnboxNormalForm a) where
 
 instance NFData a => Unbox (DoNotUnboxNormalForm a)
 
-instance NFData a => NFData (DoNotUnboxNormalForm a) where
-  {-# INLINE rnf #-}
-  rnf = rnf . coerce @(DoNotUnboxNormalForm a) @a
 
 deriveNewtypeInstances((), Any, Bool, Any, V_Any, MV_Any)
 deriveNewtypeInstances((), All, Bool, All, V_All, MV_All)


### PR DESCRIPTION
1. Drop NFData instance for DoNotUnboxNormalForm since it's not needed
2. Revert accidental deletion of documentation in 89d7584a9cb0b9aefe4676a497355ebc865c27de
3.  Rework overview of module for unboxed vectors
    
     - Mention that vector are not _necessarily_ unboxed
    
     - Enumerate all standard deriving methods. (And drop "Implementing unboxed
       vectors for new data types can be very easy", it always felt like mockery.