### PR TITLE
Drop "possibly" from force's haddocks

### DIFF
--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -892,7 +892,7 @@ createT p = G.createT p
 -- ------------------------
 
 -- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
--- possibly by copying it.
+-- by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
 --

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -805,7 +805,7 @@ createT p = runST (p >>= T.mapM unsafeFreeze)
 -- ------------------------
 
 -- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
--- possibly by copying it.
+-- by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
 --

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -731,7 +731,7 @@ createT p = G.createT p
 -- ------------------------
 
 -- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
--- possibly by copying it.
+-- by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
 --

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -742,7 +742,7 @@ createT p = G.createT p
 -- ------------------------
 
 -- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
--- possibly by copying it.
+-- by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
 --

--- a/vector/src/Data/Vector/Strict.hs
+++ b/vector/src/Data/Vector/Strict.hs
@@ -930,7 +930,7 @@ createT p = G.createT p
 -- ------------------------
 
 -- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
--- possibly by copying it.
+-- by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
 --

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -705,7 +705,7 @@ createT p = G.createT p
 -- ------------------------
 
 -- | /O(n)/ Yield the argument, but force it not to retain any extra memory,
--- possibly by copying it.
+-- by copying it.
 --
 -- This is especially useful when dealing with slices. For example:
 --


### PR DESCRIPTION
force indeed copies unconditionally. Even in case like:

> force (generate n fun)

In principle GHC could be able to elide copying using rewrite rules related to clone/New in practice it doesn't. So it's better to remove possibly since it will only confuse reader.

Fixes #511