### PR TITLE
Fix cabal description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,12 @@ jobs:
           - { cabal: "3.14", os: windows-latest, ghc: "9.10.2"  }
           - { cabal: "3.14", os: windows-latest, ghc: "9.12.2"  }
           # MacOS
-          # Fails with linker errors
-          #  > ld: warning: -single_module is obsolete
-          #  > <command line>: can't load framework: Security (not found)
-          # - { cabal: "3.14", os: macOS-13,       ghc: "8.6.5"  }
-          # - { cabal: "3.14", os: macOS-13,       ghc: "8.8.4"  }
-          - { cabal: "3.14", os: macOS-13,       ghc: "8.10.7" }
-          - { cabal: "3.14", os: macOS-13,       ghc: "9.0.2"  }
+          #
+          # Fails with:
+          # > <command line>: can't load framework: Security (not found)
+          # - { cabal: "3.14", os: macOS-15-intel, ghc: "8.8.4"  }
+          - { cabal: "3.14", os: macOS-15-intel, ghc: "8.10.7" }
+          - { cabal: "3.14", os: macOS-15-intel, ghc: "9.0.2"  }
           - { cabal: "3.14", os: macOS-latest,   ghc: "9.2.8"  }
           - { cabal: "3.14", os: macOS-latest,   ghc: "9.4.8"  }
           - { cabal: "3.14", os: macOS-latest,   ghc: "9.6.7"  }
@@ -66,7 +65,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}---CACHE_V3
+        key: ${{ runner.os }}-${{ matrix.ghc }}-CACHE_V4
     # ----------------
     - name: "Install PAPI"
       run: |

--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -20,27 +20,26 @@ Bug-Reports:    https://github.com/haskell/vector/issues
 Category:       Data, Data Structures
 Synopsis:       Efficient Arrays
 Description:
-        .
         An efficient implementation of @Int@-indexed arrays (both mutable
         and immutable), with a powerful loop optimisation framework .
-        .
+
         It is structured as follows:
-        .
+
         ["Data.Vector"] Boxed vectors of arbitrary types.
-        .
+
         ["Data.Vector.Unboxed"] Unboxed vectors with an adaptive
         representation based on data type families.
-        .
+
         ["Data.Vector.Storable"] Unboxed vectors of 'Storable' types.
-        .
+
         ["Data.Vector.Primitive"] Unboxed vectors of primitive types as
         defined by the @primitive@ package. "Data.Vector.Unboxed" is more
         flexible at no performance cost.
-        .
+
         ["Data.Vector.Generic"] Generic interface to the vector types.
-        .
+
         There is also a (draft) tutorial on common uses of vector.
-        .
+
         * <http://haskell.org/haskellwiki/Numeric_Haskell:_A_Vector_Tutorial>
 
 Tested-With:


### PR DESCRIPTION
Rendering of Description field was changed as some point and as of 3.0 version it uses haddock and trick with placing . strategically is no longer needed

I've checked haddock's output. `index.html` is now generated properly

Fixes #528