### PR TITLE
Fix some typos in `@since`

### DIFF
--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -1442,6 +1442,8 @@ break = G.break
 -- >>> import qualified Data.Vector as V
 -- >>> V.spanR (>4) $ V.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 spanR :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE spanR #-}
 spanR = G.spanR
@@ -1451,13 +1453,13 @@ spanR = G.spanR
 --
 -- Does not fuse.
 --
--- @since NEXT_VERSION
---
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector as V
 -- >>> V.breakR (<5) $ V.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 breakR :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE breakR #-}
 breakR = G.breakR
@@ -1477,7 +1479,7 @@ breakR = G.breakR
 --
 -- See also 'Data.List.groupBy', 'group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 groupBy :: (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
@@ -1497,7 +1499,7 @@ groupBy = G.groupBy
 --
 -- See also 'Data.List.group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 group :: Eq a => Vector a -> [Vector a]
 {-# INLINE group #-}
 group = G.groupBy (==)

--- a/vector/src/Data/Vector/Generic.hs
+++ b/vector/src/Data/Vector/Generic.hs
@@ -1611,6 +1611,8 @@ break f xs = case findIndex f xs of
 -- >>> import qualified Data.Vector.Strict as V
 -- >>> V.spanR (>4) $ V.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 spanR :: Vector v a => (a -> Bool) -> v a -> (v a, v a)
 {-# INLINE spanR #-}
 spanR f = breakR (not . f)
@@ -1620,13 +1622,13 @@ spanR f = breakR (not . f)
 --
 -- Does not fuse.
 --
--- @since NEXT_VERSION
---
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Strict as V
 -- >>> V.breakR (<5) $ V.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 breakR :: Vector v a => (a -> Bool) -> v a -> (v a, v a)
 {-# INLINE breakR #-}
 breakR f xs = case findIndexR f xs of
@@ -1650,7 +1652,7 @@ breakR f xs = case findIndexR f xs of
 --
 -- See also 'Data.List.groupBy'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 {-# INLINE groupBy #-}
 groupBy :: (Vector v a) => (a -> a -> Bool) -> v a -> [v a]
 groupBy _ v | null v = []
@@ -1674,7 +1676,7 @@ groupBy f v =
 --
 -- See also 'Data.List.group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 group :: (Vector v a , Eq a) => v a -> [v a]
 {-# INLINE group #-}
 group = groupBy (==)

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -1201,6 +1201,8 @@ break = G.break
 -- >>> import qualified Data.Vector.Primitive as VP
 -- >>> VP.spanR (>4) $ VP.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 spanR :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE spanR #-}
 spanR = G.spanR
@@ -1210,13 +1212,13 @@ spanR = G.spanR
 --
 -- Does not fuse.
 --
--- @since NEXT_VERSION
---
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Primitive as VP
 -- >>> VP.breakR (<5) $ VP.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 breakR :: Prim a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE breakR #-}
 breakR = G.breakR
@@ -1236,7 +1238,7 @@ breakR = G.breakR
 --
 -- See also 'Data.List.groupBy', 'group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 groupBy :: Prim a => (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
@@ -1256,7 +1258,7 @@ groupBy = G.groupBy
 --
 -- See also 'Data.List.group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 group :: (Prim a, Eq a) => Vector a -> [Vector a]
 {-# INLINE group #-}
 group = G.groupBy (==)

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -1223,6 +1223,8 @@ break = G.break
 -- >>> import qualified Data.Vector.Storable as VS
 -- >>> VS.spanR (>4) $ VS.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 spanR :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE spanR #-}
 spanR = G.spanR
@@ -1232,13 +1234,13 @@ spanR = G.spanR
 --
 -- Does not fuse.
 --
--- @since NEXT_VERSION
---
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Storable as VS
 -- >>> VS.breakR (<5) $ VS.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 breakR :: Storable a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE breakR #-}
 breakR = G.breakR
@@ -1258,7 +1260,7 @@ breakR = G.breakR
 --
 -- See also 'Data.List.groupBy', 'group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 groupBy :: Storable a => (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
@@ -1278,7 +1280,7 @@ groupBy = G.groupBy
 --
 -- See also 'Data.List.group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 group :: (Storable a, Eq a) => Vector a -> [Vector a]
 {-# INLINE group #-}
 group = G.groupBy (==)

--- a/vector/src/Data/Vector/Strict.hs
+++ b/vector/src/Data/Vector/Strict.hs
@@ -1589,8 +1589,6 @@ spanR = G.spanR
 --
 -- Does not fuse.
 --
--- @since 0.13.2.0
---
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector as V

--- a/vector/src/Data/Vector/Unboxed.hs
+++ b/vector/src/Data/Vector/Unboxed.hs
@@ -1257,6 +1257,8 @@ break = G.break
 -- >>> import qualified Data.Vector.Unboxed as VU
 -- >>> VU.spanR (>4) $ VU.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 spanR :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE spanR #-}
 spanR = G.spanR
@@ -1266,13 +1268,13 @@ spanR = G.spanR
 --
 -- Does not fuse.
 --
--- @since NEXT_VERSION
---
 -- ==== __Examples__
 --
 -- >>> import qualified Data.Vector.Unboxed as VU
 -- >>> VU.breakR (<5) $ VU.generate 10 id
 -- ([5,6,7,8,9],[0,1,2,3,4])
+--
+-- @since 0.13.2.0
 breakR :: Unbox a => (a -> Bool) -> Vector a -> (Vector a, Vector a)
 {-# INLINE breakR #-}
 breakR = G.breakR
@@ -1292,7 +1294,7 @@ breakR = G.breakR
 --
 -- See also 'Data.List.groupBy', 'group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 groupBy :: Unbox a => (a -> a -> Bool) -> Vector a -> [Vector a]
 {-# INLINE groupBy #-}
 groupBy = G.groupBy
@@ -1312,7 +1314,7 @@ groupBy = G.groupBy
 --
 -- See also 'Data.List.group'.
 --
--- @since 0.13.0.1
+-- @since 0.13.0.0
 group :: (Unbox a, Eq a) => Vector a -> [Vector a]
 {-# INLINE group #-}
 group = G.groupBy (==)


### PR DESCRIPTION
These typos were found while reading CHANGELOG of  `0.13.1.0` and `0.13.2.0`.