### PR TITLE
Add tests for manual specializations and simplification enumFromTo in vector-streaming

### DIFF
--- a/vector/tests/Main.hs
+++ b/vector/tests/Main.hs
@@ -8,6 +8,7 @@ import qualified Tests.Vector.Strict
 import qualified Tests.Vector.Unboxed
 import qualified Tests.Bundle
 import qualified Tests.Move
+import qualified Tests.Specialization
 import qualified Tests.Deriving ()
 
 import Test.Tasty (defaultMain,testGroup)
@@ -23,4 +24,5 @@ main = defaultMain $ testGroup "toplevel" $ concat
     ]
   , Tests.Vector.UnitTests.tests
   , Tests.Move.tests
+  , Tests.Specialization.tests
   ]

--- a/vector/tests/Tests/Specialization.hs
+++ b/vector/tests/Tests/Specialization.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+-- |
+-- We provide custom specialized versions for some functions so we
+-- need that specializations perform same as nonspecialized versions
+module Tests.Specialization (tests) where
+
+import Data.Char
+import Data.Int
+import Data.Word
+import Data.Typeable
+import qualified Data.Vector as Boxed
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+
+tests :: [TestTree]
+tests =
+  [ testGroup "specializations"
+    [ testGroup "enumFromTo"
+      [ specEnumFromTo (Proxy @Word8)
+      , specEnumFromTo (Proxy @Word16)
+      , specEnumFromTo (Proxy @Word32)
+      , specEnumFromTo (Proxy @Word64)
+      , specEnumFromTo (Proxy @Word)
+      , specEnumFromTo (Proxy @Int8)
+      , specEnumFromTo (Proxy @Int16)
+      , specEnumFromTo (Proxy @Int32)
+      , specEnumFromTo (Proxy @Int64)
+      , specEnumFromTo (Proxy @Int)
+      , specEnumFromTo (Proxy @Integer)
+      , specEnumFromToFloat (Proxy @Float)
+      , specEnumFromToFloat (Proxy @Double)
+      , specEnumFromToChar
+      ]
+    ]
+  ]
+
+
+-- For integral data type we need to make sure we never generate slice
+-- too big.
+specEnumFromTo
+  :: forall a. (Enum a, Eq a, Show a, Arbitrary a, Typeable a, Integral a)
+  => Proxy a -> TestTree
+{-# INLINE specEnumFromTo #-}
+specEnumFromTo _ = testProperty (show (typeOf (undefined :: a)))
+  $ \(a::a) (d::Int16) ->
+      let b = fromInteger $ fromIntegral a + fromIntegral d
+          diff = abs $ fromIntegral a - fromIntegral b :: Integer
+      in diff < 65000 ==> 
+         ( counterexample ("[" ++ show a ++ " .. " ++ show b ++ "]")
+         $ [a .. b] == Boxed.toList (Boxed.enumFromTo a b)
+         )
+
+specEnumFromToFloat
+  :: forall a. (Enum a, Eq a, Show a, Arbitrary a, Typeable a, Fractional a, Real a)
+  => Proxy a -> TestTree
+{-# INLINE specEnumFromToFloat #-}
+specEnumFromToFloat _ = testProperty (show (typeOf (undefined :: a)))
+  $ \(a::a) (d::Int16) ->
+      let b    = a + realToFrac d / 3
+          diff = abs $ a - b
+      in diff < 65000 ==>
+         ( counterexample ("[" ++ show a ++ " .. " ++ show b ++ "]")
+         $ [a .. b] == Boxed.toList (Boxed.enumFromTo a b)
+         )
+
+specEnumFromToChar :: TestTree
+specEnumFromToChar = testProperty "Char"
+  $ \(i1::Word8) (i2::Word8) ->
+      let c1 = chr $ 256 + fromIntegral i1
+          c2 = chr $ 256 + fromIntegral i2
+      in ( counterexample (show (c1,c2))
+         $ [c1 .. c2] == Boxed.toList (Boxed.enumFromTo c1 c2)
+         )

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -205,6 +205,7 @@ common tests-common
     Tests.Vector.Unboxed
     Tests.Vector.UnitTests
     Tests.Deriving
+    Tests.Specialization
     Utilities
 
   default-extensions:


### PR DESCRIPTION
We provide handwritten specializations for `enumFromTo` but don't test that they work same as standard `enumFromTo`. This PR adds tests and simplifies rewrite rules in `vector-streaming`. 

Rewrite rules in `Bundle` could be improved but that's quite a bit of work so I submitting first part as a PR