### PR TITLE
Allow base-4.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,21 @@ jobs:
       matrix:
         include:
           # Linux
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.0.2"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.2.2"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.4.4"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.6.5"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.8.4"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "8.10.7" }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.0.2"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.2.8"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.4.8"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.6.6"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.6.6",
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.0.2"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.2.2"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.4.4"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.6.5"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.8.4"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.10.7" }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.0.2"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.2.8"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.4.8"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.6.7"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.6.7",
               flags: "-fUnsafeChecks -fInternalChecks" }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.8.4"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.10.1"  }
-          - { cabal: "3.12", os: ubuntu-22.04,  ghc: "9.12"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.8"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.10"  }
+          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.12"  }
           # Win
           - { cabal: "3.12", os: windows-latest, ghc: "8.4.4"  }
           # OOM when building tests
@@ -49,15 +49,15 @@ jobs:
           - { cabal: "3.12", os: macOS-13,       ghc: "9.0.2"  }
           - { cabal: "3.12", os: macOS-latest,   ghc: "9.2.8"  }
           - { cabal: "3.12", os: macOS-latest,   ghc: "9.4.8"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.6.6"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.8.4"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.10.1"  }
+          - { cabal: "3.12", os: macOS-latest,   ghc: "9.6.7"  }
+          - { cabal: "3.12", os: macOS-latest,   ghc: "9.8"  }
+          - { cabal: "3.12", os: macOS-latest,   ghc: "9.10"  }
           - { cabal: "3.12", os: macOS-latest,   ghc: "9.12" }
       fail-fast: false
 
     steps:
     # ----------------
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
     # ----------------
     - uses: haskell-actions/setup@v2
@@ -77,7 +77,7 @@ jobs:
       run: |
         sudo apt-get install -y libpapi-dev
         echo FLAG_PAPI=-fBenchPAPI >> "$GITHUB_ENV"
-      if: matrix.os == 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-24.04'
     # ----------------
     - name: Versions
       run: |

--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -30,8 +30,10 @@ Tested-With:
   GHC == 9.0.2
   GHC == 9.2.8
   GHC == 9.4.8
-  GHC == 9.6.4
-  GHC == 9.8.2
+  GHC == 9.6.7
+  GHC == 9.8.4
+  GHC == 9.10.2
+  GHC == 9.12.2
 
 Cabal-Version:  >=1.10
 Build-Type:     Simple

--- a/vector-stream/vector-stream.cabal
+++ b/vector-stream/vector-stream.cabal
@@ -1,3 +1,4 @@
+Cabal-Version:  1.18
 Name:           vector-stream
 Version:        0.1.0.1
 -- don't forget to update the changelog file!
@@ -35,10 +36,9 @@ Tested-With:
   GHC == 9.10.2
   GHC == 9.12.2
 
-Cabal-Version:  >=1.10
 Build-Type:     Simple
 
-Extra-Source-Files:
+Extra-Doc-Files:
       changelog.md
       README.md
 
@@ -51,7 +51,7 @@ Library
   Hs-Source-Dirs:
         src
 
-  Build-Depends: base >= 4.9 && < 4.22
+  Build-Depends: base >= 4.9 && < 4.23
                , ghc-prim >= 0.2 && < 0.14
 
 source-repository head

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -162,7 +162,7 @@ Library
   Install-Includes:
         vector.h
 
-  Build-Depends: base >= 4.9 && < 4.22
+  Build-Depends: base >= 4.9 && < 4.23
                , primitive >= 0.6.4.0 && < 0.10
                , deepseq >= 1.1 && < 1.6
                , vector-stream >= 0.1 && < 0.2
@@ -248,7 +248,7 @@ test-suite vector-doctest
     buildable: False
   build-depends:
         base      -any
-      , doctest   >=0.15 && <0.24
+      , doctest   >=0.15 && <0.25
       , primitive >= 0.6.4.0 && < 0.10
       , vector    -any
 

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -53,8 +53,10 @@ Tested-With:
   GHC == 9.0.2
   GHC == 9.2.8
   GHC == 9.4.8
-  GHC == 9.6.4
-  GHC == 9.8.2
+  GHC == 9.6.7
+  GHC == 9.8.4
+  GHC == 9.10.2
+  GHC == 9.12.2
 
 Extra-doc-files:
       changelog.md


### PR DESCRIPTION
- **Bump CI to ubuntu-24.04 and latest GHC minor versions**
  

- **Allow base-4.22 and doctest-0.24**
  Closes #533
  