### PR TITLE
Implement Applicative based API 

### DIFF
--- a/vector-bench-papi/benchmarks/Main.hs
+++ b/vector-bench-papi/benchmarks/Main.hs
@@ -12,6 +12,8 @@ import Bench.Vector.Algo.Spectral   (spectral)
 import Bench.Vector.Algo.Tridiag    (tridiag)
 import Bench.Vector.Algo.FindIndexR (findIndexR, findIndexR_naive, findIndexR_manual)
 import Bench.Vector.Algo.NextPermutation (generatePermTests)
+import Bench.Vector.Algo.Applicative ( generateState, generateStateUnfold, generateIO, generateIOPrim
+                                     , lensSum, lensMap, baselineSum, baselineMap)
 
 import Bench.Vector.TestData.ParenTree (parenTree)
 import Bench.Vector.TestData.Graph     (randomGraph)
@@ -68,4 +70,14 @@ main = do
     , bench "minimumOn"  $ whnf (U.minimumOn (\x -> x*x*x)) as
     , bench "maximumOn"  $ whnf (U.maximumOn (\x -> x*x*x)) as
     , bgroup "(next|prev)Permutation" $ map (\(name, act) -> bench name $ whnfIO act) permTests
+    , bgroup "Applicative"
+      [ bench "generateState"       $ whnf generateState useSize
+      , bench "generateStateUnfold" $ whnf generateStateUnfold useSize
+      , bench "generateIO"     $ whnfIO (generateIO useSize)
+      , bench "generateIOPrim" $ whnfIO (generateIOPrim useSize)
+      , bench "sum[lens]"      $ whnf lensSum as
+      , bench "sum[base]"      $ whnf baselineSum as
+      , bench "map[lens]"      $ whnf lensMap as
+      , bench "map[base]"      $ whnf baselineMap as
+      ]
     ]

--- a/vector/benchlib/Bench/Vector/Algo/Applicative.hs
+++ b/vector/benchlib/Bench/Vector/Algo/Applicative.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- |
+-- This module provides benchmarks for functions which use API based
+-- on applicative. We use @generateA@ based benchmark for state and IO
+-- and also benchmark folds and mapping using lens since it's one of
+-- important consumers of this API.
+module Bench.Vector.Algo.Applicative
+  ( -- * Standard benchmarks
+    generateState
+  , generateStateUnfold
+  , generateIO
+  , generateIOPrim
+    -- * Lens benchmarks
+  , lensSum
+  , baselineSum
+  , lensMap
+  , baselineMap
+  ) where
+
+import Control.Applicative
+import Data.Coerce
+import Data.Functor.Identity
+import Data.Int
+import Data.Monoid
+import Data.Word
+import qualified Data.Vector.Generic as VG
+import qualified Data.Vector.Generic.Mutable as MVG
+import qualified Data.Vector.Unboxed as VU
+import System.Random.Stateful
+import System.Mem (getAllocationCounter)
+
+-- | Benchmark which is running in state monad.
+generateState :: Int -> VU.Vector Word64
+generateState n
+  = runStateGen_ (mkStdGen 42)
+  $ \g -> VG.generateA n (\_ -> uniformM g)
+
+-- | Benchmark which is running in state monad.
+generateStateUnfold :: Int -> VU.Vector Word64
+generateStateUnfold n = VU.unfoldrExactN n genWord64 (mkStdGen 42) 
+
+-- | Benchmark for running @generateA@ in IO monad.
+generateIO :: Int -> IO (VU.Vector Int64)
+generateIO n = VG.generateA n (\_ -> getAllocationCounter)
+
+-- | Baseline for 'generateIO' it uses primitive operations
+generateIOPrim :: Int -> IO (VU.Vector Int64)
+generateIOPrim n = VG.unsafeFreeze =<< MVG.replicateM n getAllocationCounter
+
+-- | Sum using lens
+lensSum :: VU.Vector Double -> Double
+{-# NOINLINE lensSum #-}
+lensSum = foldlOf' VG.traverse (+) 0 
+
+-- | Baseline for sum.
+baselineSum :: VU.Vector Double -> Double
+{-# NOINLINE baselineSum #-}
+baselineSum = VU.sum
+
+-- | Mapping over vector elements using 
+lensMap :: VU.Vector Double -> VU.Vector Double
+{-# NOINLINE lensMap #-}
+lensMap = over VG.traverse (*2)
+
+-- | Baseline for map
+baselineMap :: VU.Vector Double -> VU.Vector Double
+{-# NOINLINE baselineMap #-}
+baselineMap = VU.map (*2)
+
+----------------------------------------------------------------
+-- Bits and pieces of lens
+--
+-- We don't want to depend on lens so we just copy relevant
+-- parts. After all we don't need much
+----------------------------------------------------------------
+
+type ASetter s t a b = (a -> Identity b) -> s -> Identity t
+type Getting r s a = (a -> Const r a) -> s -> Const r s
+
+foldlOf' :: Getting (Endo (Endo r)) s a -> (r -> a -> r) -> r -> s -> r
+foldlOf' l f z0 = \xs ->
+  let f' x (Endo k) = Endo $ \z -> k $! f z x
+  in foldrOf l f' (Endo id) xs `appEndo` z0
+{-# INLINE foldlOf' #-}
+
+foldrOf :: Getting (Endo r) s a -> (a -> r -> r) -> r -> s -> r
+foldrOf l f z = flip appEndo z . foldMapOf l (Endo #. f)
+{-# INLINE foldrOf #-}
+
+foldMapOf :: Getting r s a -> (a -> r) -> s -> r
+foldMapOf = coerce
+{-# INLINE foldMapOf #-}
+
+( #. ) :: Coercible c b => (b -> c) -> (a -> b) -> (a -> c)
+( #. ) _ = coerce (\x -> x :: b) :: forall a b. Coercible b a => a -> b
+{-# INLINE (#.) #-}
+
+over :: ASetter s t a b -> (a -> b) -> s -> t
+over = coerce
+{-# INLINE over #-}

--- a/vector/benchmarks/Main.hs
+++ b/vector/benchmarks/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
+
 import Bench.Vector.Algo.MutableSet      (mutableSet)
 import Bench.Vector.Algo.ListRank        (listRank)
 import Bench.Vector.Algo.Rootfix         (rootfix)
@@ -12,6 +13,8 @@ import Bench.Vector.Algo.Spectral        (spectral)
 import Bench.Vector.Algo.Tridiag         (tridiag)
 import Bench.Vector.Algo.FindIndexR      (findIndexR, findIndexR_naive, findIndexR_manual)
 import Bench.Vector.Algo.NextPermutation (generatePermTests)
+import Bench.Vector.Algo.Applicative ( generateState, generateStateUnfold, generateIO, generateIOPrim
+                                     , lensSum, lensMap, baselineSum, baselineMap)
 
 import Bench.Vector.TestData.ParenTree (parenTree)
 import Bench.Vector.TestData.Graph     (randomGraph)
@@ -69,4 +72,14 @@ main = do
     , bench "minimumOn"  $ whnf (U.minimumOn (\x -> x*x*x)) as
     , bench "maximumOn"  $ whnf (U.maximumOn (\x -> x*x*x)) as
     , bgroup "(next|prev)Permutation" $ map (\(name, act) -> bench name $ whnfIO act) permTests
+    , bgroup "Applicative"
+      [ bench "generateState"       $ whnf generateState useSize
+      , bench "generateStateUnfold" $ whnf generateStateUnfold useSize
+      , bench "generateIO"     $ whnfIO (generateIO useSize)
+      , bench "generateIOPrim" $ whnfIO (generateIOPrim useSize)
+      , bench "sum[lens]"      $ whnf lensSum as
+      , bench "sum[base]"      $ whnf baselineSum as
+      , bench "map[lens]"      $ whnf lensMap as
+      , bench "map[base]"      $ whnf baselineMap as
+      ]
     ]

--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -1,3 +1,11 @@
+# Changes in version NEXT_VERSION
+
+ * [#522](https://github.com/haskell/vector/pull/522) API using Applicatives
+   added: `traverse` & friends.
+   * [#518](https://github.com/haskell/vector/pull/518) `UnboxViaStorable` added.
+   Vector constructors are reexported for `DoNotUnbox*`.
+ * [#531](https://github.com/haskell/vector/pull/531) `iconcatMap` added.
+
 # Changes in version 0.13.2.0
 
  * Strict boxed vector `Data.Vector.Strict` and `Data.Vector.Strict.Mutable` is

--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -458,12 +458,7 @@ instance Foldable.Foldable Vector where
 
 instance Traversable.Traversable Vector where
   {-# INLINE traverse #-}
-  traverse f xs =
-      -- Get the length of the vector in /O(1)/ time
-      let !n = G.length xs
-      -- Use fromListN to be more efficient in construction of resulting vector
-      -- Also behaves better with compact regions, preventing runtime exceptions
-      in  Data.Vector.fromListN n Applicative.<$> Traversable.traverse f (toList xs)
+  traverse = traverse
 
   {-# INLINE mapM #-}
   mapM = mapM

--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -156,6 +156,10 @@ module Data.Vector (
   scanr, scanr', scanr1, scanr1',
   iscanr, iscanr',
 
+  -- * Applicative API
+  replicateA, generateA, traverse, itraverse, forA, iforA,
+  traverse_, itraverse_, forA_, iforA_,
+
   -- ** Comparisons
   eqBy, cmpBy,
 
@@ -174,6 +178,7 @@ module Data.Vector (
   freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy
 ) where
 
+import Control.Applicative (Applicative)
 import Data.Vector.Mutable  ( MVector(..) )
 import Data.Primitive.Array
 import qualified Data.Vector.Fusion.Bundle as Bundle
@@ -2204,6 +2209,97 @@ fromList = G.fromList
 fromListN :: Int -> [a] -> Vector a
 {-# INLINE fromListN #-}
 fromListN = G.fromListN
+
+-- Applicative
+-- -----------
+
+-- | Construct a vector of the given length by applying the applicative
+-- action to each index.
+--
+-- @since NEXT_VERSION
+generateA :: (Applicative f) => Int -> (Int -> f a) -> f (Vector a)
+generateA = G.generateA
+
+-- | Execute the applicative action the given number of times and store the
+-- results in a vector.
+--
+-- @since NEXT_VERSION
+replicateA :: (Applicative f) => Int -> f a -> f (Vector a)
+{-# INLINE replicateA #-}
+replicateA = G.replicateA
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results.
+--
+-- @since NEXT_VERSION
+traverse :: (Applicative f)
+         => (a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE traverse #-}
+traverse = G.traverse
+
+-- | Apply the applicative action to every element of a vector and its
+-- index, yielding a vector of results.
+--
+-- @since NEXT_VERSION
+itraverse :: (Applicative f)
+          => (Int -> a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE itraverse #-}
+itraverse = G.itraverse
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results. This is flipped version of 'traverse'.
+--
+-- @since NEXT_VERSION
+forA :: (Applicative f)
+     => Vector a -> (a -> f b) -> f (Vector b)
+{-# INLINE forA #-}
+forA = G.forA
+
+-- | Apply the applicative action to every element of a vector and its
+--   index, yielding a vector of results. This is flipped version of 'itraverse'.
+--
+-- @since NEXT_VERSION
+iforA :: (Applicative f)
+      => Vector a -> (Int -> a -> f b) -> f (Vector b)
+{-# INLINE iforA #-}
+iforA = G.iforA
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+traverse_ :: (Applicative f)
+          => (a -> f b) -> Vector a -> f ()
+{-# INLINE traverse_ #-}
+traverse_ = G.traverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+itraverse_ :: (Applicative f)
+           => (Int -> a -> f b) -> Vector a -> f ()
+{-# INLINE itraverse_ #-}
+itraverse_ = G.itraverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+forA_ :: (Applicative f)
+      => Vector a -> (a -> f b) -> f ()
+{-# INLINE forA_ #-}
+forA_ = G.forA_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+iforA_ :: (Applicative f)
+      => Vector a -> (Int -> a -> f b) -> f ()
+{-# INLINE iforA_ #-}
+iforA_ = G.iforA_
+
 
 -- Conversions - Arrays
 -- -----------------------------

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -2678,6 +2678,8 @@ runSTA !sz = \(STA fun) -> runST $ do
 
 -- | Construct a vector of the given length by applying the applicative
 -- action to each index.
+--
+-- @since NEXT_VERSION
 generateA :: (Applicative f, Vector v a) => Int -> (Int -> f a) -> f (v a)
 {-# INLINE[1] generateA #-}
 generateA 0 _ = pure empty
@@ -2700,6 +2702,8 @@ generateA_ST :: (Vector v a) => Int -> (Int -> ST s a) -> ST s (v a)
 {-# INLINE generateA_ST #-}
 generateA_ST = unsafeGeneratePrim
 
+-- Identity is used in lest for mapping over structures. So it's
+-- relatively important case.
 generateA_Identity :: (Vector v a) => Int -> (Int -> Identity a) -> Identity (v a)
 {-# INLINE generateA_Identity #-}
 generateA_Identity n f = Identity (generate n (runIdentity . f))
@@ -2715,12 +2719,16 @@ generateA_Identity n f = Identity (generate n (runIdentity . f))
 
 -- | Execute the applicative action the given number of times and store the
 -- results in a vector.
+--
+-- @since NEXT_VERSION
 replicateA :: (Applicative f, Vector v a) => Int -> f a -> f (v a)
 {-# INLINE replicateA #-}
 replicateA n f = generateA n (\_ -> f)
 
 -- | Apply the applicative action to all elements of the vector, yielding a
 -- vector of results.
+--
+-- @since NEXT_VERSION
 traverse :: (Applicative f, Vector v a, Vector v b)
          => (a -> f b) -> v a -> f (v b)
 {-# INLINE traverse #-}
@@ -2728,6 +2736,8 @@ traverse f v = generateA (length v) $ \i -> f (unsafeIndex v i)
 
 -- | Apply the applicative action to every element of a vector and its
 -- index, yielding a vector of results.
+--
+-- @since NEXT_VERSION
 itraverse :: (Applicative f, Vector v a, Vector v b)
           => (Int -> a -> f b) -> v a -> f (v b)
 {-# INLINE itraverse #-}
@@ -2735,6 +2745,8 @@ itraverse f v = generateA (length v) $ \i -> f i (unsafeIndex v i)
 
 -- | Apply the applicative action to all elements of the vector, yielding a
 -- vector of results. This is flipped version of 'traverse'.
+--
+-- @since NEXT_VERSION
 forA :: (Applicative f, Vector v a, Vector v b)
      => v a -> (a -> f b) -> f (v b)
 {-# INLINE forA #-}
@@ -2742,6 +2754,8 @@ forA v f = generateA (length v) $ \i -> f (unsafeIndex v i)
 
 -- | Apply the applicative action to every element of a vector and its
 --   index, yielding a vector of results. This is flipped version of 'itraverse'.
+--
+-- @since NEXT_VERSION
 iforA :: (Applicative f, Vector v a, Vector v b)
       => v a -> (Int -> a -> f b) -> f (v b)
 {-# INLINE iforA #-}
@@ -2749,6 +2763,8 @@ iforA v f = generateA (length v) $ \i -> f i (unsafeIndex v i)
 
 -- | Map each element of a structure to an 'Applicative' action, evaluate these
 --   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
 traverse_ :: (Applicative f, Vector v a)
           => (a -> f b) -> v a -> f ()
 {-# INLINE traverse_ #-}
@@ -2757,6 +2773,8 @@ traverse_ f = foldr step (pure ())
 
 -- | Map each element of a structure to an 'Applicative' action, evaluate these
 --   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
 itraverse_ :: (Applicative f, Vector v a)
            => (Int -> a -> f b) -> v a -> f ()
 {-# INLINE itraverse_ #-}
@@ -2765,6 +2783,8 @@ itraverse_ f = ifoldr step (pure ())
 
 -- | Map each element of a structure to an 'Applicative' action, evaluate these
 --   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
 forA_ :: (Applicative f, Vector v a)
       => v a -> (a -> f b) -> f ()
 {-# INLINE forA_ #-}
@@ -2772,6 +2792,8 @@ forA_ = flip traverse_
 
 -- | Map each element of a structure to an 'Applicative' action, evaluate these
 --   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
 iforA_ :: (Applicative f, Vector v a)
       => v a -> (Int -> a -> f b) -> f ()
 {-# INLINE iforA_ #-}

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -2715,41 +2715,41 @@ generateA_Identity n f = Identity (generate n (runIdentity . f))
 
 -- | Execute the applicative action the given number of times and store the
 -- results in a vector.
-replicateA :: (Vector v a, Applicative f) => Int -> f a -> f (v a)
+replicateA :: (Applicative f, Vector v a) => Int -> f a -> f (v a)
 {-# INLINE replicateA #-}
 replicateA n f = generateA n (\_ -> f)
 
 -- | Apply the applicative action to all elements of the vector, yielding a
 -- vector of results.
-traverse :: (Vector v a, Vector v b, Applicative f)
+traverse :: (Applicative f, Vector v a, Vector v b)
          => (a -> f b) -> v a -> f (v b)
 {-# INLINE traverse #-}
 traverse f v = generateA (length v) $ \i -> f (unsafeIndex v i)
 
 -- | Apply the applicative action to every element of a vector and its
 -- index, yielding a vector of results.
-itraverse :: (Vector v a, Vector v b, Applicative f)
+itraverse :: (Applicative f, Vector v a, Vector v b)
           => (Int -> a -> f b) -> v a -> f (v b)
 {-# INLINE itraverse #-}
 itraverse f v = generateA (length v) $ \i -> f i (unsafeIndex v i)
 
 -- | Apply the applicative action to all elements of the vector, yielding a
 -- vector of results. This is flipped version of 'traverse'.
-forA :: (Vector v a, Vector v b, Applicative f)
+forA :: (Applicative f, Vector v a, Vector v b)
      => v a -> (a -> f b) -> f (v b)
 {-# INLINE forA #-}
 forA v f = generateA (length v) $ \i -> f (unsafeIndex v i)
 
 -- | Apply the applicative action to every element of a vector and its
 --   index, yielding a vector of results. This is flipped version of 'itraverse'.
-iforA :: (Vector v a, Vector v b, Applicative f)
+iforA :: (Applicative f, Vector v a, Vector v b)
       => v a -> (Int -> a -> f b) -> f (v b)
 {-# INLINE iforA #-}
 iforA v f = generateA (length v) $ \i -> f i (unsafeIndex v i)
 
 -- | Map each element of a structure to an 'Applicative' action, evaluate these
 --   actions from left to right, and ignore the results.
-traverse_ :: (Vector v a, Applicative f)
+traverse_ :: (Applicative f, Vector v a)
           => (a -> f b) -> v a -> f ()
 {-# INLINE traverse_ #-}
 traverse_ f = foldr step (pure ())
@@ -2757,7 +2757,7 @@ traverse_ f = foldr step (pure ())
 
 -- | Map each element of a structure to an 'Applicative' action, evaluate these
 --   actions from left to right, and ignore the results.
-itraverse_ :: (Vector v a, Applicative f)
+itraverse_ :: (Applicative f, Vector v a)
            => (Int -> a -> f b) -> v a -> f ()
 {-# INLINE itraverse_ #-}
 itraverse_ f = ifoldr step (pure ())
@@ -2765,14 +2765,14 @@ itraverse_ f = ifoldr step (pure ())
 
 -- | Map each element of a structure to an 'Applicative' action, evaluate these
 --   actions from left to right, and ignore the results.
-forA_ :: (Vector v a, Applicative f)
+forA_ :: (Applicative f, Vector v a)
       => v a -> (a -> f b) -> f ()
 {-# INLINE forA_ #-}
 forA_ = flip traverse_
 
 -- | Map each element of a structure to an 'Applicative' action, evaluate these
 --   actions from left to right, and ignore the results.
-iforA_ :: (Vector v a, Applicative f)
+iforA_ :: (Applicative f, Vector v a)
       => v a -> (Int -> a -> f b) -> f ()
 {-# INLINE iforA_ #-}
 iforA_ = flip itraverse_

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -2682,8 +2682,9 @@ runSTA !sz = \(STA fun) -> runST $ do
 -- @since NEXT_VERSION
 generateA :: (Applicative f, Vector v a) => Int -> (Int -> f a) -> f (v a)
 {-# INLINE[1] generateA #-}
-generateA 0 _ = pure empty
-generateA n f = runSTA n <$> go 0
+generateA n f
+  | n <= 0    = pure empty
+  | otherwise = runSTA n <$> go 0
   where
     go !i | i >= n    = pure $ STA $ \_ -> pure ()
           | otherwise =  (\a (STA m) -> STA $ \mv -> M.unsafeWrite mv i a >> m mv)

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -2679,7 +2679,7 @@ replicateA :: (Vector v a, Applicative f) => Int -> f a -> f (v a)
 replicateA n f = generateA n (\_ -> f)
 
 
--- | Construct a vector of the given length by applying the monadic
+-- | Construct a vector of the given length by applying the applicative
 -- action to each index.
 generateA :: (Vector v a, Applicative f) => Int -> (Int -> f a) -> f (v a)
 {-# INLINE generateA #-}

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -138,6 +138,10 @@ module Data.Vector.Primitive (
   scanr, scanr', scanr1, scanr1',
   iscanr, iscanr',
 
+  -- * Applicative API
+  replicateA, generateA, traverse, itraverse, forA, iforA,
+  traverse_, itraverse_, forA_, iforA_,
+
   -- ** Comparisons
   eqBy, cmpBy,
 
@@ -157,6 +161,7 @@ module Data.Vector.Primitive (
   Prim
 ) where
 
+import           Control.Applicative (Applicative)
 import qualified Data.Vector.Generic           as G
 import           Data.Vector.Primitive.Mutable ( MVector(..) )
 import           Data.Vector.Internal.Check
@@ -1874,6 +1879,98 @@ fromList = G.fromList
 fromListN :: Prim a => Int -> [a] -> Vector a
 {-# INLINE fromListN #-}
 fromListN = G.fromListN
+
+
+-- Applicative
+-- -----------
+
+-- | Construct a vector of the given length by applying the applicative
+-- action to each index.
+--
+-- @since NEXT_VERSION
+generateA :: (Applicative f, Prim a) => Int -> (Int -> f a) -> f (Vector a)
+generateA = G.generateA
+
+-- | Execute the applicative action the given number of times and store the
+-- results in a vector.
+--
+-- @since NEXT_VERSION
+replicateA :: (Applicative f, Prim a) => Int -> f a -> f (Vector a)
+{-# INLINE replicateA #-}
+replicateA = G.replicateA
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results.
+--
+-- @since NEXT_VERSION
+traverse :: (Applicative f, Prim a, Prim b)
+         => (a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE traverse #-}
+traverse = G.traverse
+
+-- | Apply the applicative action to every element of a vector and its
+-- index, yielding a vector of results.
+--
+-- @since NEXT_VERSION
+itraverse :: (Applicative f, Prim a, Prim b)
+          => (Int -> a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE itraverse #-}
+itraverse = G.itraverse
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results. This is flipped version of 'traverse'.
+--
+-- @since NEXT_VERSION
+forA :: (Applicative f, Prim a, Prim b)
+     => Vector a -> (a -> f b) -> f (Vector b)
+{-# INLINE forA #-}
+forA = G.forA
+
+-- | Apply the applicative action to every element of a vector and its
+--   index, yielding a vector of results. This is flipped version of 'itraverse'.
+--
+-- @since NEXT_VERSION
+iforA :: (Applicative f, Prim a, Prim b)
+      => Vector a -> (Int -> a -> f b) -> f (Vector b)
+{-# INLINE iforA #-}
+iforA = G.iforA
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+traverse_ :: (Applicative f, Prim a)
+          => (a -> f b) -> Vector a -> f ()
+{-# INLINE traverse_ #-}
+traverse_ = G.traverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+itraverse_ :: (Applicative f, Prim a)
+           => (Int -> a -> f b) -> Vector a -> f ()
+{-# INLINE itraverse_ #-}
+itraverse_ = G.itraverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+forA_ :: (Applicative f, Prim a)
+      => Vector a -> (a -> f b) -> f ()
+{-# INLINE forA_ #-}
+forA_ = G.forA_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+iforA_ :: (Applicative f, Prim a)
+      => Vector a -> (Int -> a -> f b) -> f ()
+{-# INLINE iforA_ #-}
+iforA_ = G.iforA_
+
 
 -- Conversions - Unsafe casts
 -- --------------------------

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -135,6 +135,10 @@ module Data.Vector.Storable (
   scanr, scanr', scanr1, scanr1',
   iscanr, iscanr',
 
+  -- * Applicative API
+  replicateA, generateA, traverse, itraverse, forA, iforA,
+  traverse_, itraverse_, forA_, iforA_,
+
   -- ** Comparisons
   eqBy, cmpBy,
 
@@ -163,6 +167,7 @@ module Data.Vector.Storable (
   Storable
 ) where
 
+import           Control.Applicative (Applicative)
 import qualified Data.Vector.Generic          as G
 import           Data.Vector.Storable.Mutable ( MVector(..) )
 import Data.Vector.Storable.Internal
@@ -1920,6 +1925,98 @@ fromList = G.fromList
 fromListN :: Storable a => Int -> [a] -> Vector a
 {-# INLINE fromListN #-}
 fromListN = G.fromListN
+
+
+-- Applicative
+-- -----------
+
+-- | Construct a vector of the given length by applying the applicative
+-- action to each index.
+--
+-- @since NEXT_VERSION
+generateA :: (Applicative f, Storable a) => Int -> (Int -> f a) -> f (Vector a)
+generateA = G.generateA
+
+-- | Execute the applicative action the given number of times and store the
+-- results in a vector.
+--
+-- @since NEXT_VERSION
+replicateA :: (Applicative f, Storable a) => Int -> f a -> f (Vector a)
+{-# INLINE replicateA #-}
+replicateA = G.replicateA
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results.
+--
+-- @since NEXT_VERSION
+traverse :: (Applicative f, Storable a, Storable b)
+         => (a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE traverse #-}
+traverse = G.traverse
+
+-- | Apply the applicative action to every element of a vector and its
+-- index, yielding a vector of results.
+--
+-- @since NEXT_VERSION
+itraverse :: (Applicative f, Storable a, Storable b)
+          => (Int -> a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE itraverse #-}
+itraverse = G.itraverse
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results. This is flipped version of 'traverse'.
+--
+-- @since NEXT_VERSION
+forA :: (Applicative f, Storable a, Storable b)
+     => Vector a -> (a -> f b) -> f (Vector b)
+{-# INLINE forA #-}
+forA = G.forA
+
+-- | Apply the applicative action to every element of a vector and its
+--   index, yielding a vector of results. This is flipped version of 'itraverse'.
+--
+-- @since NEXT_VERSION
+iforA :: (Applicative f, Storable a, Storable b)
+      => Vector a -> (Int -> a -> f b) -> f (Vector b)
+{-# INLINE iforA #-}
+iforA = G.iforA
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+traverse_ :: (Applicative f, Storable a)
+          => (a -> f b) -> Vector a -> f ()
+{-# INLINE traverse_ #-}
+traverse_ = G.traverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+itraverse_ :: (Applicative f, Storable a)
+           => (Int -> a -> f b) -> Vector a -> f ()
+{-# INLINE itraverse_ #-}
+itraverse_ = G.itraverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+forA_ :: (Applicative f, Storable a)
+      => Vector a -> (a -> f b) -> f ()
+{-# INLINE forA_ #-}
+forA_ = G.forA_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+iforA_ :: (Applicative f, Storable a)
+      => Vector a -> (Int -> a -> f b) -> f ()
+{-# INLINE iforA_ #-}
+iforA_ = G.iforA_
+
 
 -- Conversions - Unsafe casts
 -- --------------------------

--- a/vector/src/Data/Vector/Strict.hs
+++ b/vector/src/Data/Vector/Strict.hs
@@ -402,12 +402,7 @@ instance Applicative.Alternative Vector where
 
 instance Traversable.Traversable Vector where
   {-# INLINE traverse #-}
-  traverse f xs =
-      -- Get the length of the vector in /O(1)/ time
-      let !n = G.length xs
-      -- Use fromListN to be more efficient in construction of resulting vector
-      -- Also behaves better with compact regions, preventing runtime exceptions
-      in  Data.Vector.Strict.fromListN n Applicative.<$> Traversable.traverse f (toList xs)
+  traverse = traverse
 
   {-# INLINE mapM #-}
   mapM = mapM

--- a/vector/src/Data/Vector/Strict.hs
+++ b/vector/src/Data/Vector/Strict.hs
@@ -154,6 +154,10 @@ module Data.Vector.Strict (
   scanr, scanr', scanr1, scanr1',
   iscanr, iscanr',
 
+  -- * Applicative API
+  replicateA, generateA, traverse, itraverse, forA, iforA,
+  traverse_, itraverse_, forA_, iforA_,
+
   -- ** Comparisons
   eqBy, cmpBy,
 
@@ -173,6 +177,7 @@ module Data.Vector.Strict (
   freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy
 ) where
 
+import Control.Applicative (Applicative)
 import Data.Coerce
 import Data.Vector.Strict.Mutable  ( MVector(..) )
 import Data.Primitive.Array
@@ -2476,6 +2481,97 @@ fromList = G.fromList
 fromListN :: Int -> [a] -> Vector a
 {-# INLINE fromListN #-}
 fromListN = G.fromListN
+
+-- Applicative
+-- -----------
+
+-- | Construct a vector of the given length by applying the applicative
+-- action to each index.
+--
+-- @since NEXT_VERSION
+generateA :: (Applicative f) => Int -> (Int -> f a) -> f (Vector a)
+generateA = G.generateA
+
+-- | Execute the applicative action the given number of times and store the
+-- results in a vector.
+--
+-- @since NEXT_VERSION
+replicateA :: (Applicative f) => Int -> f a -> f (Vector a)
+{-# INLINE replicateA #-}
+replicateA = G.replicateA
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results.
+--
+-- @since NEXT_VERSION
+traverse :: (Applicative f)
+         => (a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE traverse #-}
+traverse = G.traverse
+
+-- | Apply the applicative action to every element of a vector and its
+-- index, yielding a vector of results.
+--
+-- @since NEXT_VERSION
+itraverse :: (Applicative f)
+          => (Int -> a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE itraverse #-}
+itraverse = G.itraverse
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results. This is flipped version of 'traverse'.
+--
+-- @since NEXT_VERSION
+forA :: (Applicative f)
+     => Vector a -> (a -> f b) -> f (Vector b)
+{-# INLINE forA #-}
+forA = G.forA
+
+-- | Apply the applicative action to every element of a vector and its
+--   index, yielding a vector of results. This is flipped version of 'itraverse'.
+--
+-- @since NEXT_VERSION
+iforA :: (Applicative f)
+      => Vector a -> (Int -> a -> f b) -> f (Vector b)
+{-# INLINE iforA #-}
+iforA = G.iforA
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+traverse_ :: (Applicative f)
+          => (a -> f b) -> Vector a -> f ()
+{-# INLINE traverse_ #-}
+traverse_ = G.traverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+itraverse_ :: (Applicative f)
+           => (Int -> a -> f b) -> Vector a -> f ()
+{-# INLINE itraverse_ #-}
+itraverse_ = G.itraverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+forA_ :: (Applicative f)
+      => Vector a -> (a -> f b) -> f ()
+{-# INLINE forA_ #-}
+forA_ = G.forA_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+iforA_ :: (Applicative f)
+      => Vector a -> (Int -> a -> f b) -> f ()
+{-# INLINE iforA_ #-}
+iforA_ = G.iforA_
+
 
 -- Conversions - Lazy vectors
 -- -----------------------------

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -193,6 +193,10 @@ module Data.Vector.Unboxed (
   scanr, scanr', scanr1, scanr1',
   iscanr, iscanr',
 
+  -- * Applicative API
+  replicateA, generateA, traverse, itraverse, forA, iforA,
+  traverse_, itraverse_, forA_, iforA_,
+
   -- ** Comparisons
   eqBy, cmpBy,
 
@@ -221,6 +225,7 @@ module Data.Vector.Unboxed (
   DoNotUnboxNormalForm(..)
 ) where
 
+import Control.Applicative (Applicative)
 import Data.Vector.Unboxed.Base
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Fusion.Bundle as Bundle
@@ -2011,6 +2016,98 @@ fromList = G.fromList
 fromListN :: Unbox a => Int -> [a] -> Vector a
 {-# INLINE fromListN #-}
 fromListN = G.fromListN
+
+
+-- Applicative
+-- -----------
+
+-- | Construct a vector of the given length by applying the applicative
+-- action to each index.
+--
+-- @since NEXT_VERSION
+generateA :: (Applicative f, Unbox a) => Int -> (Int -> f a) -> f (Vector a)
+generateA = G.generateA
+
+-- | Execute the applicative action the given number of times and store the
+-- results in a vector.
+--
+-- @since NEXT_VERSION
+replicateA :: (Applicative f, Unbox a) => Int -> f a -> f (Vector a)
+{-# INLINE replicateA #-}
+replicateA = G.replicateA
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results.
+--
+-- @since NEXT_VERSION
+traverse :: (Applicative f, Unbox a, Unbox b)
+         => (a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE traverse #-}
+traverse = G.traverse
+
+-- | Apply the applicative action to every element of a vector and its
+-- index, yielding a vector of results.
+--
+-- @since NEXT_VERSION
+itraverse :: (Applicative f, Unbox a, Unbox b)
+          => (Int -> a -> f b) -> Vector a -> f (Vector b)
+{-# INLINE itraverse #-}
+itraverse = G.itraverse
+
+-- | Apply the applicative action to all elements of the vector, yielding a
+-- vector of results. This is flipped version of 'traverse'.
+--
+-- @since NEXT_VERSION
+forA :: (Applicative f, Unbox a, Unbox b)
+     => Vector a -> (a -> f b) -> f (Vector b)
+{-# INLINE forA #-}
+forA = G.forA
+
+-- | Apply the applicative action to every element of a vector and its
+--   index, yielding a vector of results. This is flipped version of 'itraverse'.
+--
+-- @since NEXT_VERSION
+iforA :: (Applicative f, Unbox a, Unbox b)
+      => Vector a -> (Int -> a -> f b) -> f (Vector b)
+{-# INLINE iforA #-}
+iforA = G.iforA
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+traverse_ :: (Applicative f, Unbox a)
+          => (a -> f b) -> Vector a -> f ()
+{-# INLINE traverse_ #-}
+traverse_ = G.traverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+itraverse_ :: (Applicative f, Unbox a)
+           => (Int -> a -> f b) -> Vector a -> f ()
+{-# INLINE itraverse_ #-}
+itraverse_ = G.itraverse_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+forA_ :: (Applicative f, Unbox a)
+      => Vector a -> (a -> f b) -> f ()
+{-# INLINE forA_ #-}
+forA_ = G.forA_
+
+-- | Map each element of a structure to an 'Applicative' action, evaluate these
+--   actions from left to right, and ignore the results.
+--
+-- @since NEXT_VERSION
+iforA_ :: (Applicative f, Unbox a)
+      => Vector a -> (Int -> a -> f b) -> f ()
+{-# INLINE iforA_ #-}
+iforA_ = G.iforA_
+
 
 -- Conversions - Mutable vectors
 -- -----------------------------

--- a/vector/tests/Tests/Vector/Boxed.hs
+++ b/vector/tests/Tests/Vector/Boxed.hs
@@ -22,6 +22,7 @@ testGeneralBoxedVector dummy = concatMap ($ dummy)
   , testFunctorFunctions
   , testMonadFunctions
   , testApplicativeFunctions
+  , testTraverseFunctions
   , testAlternativeFunctions
   , testSequenceFunctions
   , testDataFunctions

--- a/vector/tests/Tests/Vector/Primitive.hs
+++ b/vector/tests/Tests/Vector/Primitive.hs
@@ -17,6 +17,7 @@ testGeneralPrimitiveVector dummy = concatMap ($ dummy)
   , inline testPolymorphicFunctions
   , testOrdFunctions
   , testMonoidFunctions
+  , testTraverseFunctions
   , testDataFunctions
   ]
 

--- a/vector/tests/Tests/Vector/Storable.hs
+++ b/vector/tests/Tests/Vector/Storable.hs
@@ -17,6 +17,7 @@ testGeneralStorableVector dummy = concatMap ($ dummy)
   , inline testPolymorphicFunctions
   , testOrdFunctions
   , testMonoidFunctions
+  , testTraverseFunctions
   , testDataFunctions
   ]
 

--- a/vector/tests/Tests/Vector/Strict.hs
+++ b/vector/tests/Tests/Vector/Strict.hs
@@ -22,6 +22,7 @@ testGeneralBoxedVector dummy = concatMap ($ dummy)
   , testFunctorFunctions
   , testMonadFunctions
   , testApplicativeFunctions
+  , testTraverseFunctions
   , testAlternativeFunctions
   , testSequenceFunctions
   , testDataFunctions

--- a/vector/tests/Tests/Vector/Unboxed.hs
+++ b/vector/tests/Tests/Vector/Unboxed.hs
@@ -17,6 +17,7 @@ testGeneralUnboxedVector dummy = concatMap ($ dummy)
   , testOrdFunctions
   , testTuplyFunctions
   , testMonoidFunctions
+  , testTraverseFunctions
   , testDataFunctions
   ]
 

--- a/vector/tests/Utilities.hs
+++ b/vector/tests/Utilities.hs
@@ -266,7 +266,11 @@ xs // ps = go xs ps' 0
     go [] _ _      = []
 
 
-withIndexFirst m f = m (uncurry f) . zip [0..]
+-- withIndexFirst :: (Int -> a -> [a]) -> [a] -> [a]
+
+withIndexFirst :: (((Int, a) -> b) -> [(Int, a)] -> c)
+               -> ((Int -> a -> b) -> [a]        -> c)
+withIndexFirst m f = m (uncurry f) . zip [0::Int ..]
 
 modifyList :: [a] -> (a -> a) -> Int -> [a]
 modifyList xs f i = zipWith merge xs (replicate i Nothing ++ [Just f] ++ repeat Nothing)
@@ -285,6 +289,12 @@ imapM = withIndexFirst mapM
 
 imapM_ :: Monad m => (Int -> a -> m b) -> [a] -> m ()
 imapM_ = withIndexFirst mapM_
+
+itraverse :: Applicative m => (Int -> a -> m a) -> [a] -> m [a]
+itraverse = withIndexFirst traverse
+
+itraverse_ :: Applicative m => (Int -> a -> m a) -> [a] -> m ()
+itraverse_ = withIndexFirst traverse_
 
 iconcatMap :: (Int -> a -> [a]) -> [a] -> [a]
 iconcatMap f = concat . withIndexFirst map f

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -289,6 +289,7 @@ library benchmarks-O2
         Bench.Vector.Algo.Quickhull
         Bench.Vector.Algo.Spectral
         Bench.Vector.Algo.Tridiag
+        Bench.Vector.Algo.Applicative
         Bench.Vector.Algo.FindIndexR
         Bench.Vector.Algo.NextPermutation
         Bench.Vector.TestData.ParenTree


### PR DESCRIPTION
Implementation follows plan described in #477 with `generateA :: Applicative f => Int -> (Int -> f a) -> f (v a)` as primitive. It is not subject to stream fusion.  

Writing `generateA`  is not difficult. Problem is doing it efficiently. Current benchmarks are (suggestions for more are very welcome):

1. Generate vector of random numbers using state monad
2. Generate vector using IO action
3. Compute sum of vector using lens
4. Map vector using lens

First and naive implementation uses list as intermediate data structure. Sum benchmark performs well in this case. Using `STA` instead brings map benchmark on par with explicit loop and produces slight (5-10%) improvements in state and IO benchmark)
```haskell
newtype STA v a = STA {  _runSTA :: forall s. Mutable v s a -> ST s (v a) }
```

Currently sum and map perform on par with explicit loop.  State gives 7x slowdown and 8x allocations, IO benchmark 4x slowdown and 8x allocations. We obviously can add rewrite rules for `IO`/`ST` but maybe there're more general optimizations.

-----
Fixes #477, #69, #132, #144


