### PR TITLE
Export unstreamPrimM & unsafeUnstreamPrimM

### DIFF
--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -2,7 +2,9 @@
 
  * [#522](https://github.com/haskell/vector/pull/522) API using Applicatives
    added: `traverse` & friends.
-   * [#518](https://github.com/haskell/vector/pull/518) `UnboxViaStorable` added.
+ * `unstreamPrimM` and `unsafeUnstreamPrimM` are added to `Data.Vector.Generic`
+   for converting monadic streams to vectors.
+ * [#518](https://github.com/haskell/vector/pull/518) `UnboxViaStorable` added.
    Vector constructors are reexported for `DoNotUnbox*`.
  * [#531](https://github.com/haskell/vector/pull/531) `iconcatMap` added.
 


### PR DESCRIPTION
This gives more options for working with monadic streams

As was discussed in #416 unstream variant which writes directly in buffer is unsafe when it uses `unsafeFreeze` and monad support nondeterminism. Thus `unstreamPrimM` uses `freeze` and add copy but this is still an improvement over `unstreamM` which create intermediate list. `unsafeUnstreamPrimM` is provided as well

Fixes #416