### PR TITLE
Add Unboxed instances for Storable vectors

### DIFF
--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -210,6 +210,7 @@ module Data.Vector.Unboxed (
   UnboxViaPrim(..),
   As(..),
   IsoUnbox(..),
+  UnboxViaStorable(..),
 
   -- *** /Lazy/ boxing
   DoNotUnboxLazy(..),

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -68,7 +68,7 @@
 -- @
 module Data.Vector.Unboxed (
   -- * Unboxed vectors
-  Vector(V_UnboxAs, V_UnboxViaPrim), MVector(..), Unbox,
+  Vector(V_UnboxAs, V_UnboxViaPrim, V_UnboxViaStorable), MVector(..), Unbox,
 
   -- * Accessors
 

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -68,7 +68,8 @@
 -- @
 module Data.Vector.Unboxed (
   -- * Unboxed vectors
-  Vector(V_UnboxAs, V_UnboxViaPrim, V_UnboxViaStorable), MVector(..), Unbox,
+  Vector(V_UnboxAs, V_UnboxViaPrim, V_UnboxViaStorable,V_DoNotUnboxLazy,V_DoNotUnboxStrict,V_DoNotUnboxNormalForm),
+  MVector(..), Unbox,
 
   -- * Accessors
 

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -188,14 +188,14 @@ instance G.Vector Vector () where
 -- >>>
 -- >>> newtype Foo = Foo Int deriving VP.Prim
 -- >>>
--- >>> newtype instance VU.MVector s Foo = MV_Int (VP.MVector s Foo)
--- >>> newtype instance VU.Vector    Foo = V_Int  (VP.Vector    Foo)
+-- >>> newtype instance VU.MVector s Foo = MV_Foo (VP.MVector s Foo)
+-- >>> newtype instance VU.Vector    Foo = V_Foo  (VP.Vector    Foo)
 -- >>> deriving via (VU.UnboxViaPrim Foo) instance VGM.MVector VU.MVector Foo
 -- >>> deriving via (VU.UnboxViaPrim Foo) instance VG.Vector   VU.Vector  Foo
 -- >>> instance VU.Unbox Foo
 --
 -- Second example is essentially same but with a twist. Instead of
--- using @Prim@ instance of data type, we use underlying instance of @Int@:
+-- using 'P.Prim' instance of data type, we use underlying instance of 'Int':
 --
 -- >>> :set -XTypeFamilies -XStandaloneDeriving -XDerivingVia -XMultiParamTypeClasses
 -- >>>
@@ -206,8 +206,8 @@ instance G.Vector Vector () where
 -- >>>
 -- >>> newtype Foo = Foo Int
 -- >>>
--- >>> newtype instance VU.MVector s Foo = MV_Int (VP.MVector s Int)
--- >>> newtype instance VU.Vector    Foo = V_Int  (VP.Vector    Int)
+-- >>> newtype instance VU.MVector s Foo = MV_Foo (VP.MVector s Int)
+-- >>> newtype instance VU.Vector    Foo = V_Foo  (VP.Vector    Int)
 -- >>> deriving via (VU.UnboxViaPrim Int) instance VGM.MVector VU.MVector Foo
 -- >>> deriving via (VU.UnboxViaPrim Int) instance VG.Vector   VU.Vector  Foo
 -- >>> instance VU.Unbox Foo

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -774,8 +774,7 @@ instance (Unbox a, Unbox b) => G.Vector Vector (Arg a b) where
 -- manually. Then we use deriving via to define necessary instances.
 --
 -- >>> :set -XTypeFamilies -XStandaloneDeriving -XDerivingVia -XMultiParamTypeClasses
--- >>> -- Needed to derive Prim
--- >>> :set -XGeneralizedNewtypeDeriving -XDataKinds -XUnboxedTuples -XPolyKinds
+-- >>> :set -XGeneralizedNewtypeDeriving
 -- >>>
 -- >>> import qualified Data.Vector.Generic         as VG
 -- >>> import qualified Data.Vector.Generic.Mutable as VGM
@@ -808,7 +807,7 @@ instance (Unbox a, Unbox b) => G.Vector Vector (Arg a b) where
 -- >>> deriving via (VU.UnboxViaStorable Int) instance VG.Vector   VU.Vector  Foo
 -- >>> instance VU.Unbox Foo
 --
--- @since 0.13.0.0
+-- @since 0.13.3.0
 newtype UnboxViaStorable a = UnboxViaStorable a
 
 newtype instance MVector s (UnboxViaStorable a) = MV_UnboxViaStorable (St.MVector s a)
@@ -875,7 +874,6 @@ instance St.Storable a => Unbox (UnboxViaStorable a)
 -- >>> :set -XTypeFamilies -XStandaloneDeriving -XDerivingVia
 -- >>> :set -XMultiParamTypeClasses -XTypeOperators -XFlexibleInstances
 -- >>> import qualified Data.Vector.Unboxed         as VU
--- >>> import qualified Data.Vector.Unboxed.Mutable as VUM
 -- >>> import qualified Data.Vector.Generic         as VG
 -- >>> import qualified Data.Vector.Generic.Mutable as VGM
 -- >>> :{
@@ -888,7 +886,7 @@ instance St.Storable a => Unbox (UnboxViaStorable a)
 -- >>>   {-# INLINE fromURepr #-}
 -- >>> newtype instance VU.MVector s (Foo a) = MV_Foo (VU.MVector s (Int, VU.DoNotUnboxLazy a))
 -- >>> newtype instance VU.Vector    (Foo a) = V_Foo  (VU.Vector    (Int, VU.DoNotUnboxLazy a))
--- >>> deriving via (Foo a `VU.As` (Int, VU.DoNotUnboxLazy a)) instance VGM.MVector VUM.MVector (Foo a)
+-- >>> deriving via (Foo a `VU.As` (Int, VU.DoNotUnboxLazy a)) instance VGM.MVector VU.MVector (Foo a)
 -- >>> deriving via (Foo a `VU.As` (Int, VU.DoNotUnboxLazy a)) instance VG.Vector   VU.Vector   (Foo a)
 -- >>> instance VU.Unbox (Foo a)
 -- >>> :}
@@ -960,7 +958,6 @@ instance Unbox (DoNotUnboxLazy a)
 -- >>> :set -XBangPatterns -XTypeFamilies -XStandaloneDeriving -XDerivingVia
 -- >>> :set -XMultiParamTypeClasses -XTypeOperators -XFlexibleInstances
 -- >>> import qualified Data.Vector.Unboxed         as VU
--- >>> import qualified Data.Vector.Unboxed.Mutable as VUM
 -- >>> import qualified Data.Vector.Generic         as VG
 -- >>> import qualified Data.Vector.Generic.Mutable as VGM
 -- >>> :{
@@ -973,7 +970,7 @@ instance Unbox (DoNotUnboxLazy a)
 -- >>>   {-# INLINE fromURepr #-}
 -- >>> newtype instance VU.MVector s (Bar a) = MV_Bar (VU.MVector s (Int, VU.DoNotUnboxStrict a))
 -- >>> newtype instance VU.Vector    (Bar a) = V_Bar  (VU.Vector    (Int, VU.DoNotUnboxStrict a))
--- >>> deriving via (Bar a `VU.As` (Int, VU.DoNotUnboxStrict a)) instance VGM.MVector VUM.MVector (Bar a)
+-- >>> deriving via (Bar a `VU.As` (Int, VU.DoNotUnboxStrict a)) instance VGM.MVector VU.MVector (Bar a)
 -- >>> deriving via (Bar a `VU.As` (Int, VU.DoNotUnboxStrict a)) instance VG.Vector   VU.Vector   (Bar a)
 -- >>> instance VU.Unbox (Bar a)
 -- >>> :}
@@ -1045,7 +1042,6 @@ instance Unbox (DoNotUnboxStrict a)
 -- >>> :set -XTypeFamilies -XStandaloneDeriving -XDerivingVia
 -- >>> :set -XMultiParamTypeClasses -XTypeOperators -XFlexibleInstances
 -- >>> import qualified Data.Vector.Unboxed         as VU
--- >>> import qualified Data.Vector.Unboxed.Mutable as VUM
 -- >>> import qualified Data.Vector.Generic         as VG
 -- >>> import qualified Data.Vector.Generic.Mutable as VGM
 -- >>> import qualified Control.DeepSeq             as NF
@@ -1059,7 +1055,7 @@ instance Unbox (DoNotUnboxStrict a)
 -- >>>   {-# INLINE fromURepr #-}
 -- >>> newtype instance VU.MVector s (Baz a) = MV_Baz (VU.MVector s (Int, VU.DoNotUnboxNormalForm a))
 -- >>> newtype instance VU.Vector    (Baz a) = V_Baz  (VU.Vector    (Int, VU.DoNotUnboxNormalForm a))
--- >>> deriving via (Baz a `VU.As` (Int, VU.DoNotUnboxNormalForm a)) instance NF.NFData a => VGM.MVector VUM.MVector (Baz a)
+-- >>> deriving via (Baz a `VU.As` (Int, VU.DoNotUnboxNormalForm a)) instance NF.NFData a => VGM.MVector VU.MVector (Baz a)
 -- >>> deriving via (Baz a `VU.As` (Int, VU.DoNotUnboxNormalForm a)) instance NF.NFData a => VG.Vector   VU.Vector   (Baz a)
 -- >>> instance NF.NFData a => VU.Unbox (Baz a)
 -- >>> :}

--- a/vector/tests/Main.hs
+++ b/vector/tests/Main.hs
@@ -8,6 +8,7 @@ import qualified Tests.Vector.Strict
 import qualified Tests.Vector.Unboxed
 import qualified Tests.Bundle
 import qualified Tests.Move
+import qualified Tests.Deriving ()
 
 import Test.Tasty (defaultMain,testGroup)
 

--- a/vector/tests/Tests/Deriving.hs
+++ b/vector/tests/Tests/Deriving.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash                  #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UnboxedTuples              #-}
+#if MIN_VERSION_base(4,12,0)
+{-# LANGUAGE DerivingVia                #-}
+#endif
+-- |
+-- These tests make sure that derived Unbox instances actually works.
+-- It's distressingly easy to forget to export some constructor and
+-- make seemingly fine code noncompilable.
+--
+-- We're only interested in checking whether examples compiling.
+-- Doctests aren't reliable in ensuring that!
+module Tests.Deriving () where
+
+import Control.DeepSeq
+import qualified Data.Vector.Generic         as VG
+import qualified Data.Vector.Generic.Mutable as VGM
+import qualified Data.Vector.Storable        as VS
+import qualified Data.Vector.Primitive       as VP
+import qualified Data.Vector.Unboxed         as VU
+
+#if MIN_VERSION_base(4,12,0)
+----------------------------------------------------------------
+-- Primitive 
+
+newtype FooP1 = FooP1 Int deriving VP.Prim
+
+newtype instance VU.MVector s FooP1 = MV_FooP1 (VP.MVector s FooP1)
+newtype instance VU.Vector    FooP1 = V_FooP1  (VP.Vector    FooP1)
+deriving via (VU.UnboxViaPrim FooP1) instance VGM.MVector VU.MVector FooP1
+deriving via (VU.UnboxViaPrim FooP1) instance VG.Vector   VU.Vector  FooP1
+instance VU.Unbox FooP1
+
+
+
+newtype FooP2 = FooP2 Int
+
+newtype instance VU.MVector s FooP2 = MV_FooP2 (VP.MVector s Int)
+newtype instance VU.Vector    FooP2 = V_FooP2  (VP.Vector    Int)
+deriving via (VU.UnboxViaPrim Int) instance VGM.MVector VU.MVector FooP2
+deriving via (VU.UnboxViaPrim Int) instance VG.Vector   VU.Vector  FooP2
+instance VU.Unbox FooP2
+
+
+----------------------------------------------------------------
+-- Storable
+
+newtype FooS1 = FooS1 Int deriving VS.Storable
+
+newtype instance VU.MVector s FooS1 = MV_FooS1 (VS.MVector s FooS1)
+newtype instance VU.Vector    FooS1 = V_FooS1  (VS.Vector    FooS1)
+deriving via (VU.UnboxViaStorable FooS1) instance VGM.MVector VU.MVector FooS1
+deriving via (VU.UnboxViaStorable FooS1) instance VG.Vector   VU.Vector  FooS1
+instance VU.Unbox FooS1
+
+
+newtype FooS2 = FooS2 Int
+
+newtype instance VU.MVector s FooS2 = MV_FooS2 (VS.MVector s Int)
+newtype instance VU.Vector    FooS2 = V_FooS2  (VS.Vector    Int)
+deriving via (VU.UnboxViaStorable Int) instance VGM.MVector VU.MVector FooS2
+deriving via (VU.UnboxViaStorable Int) instance VG.Vector   VU.Vector  FooS2
+instance VU.Unbox FooS2
+
+
+----------------------------------------------------------------
+-- Boxed variants
+
+
+data FooLazy a = FooLazy Int a
+  deriving (Eq, Ord, Show)
+
+instance VU.IsoUnbox (FooLazy a) (Int, VU.DoNotUnboxLazy a) where
+  toURepr (FooLazy i a) = (i, VU.DoNotUnboxLazy a)
+  fromURepr (i, VU.DoNotUnboxLazy a) = FooLazy i a
+  {-# INLINE toURepr #-}
+  {-# INLINE fromURepr #-}
+
+newtype instance VU.MVector s (FooLazy a) = MV_FooLazy (VU.MVector s (Int, VU.DoNotUnboxLazy a))
+newtype instance VU.Vector    (FooLazy a) = V_FooLazy  (VU.Vector    (Int, VU.DoNotUnboxLazy a))
+deriving via (FooLazy a `VU.As` (Int, VU.DoNotUnboxLazy a)) instance VGM.MVector VU.MVector (FooLazy a)
+deriving via (FooLazy a `VU.As` (Int, VU.DoNotUnboxLazy a)) instance VG.Vector   VU.Vector   (FooLazy a)
+instance VU.Unbox (FooLazy a)
+
+
+
+data FooStrict a = FooStrict Int a
+  deriving (Eq, Ord, Show)
+
+instance VU.IsoUnbox (FooStrict a) (Int, VU.DoNotUnboxStrict a) where
+  toURepr (FooStrict i a) = (i, VU.DoNotUnboxStrict a)
+  fromURepr (i, VU.DoNotUnboxStrict a) = FooStrict i a
+  {-# INLINE toURepr #-}
+  {-# INLINE fromURepr #-}
+
+newtype instance VU.MVector s (FooStrict a) = MV_FooStrict (VU.MVector s (Int, VU.DoNotUnboxStrict a))
+newtype instance VU.Vector    (FooStrict a) = V_FooStrict  (VU.Vector    (Int, VU.DoNotUnboxStrict a))
+deriving via (FooStrict a `VU.As` (Int, VU.DoNotUnboxStrict a)) instance VGM.MVector VU.MVector (FooStrict a)
+deriving via (FooStrict a `VU.As` (Int, VU.DoNotUnboxStrict a)) instance VG.Vector   VU.Vector   (FooStrict a)
+instance VU.Unbox (FooStrict a)
+
+
+data FooNormalForm a = FooNormalForm Int a
+  deriving (Eq, Ord, Show)
+
+instance VU.IsoUnbox (FooNormalForm a) (Int, VU.DoNotUnboxNormalForm a) where
+  toURepr (FooNormalForm i a) = (i, VU.DoNotUnboxNormalForm a)
+  fromURepr (i, VU.DoNotUnboxNormalForm a) = FooNormalForm i a
+  {-# INLINE toURepr #-}
+  {-# INLINE fromURepr #-}
+
+newtype instance VU.MVector s (FooNormalForm a) = MV_FooNormalForm (VU.MVector s (Int, VU.DoNotUnboxNormalForm a))
+newtype instance VU.Vector    (FooNormalForm a) = V_FooNormalForm  (VU.Vector    (Int, VU.DoNotUnboxNormalForm a))
+deriving via (FooNormalForm a `VU.As` (Int, VU.DoNotUnboxNormalForm a))
+    instance NFData a => VGM.MVector VU.MVector (FooNormalForm a)
+deriving via (FooNormalForm a `VU.As` (Int, VU.DoNotUnboxNormalForm a))
+    instance NFData a => VG.Vector VU.Vector (FooNormalForm a)
+instance NFData a => VU.Unbox (FooNormalForm a)
+
+
+
+----------------------------------------------------------------
+-- Unboxed
+
+
+data FooAs a = FooAs Int a
+  deriving Show
+
+instance VU.IsoUnbox (FooAs a) (Int,a) where
+  toURepr (FooAs i a) = (i,a)
+  fromURepr (i,a) = FooAs i a
+  {-# INLINE toURepr #-}
+  {-# INLINE fromURepr #-}
+
+newtype instance VU.MVector s (FooAs a) = MV_FooAs (VU.MVector s (Int, a))
+newtype instance VU.Vector    (FooAs a) = V_FooAs  (VU.Vector    (Int, a))
+deriving via (FooAs a `VU.As` (Int, a)) instance VU.Unbox a => VGM.MVector VU.MVector (FooAs a)
+deriving via (FooAs a `VU.As` (Int, a)) instance VU.Unbox a => VG.Vector   VU.Vector   (FooAs a)
+instance VU.Unbox a => VU.Unbox (FooAs a)
+
+#endif

--- a/vector/tests/Tests/Deriving.hs
+++ b/vector/tests/Tests/Deriving.hs
@@ -25,6 +25,8 @@ module Tests.Deriving () where
 import Control.DeepSeq
 import qualified Data.Vector.Generic         as VG
 import qualified Data.Vector.Generic.Mutable as VGM
+import qualified Data.Vector                 as V
+import qualified Data.Vector.Strict          as VV
 import qualified Data.Vector.Storable        as VS
 import qualified Data.Vector.Primitive       as VP
 import qualified Data.Vector.Unboxed         as VU
@@ -127,6 +129,39 @@ deriving via (FooNormalForm a `VU.As` (Int, VU.DoNotUnboxNormalForm a))
     instance NFData a => VG.Vector VU.Vector (FooNormalForm a)
 instance NFData a => VU.Unbox (FooNormalForm a)
 
+
+
+data BoxedLazy = BoxedLazy Int
+  deriving (Eq, Ord, Show)
+
+newtype instance VU.MVector s BoxedLazy = MV_BoxedLazy (V.MVector s BoxedLazy)
+newtype instance VU.Vector    BoxedLazy = V_BoxedLazy  (V.Vector    BoxedLazy)
+deriving via (VU.DoNotUnboxLazy BoxedLazy) instance VGM.MVector VU.MVector BoxedLazy
+deriving via (VU.DoNotUnboxLazy BoxedLazy) instance VG.Vector   VU.Vector  BoxedLazy
+instance VU.Unbox BoxedLazy
+
+
+data BoxedStrict = BoxedStrict Int
+  deriving (Eq, Ord, Show)
+
+newtype instance VU.MVector s BoxedStrict = MV_BoxedStrict (VV.MVector s BoxedStrict)
+newtype instance VU.Vector    BoxedStrict = V_BoxedStrict  (VV.Vector    BoxedStrict)
+deriving via (VU.DoNotUnboxStrict BoxedStrict) instance VGM.MVector VU.MVector BoxedStrict
+deriving via (VU.DoNotUnboxStrict BoxedStrict) instance VG.Vector   VU.Vector  BoxedStrict
+instance VU.Unbox BoxedStrict
+
+
+data BoxedNormalForm = BoxedNormalForm Int
+  deriving (Eq, Ord, Show)
+
+instance NFData BoxedNormalForm where
+  rnf (BoxedNormalForm i) = rnf i
+
+newtype instance VU.MVector s BoxedNormalForm = MV_BoxedNormalForm (VV.MVector s BoxedNormalForm)
+newtype instance VU.Vector    BoxedNormalForm = V_BoxedNormalForm  (VV.Vector    BoxedNormalForm)
+deriving via (VU.DoNotUnboxNormalForm BoxedNormalForm) instance VGM.MVector VU.MVector BoxedNormalForm
+deriving via (VU.DoNotUnboxNormalForm BoxedNormalForm) instance VG.Vector   VU.Vector  BoxedNormalForm
+instance VU.Unbox BoxedNormalForm
 
 
 ----------------------------------------------------------------

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -188,6 +188,7 @@ common tests-common
                , template-haskell
                , base-orphans >= 0.6
                , vector
+               , deepseq
                , primitive
                , random
                , QuickCheck >= 2.9 && < 2.16
@@ -206,6 +207,7 @@ common tests-common
     Tests.Vector.Primitive
     Tests.Vector.Unboxed
     Tests.Vector.UnitTests
+    Tests.Deriving
     Utilities
 
   default-extensions:


### PR DESCRIPTION
This is a follow up for the `DoNotUnbox*` family of newtype `DerivingVia` wrappers (#508). It allows treating `Storable` vectors as unboxed vectors. My personal use case is combining parallel arrays received from C FFI into a single `Vector`. I left [a comment](https://github.com/haskell/vector/issues/503#issuecomment-2389978679) about this in #503, and did not get a response, but I still think this is a nice thing to have in `vector`.

I followed the implementation for `UnboxViaPrim` and named this new wrapper `UnboxViaStorable`. While working on this PR, I noticed that the documentation for `UnboxViaPrim` named the vector for `Foo` `[M]V_Int` instead of `[M]V_Foo`, so I also corrected them.

As a minor detail, the previous PR imports `Data.Vector.Strict` qualified as `S`, so I cannot use `S` for `Storable` and had to use `St`. I can change it if there is a preferred naming scheme for qualified imports.