### PR TITLE
#define NOT_VECTOR_MODULE is not used anywhere

### DIFF
--- a/vector/src/Data/Vector/Fusion/Bundle.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle.hs
@@ -97,8 +97,6 @@ import Prelude
 import Data.Functor.Classes (Eq1 (..), Ord1 (..))
 import GHC.Base ( build )
 
--- Data.Vector.Internal.Check is unused
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 -- | The type of pure streams

--- a/vector/src/Data/Vector/Generic/Mutable/Base.hs
+++ b/vector/src/Data/Vector/Generic/Mutable/Base.hs
@@ -22,8 +22,6 @@ module Data.Vector.Generic.Mutable.Base (
 
 import Control.Monad.ST
 
--- Data.Vector.Internal.Check is unused
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 -- | Class of mutable vectors parameterised with a primitive state token.

--- a/vector/src/Data/Vector/Generic/New.hs
+++ b/vector/src/Data/Vector/Generic/New.hs
@@ -44,8 +44,6 @@ import Prelude
   , return, seq
   , (.), (=<<) )
 
--- Data.Vector.Internal.Check is unused
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 -- | This data type is a wrapper around a monadic action which produces

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -90,8 +90,6 @@ import Prelude
 import Data.Coerce
 import Unsafe.Coerce
 
--- Data.Vector.Internal.Check is unnecessary
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 type role MVector nominal nominal

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -199,8 +199,6 @@ import Data.Coerce
 import qualified GHC.Exts as Exts
 import Unsafe.Coerce
 
--- Data.Vector.Internal.Check is unused
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 type role Vector nominal

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -108,8 +108,6 @@ import Prelude
 import Data.Coerce
 import Unsafe.Coerce
 
--- Data.Vector.Internal.Check is not needed
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 type role MVector nominal nominal

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -244,8 +244,6 @@ import Data.Semigroup ( Semigroup(..) )
 
 import qualified GHC.Exts as Exts (IsList(..))
 
-
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 -- See http://trac.haskell.org/vector/ticket/12

--- a/vector/src/Data/Vector/Unboxed/Base.hs
+++ b/vector/src/Data/Vector/Unboxed/Base.hs
@@ -64,8 +64,6 @@ import GHC.Generics
 import Data.Coerce
 import Data.Kind     (Type)
 
--- Data.Vector.Internal.Check is unused
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 data family MVector s a

--- a/vector/src/Data/Vector/Unboxed/Mutable.hs
+++ b/vector/src/Data/Vector/Unboxed/Mutable.hs
@@ -74,8 +74,6 @@ import Control.Monad.Primitive
 
 import Prelude ( Ord, Bool, Int, Maybe, Ordering(..) )
 
--- don't import an unused Data.Vector.Internal.Check
-#define NOT_VECTOR_MODULE
 #include "vector.h"
 
 -- Length information


### PR DESCRIPTION
Grepping source code for  NOT_VECTOR_MODULE found no matches.