### PR TITLE
Add map for mutable vector which modify it in place.

### DIFF
--- a/vector/changelog.md
+++ b/vector/changelog.md
@@ -2,7 +2,9 @@
 
  * [#522](https://github.com/haskell/vector/pull/522) API using Applicatives
    added: `traverse` & friends.
-   * [#518](https://github.com/haskell/vector/pull/518) `UnboxViaStorable` added.
+ * [#545](https://github.com/haskell/vector/pull/545) `mapInPlace`,
+   `imapInPlace`, `mapInPlaceM`, `imapInPlaceM` added to mutable vectors API.
+ * [#518](https://github.com/haskell/vector/pull/518) `UnboxViaStorable` added.
    Vector constructors are reexported for `DoNotUnbox*`.
  * [#531](https://github.com/haskell/vector/pull/531) `iconcatMap` added.
 

--- a/vector/src/Data/Vector/Generic/Mutable.hs
+++ b/vector/src/Data/Vector/Generic/Mutable.hs
@@ -58,6 +58,7 @@ module Data.Vector.Generic.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
+  mapInPlace, imapInPlace, mapInPlaceM, imapInPlaceM,
   nextPermutation, nextPermutationBy,
   prevPermutation, prevPermutationBy,
 
@@ -1214,6 +1215,40 @@ partitionWithUnknown f s
 
 -- Modifying vectors
 -- -----------------
+
+-- | Modify vector in place by applying function to each element.
+--
+-- @since NEXT_VERSION
+mapInPlace :: (PrimMonad m, MVector v a) => (a -> a) -> v (PrimState m) a -> m ()
+{-# INLINE mapInPlace #-}
+mapInPlace f v
+  = stToPrim
+  $ forI_ v $ \i -> unsafeWrite v i . f =<< unsafeRead v i
+
+-- | Modify vector in place by applying function to each element and its index.
+--
+-- @since NEXT_VERSION
+imapInPlace :: (PrimMonad m, MVector v a) => (Int -> a -> a) -> v (PrimState m) a -> m ()
+{-# INLINE imapInPlace #-}
+imapInPlace f v
+  = stToPrim
+  $ forI_ v $ \i -> unsafeWrite v i . f i =<< unsafeRead v i
+
+-- | Modify vector in place by applying monadic function to each element in order.
+--
+-- @since NEXT_VERSION
+mapInPlaceM :: (PrimMonad m, MVector v a) => (a -> m a) -> v (PrimState m) a -> m ()
+{-# INLINE mapInPlaceM #-}
+mapInPlaceM f v
+  = forI_ v $ \i -> unsafeWrite v i =<< f =<< unsafeRead v i
+
+-- | Modify vector in place by applying monadic function to each element and its index in order.
+--
+-- @since NEXT_VERSION
+imapInPlaceM :: (PrimMonad m, MVector v a) => (Int -> a -> m a) -> v (PrimState m) a -> m ()
+{-# INLINE imapInPlaceM #-}
+imapInPlaceM f v
+  = forI_ v $ \i -> unsafeWrite v i =<< f i =<< unsafeRead v i
 
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.

--- a/vector/src/Data/Vector/Mutable.hs
+++ b/vector/src/Data/Vector/Mutable.hs
@@ -57,6 +57,7 @@ module Data.Vector.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
+  mapInPlace, imapInPlace, mapInPlaceM, imapInPlaceM,
   nextPermutation, nextPermutationBy,
   prevPermutation, prevPermutationBy,
 
@@ -570,6 +571,34 @@ unsafeMove = G.unsafeMove
 
 -- Modifying vectors
 -- -----------------
+
+-- | Modify vector in place by applying function to each element.
+--
+-- @since NEXT_VERSION
+mapInPlace :: (PrimMonad m) => (a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlace #-}
+mapInPlace = G.mapInPlace
+
+-- | Modify vector in place by applying function to each element and its index.
+--
+-- @since NEXT_VERSION
+imapInPlace :: (PrimMonad m) => (Int -> a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlace #-}
+imapInPlace = G.imapInPlace
+
+-- | Modify vector in place by applying monadic function to each element in order.
+--
+-- @since NEXT_VERSION
+mapInPlaceM :: (PrimMonad m) => (a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlaceM #-}
+mapInPlaceM = G.mapInPlaceM
+
+-- | Modify vector in place by applying monadic function to each element and its index in order.
+--
+-- @since NEXT_VERSION
+imapInPlaceM :: (PrimMonad m) => (Int -> a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlaceM #-}
+imapInPlaceM = G.imapInPlaceM
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
 -- Returns False when the input is the last item in the enumeration, i.e., if it is in

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -56,6 +56,7 @@ module Data.Vector.Primitive.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
+  mapInPlace, imapInPlace, mapInPlaceM, imapInPlaceM,
   nextPermutation, nextPermutationBy,
   prevPermutation, prevPermutationBy,
 
@@ -534,6 +535,34 @@ unsafeMove = G.unsafeMove
 
 -- Modifying vectors
 -- -----------------
+
+-- | Modify vector in place by applying function to each element.
+--
+-- @since NEXT_VERSION
+mapInPlace :: (PrimMonad m, Prim a) => (a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlace #-}
+mapInPlace = G.mapInPlace
+
+-- | Modify vector in place by applying function to each element and its index.
+--
+-- @since NEXT_VERSION
+imapInPlace :: (PrimMonad m, Prim a) => (Int -> a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlace #-}
+imapInPlace = G.imapInPlace
+
+-- | Modify vector in place by applying monadic function to each element in order.
+--
+-- @since NEXT_VERSION
+mapInPlaceM :: (PrimMonad m, Prim a) => (a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlaceM #-}
+mapInPlaceM = G.mapInPlaceM
+
+-- | Modify vector in place by applying monadic function to each element and its index in order.
+--
+-- @since NEXT_VERSION
+imapInPlaceM :: (PrimMonad m, Prim a) => (Int -> a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlaceM #-}
+imapInPlaceM = G.imapInPlaceM
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
 -- Returns False when the input is the last item in the enumeration, i.e., if it is in

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -57,6 +57,7 @@ module Data.Vector.Storable.Mutable(
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
+  mapInPlace, imapInPlace, mapInPlaceM, imapInPlaceM,
   nextPermutation, nextPermutationBy,
   prevPermutation, prevPermutationBy,
 
@@ -634,6 +635,35 @@ unsafeMove = G.unsafeMove
 
 -- Modifying vectors
 -- -----------------
+
+
+-- | Modify vector in place by applying function to each element.
+--
+-- @since NEXT_VERSION
+mapInPlace :: (PrimMonad m, Storable a) => (a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlace #-}
+mapInPlace = G.mapInPlace
+
+-- | Modify vector in place by applying function to each element and its index.
+--
+-- @since NEXT_VERSION
+imapInPlace :: (PrimMonad m, Storable a) => (Int -> a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlace #-}
+imapInPlace = G.imapInPlace
+
+-- | Modify vector in place by applying monadic function to each element in order.
+--
+-- @since NEXT_VERSION
+mapInPlaceM :: (PrimMonad m, Storable a) => (a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlaceM #-}
+mapInPlaceM = G.mapInPlaceM
+
+-- | Modify vector in place by applying monadic function to each element and its index in order.
+--
+-- @since NEXT_VERSION
+imapInPlaceM :: (PrimMonad m, Storable a) => (Int -> a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlaceM #-}
+imapInPlaceM = G.imapInPlaceM
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
 -- Returns False when the input is the last item in the enumeration, i.e., if it is in

--- a/vector/src/Data/Vector/Strict/Mutable.hs
+++ b/vector/src/Data/Vector/Strict/Mutable.hs
@@ -61,6 +61,7 @@ module Data.Vector.Strict.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
+  mapInPlace, imapInPlace, mapInPlaceM, imapInPlaceM,
   nextPermutation, nextPermutationBy,
   prevPermutation, prevPermutationBy,
 
@@ -549,6 +550,34 @@ unsafeMove = G.unsafeMove
 
 -- Modifying vectors
 -- -----------------
+
+-- | Modify vector in place by applying function to each element.
+--
+-- @since NEXT_VERSION
+mapInPlace :: (PrimMonad m) => (a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlace #-}
+mapInPlace = G.mapInPlace
+
+-- | Modify vector in place by applying function to each element and its index.
+--
+-- @since NEXT_VERSION
+imapInPlace :: (PrimMonad m) => (Int -> a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlace #-}
+imapInPlace = G.imapInPlace
+
+-- | Modify vector in place by applying monadic function to each element in order.
+--
+-- @since NEXT_VERSION
+mapInPlaceM :: (PrimMonad m) => (a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlaceM #-}
+mapInPlaceM = G.mapInPlaceM
+
+-- | Modify vector in place by applying monadic function to each element and its index in order.
+--
+-- @since NEXT_VERSION
+imapInPlaceM :: (PrimMonad m) => (Int -> a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlaceM #-}
+imapInPlaceM = G.imapInPlaceM
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
 -- Returns False when the input is the last item in the enumeration, i.e., if it is in

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -58,6 +58,7 @@ module Data.Vector.Unboxed.Mutable (
   ifoldr, ifoldr', ifoldrM, ifoldrM',
 
   -- * Modifying vectors
+  mapInPlace, imapInPlace, mapInPlaceM, imapInPlaceM,
   nextPermutation, nextPermutationBy,
   prevPermutation, prevPermutationBy,
 
@@ -441,6 +442,34 @@ unsafeMove = G.unsafeMove
 
 -- Modifying vectors
 -- -----------------
+
+-- | Modify vector in place by applying function to each element.
+--
+-- @since NEXT_VERSION
+mapInPlace :: (PrimMonad m, Unbox a) => (a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlace #-}
+mapInPlace = G.mapInPlace
+
+-- | Modify vector in place by applying function to each element and its index.
+--
+-- @since NEXT_VERSION
+imapInPlace :: (PrimMonad m, Unbox a) => (Int -> a -> a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlace #-}
+imapInPlace = G.imapInPlace
+
+-- | Modify vector in place by applying monadic function to each element in order.
+--
+-- @since NEXT_VERSION
+mapInPlaceM :: (PrimMonad m, Unbox a) => (a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE mapInPlaceM #-}
+mapInPlaceM = G.mapInPlaceM
+
+-- | Modify vector in place by applying monadic function to each element and its index in order.
+--
+-- @since NEXT_VERSION
+imapInPlaceM :: (PrimMonad m, Unbox a) => (Int -> a -> m a) -> MVector (PrimState m) a -> m ()
+{-# INLINE imapInPlaceM #-}
+imapInPlaceM = G.imapInPlaceM
 
 -- | Compute the (lexicographically) next permutation of the given vector in-place.
 -- Returns False when the input is the last item in the enumeration, i.e., if it is in

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -101,7 +101,6 @@ common flag-Wall
     if impl(ghc >= 8.0) && impl(ghc < 8.1)
       Ghc-Options:   -Wno-redundant-constraints
 
-
 Library
   import:           flag-Wall
   Default-Language: Haskell2010
@@ -184,6 +183,9 @@ Library
 -- rewrite rules
 common tests-common
   Default-Language: Haskell2010
+  -- Disable pointless warning about partial functions
+  if impl(ghc >= 9.8)
+    Ghc-Options:  -Wno-x-partial
   Ghc-Options:      -fno-warn-missing-signatures
   hs-source-dirs:   tests
   Build-Depends: base >= 4.5 && < 5


### PR DESCRIPTION
This is last part of API for mutable vectors

Naming was discussed at length in #334. I somewhat arbitrarily picked variant with `InPlace` suffix. But I don't feel strongly about it and this is good moment for final decision. Bikeshedding season is on


Fixes #334