### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
           - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.12.2"  }
           # Win
           - { cabal: "3.14", os: windows-latest, ghc: "8.4.4"  }
-          # OOM when building tests
-          # - { cabal: "3.6", os: windows-latest, ghc: "8.6.5"  }
-          # - { cabal: "3.6", os: windows-latest, ghc: "8.8.4"  }
-          # - { cabal: "3.6", os: windows-latest, ghc: "8.10.4" }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.6.7"  }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.8.4"  }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.10.2"  }
+          - { cabal: "3.14", os: windows-latest, ghc: "9.12.2"  }
           # Too flaky:
           # - { cabal: "3.6", os: windows-latest,  ghc: "9.0.1"  }
           # MacOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,11 @@ jobs:
           # - { cabal: "3.6", os: windows-latest,  ghc: "9.0.1"  }
           # MacOS
           - { cabal: "3.14", os: macOS-13,       ghc: "8.4.4"  }
-          - { cabal: "3.14", os: macOS-13,       ghc: "8.6.5"  }
-          - { cabal: "3.14", os: macOS-13,       ghc: "8.8.4"  }
+          # Fails with linker errors
+          #  > ld: warning: -single_module is obsolete
+          #  > <command line>: can't load framework: Security (not found)
+          # - { cabal: "3.14", os: macOS-13,       ghc: "8.6.5"  }
+          # - { cabal: "3.14", os: macOS-13,       ghc: "8.8.4"  }
           - { cabal: "3.14", os: macOS-13,       ghc: "8.10.7" }
           - { cabal: "3.14", os: macOS-13,       ghc: "9.0.2"  }
           - { cabal: "3.14", os: macOS-latest,   ghc: "9.2.8"  }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,28 +90,39 @@ jobs:
     - name: Make sdist
       run: |
         mkdir sdist
-        cabal sdist vector -o sdist
+        cabal sdist vector            -o sdist
+        cabal sdist vector-stream     -o sdist
+        cabal sdist vector-bench-papi -o sdist
     - name: Unpack
       run: |
         mkdir unpacked
-        tar -C unpacked -xzf sdist/vector*tar.gz
-        cd unpacked
+        for NM in sdist/vector*tar.gz; do
+            tar -C unpacked -xzf $NM
+        done
+        echo "packages:"            >> unpacked/cabal.project
+        echo "    vector-*/*.cabal" >> unpacked/cabal.project
     # ----------------
     - name: cabal check
       run: |
-        (cd vector-stream && cabal -vnormal check)
-        (cd vector        && cabal -vnormal check)
-    # ----------------
+        for nm in vector-*; do
+            echo Checking $nm
+            (cd "$nm" && cabal -vnormal check)
+        done
+      working-directory: unpacked/
+   # ----------------
     - name: Build
       run: |
         echo FLAG_PAPI=$FLAG_PAPI
         cabal configure ${{ matrix.flags }} $FLAG_PAPI --haddock-all --enable-tests --enable-benchmarks --benchmark-option=-l
         cabal build all --write-ghc-environment-files=always
+      working-directory: unpacked/
     # ----------------
     - name: Test
       run: |
         cabal test all
+      working-directory: unpacked/
     # ----------------
     - name: Bench
       run: |
         cabal bench all
+      working-directory: unpacked/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,23 @@ jobs:
       matrix:
         include:
           # Linux
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.0.2"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.2.2"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.4.4"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.6.5"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.8.4"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "8.10.7" }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.0.2"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.2.8"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.4.8"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.6.7"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.6.7",
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "8.0.2"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "8.2.2"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "8.4.4"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "8.6.5"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "8.8.4"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "8.10.7" }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.0.2"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.2.8"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.4.8"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.6.7"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.6.7",
               flags: "-fUnsafeChecks -fInternalChecks" }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.8"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.10"  }
-          - { cabal: "3.12", os: ubuntu-24.04,  ghc: "9.12"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.8.4"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.10.2"  }
+          - { cabal: "3.14", os: ubuntu-24.04,  ghc: "9.12.2"  }
           # Win
-          - { cabal: "3.12", os: windows-latest, ghc: "8.4.4"  }
+          - { cabal: "3.14", os: windows-latest, ghc: "8.4.4"  }
           # OOM when building tests
           # - { cabal: "3.6", os: windows-latest, ghc: "8.6.5"  }
           # - { cabal: "3.6", os: windows-latest, ghc: "8.8.4"  }
@@ -42,17 +42,17 @@ jobs:
           # Too flaky:
           # - { cabal: "3.6", os: windows-latest,  ghc: "9.0.1"  }
           # MacOS
-          - { cabal: "3.12", os: macOS-13,       ghc: "8.4.4"  }
-          - { cabal: "3.12", os: macOS-13,       ghc: "8.6.5"  }
-          - { cabal: "3.12", os: macOS-13,       ghc: "8.8.4"  }
-          - { cabal: "3.12", os: macOS-13,       ghc: "8.10.7" }
-          - { cabal: "3.12", os: macOS-13,       ghc: "9.0.2"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.2.8"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.4.8"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.6.7"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.8"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.10"  }
-          - { cabal: "3.12", os: macOS-latest,   ghc: "9.12" }
+          - { cabal: "3.14", os: macOS-13,       ghc: "8.4.4"  }
+          - { cabal: "3.14", os: macOS-13,       ghc: "8.6.5"  }
+          - { cabal: "3.14", os: macOS-13,       ghc: "8.8.4"  }
+          - { cabal: "3.14", os: macOS-13,       ghc: "8.10.7" }
+          - { cabal: "3.14", os: macOS-13,       ghc: "9.0.2"  }
+          - { cabal: "3.14", os: macOS-latest,   ghc: "9.2.8"  }
+          - { cabal: "3.14", os: macOS-latest,   ghc: "9.4.8"  }
+          - { cabal: "3.14", os: macOS-latest,   ghc: "9.6.7"  }
+          - { cabal: "3.14", os: macOS-latest,   ghc: "9.8.4"  }
+          - { cabal: "3.14", os: macOS-latest,   ghc: "9.10.2" }
+          - { cabal: "3.14", os: macOS-latest,   ghc: "9.12.2" }
       fail-fast: false
 
     steps:


### PR DESCRIPTION
- Update cabal to 3.14
- Drop maxOS build for GHC 8.6, 8.8. They failed due to some linker problem
- Add GHC 9.6-9.12 to windows builds
- Perform build in `unpacked` directory which contains unpacked source distribution created by `cabal sdist`. This is to check that source distribution created by cabal are buildable and pass tests. 