### PR TITLE
Simplify rewrite rules for enumFromTo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-CACHE_V4
+        key: ${{ runner.os }}-${{ matrix.ghc }}-CACHE_V5
     # ----------------
     - name: "Install PAPI"
       run: |
@@ -117,3 +117,26 @@ jobs:
       run: |
         cabal bench all
       working-directory: unpacked/
+  # Job for checking that vector is buildable and works correctly on 32-bit
+  # systems. Adapted from bitvec's CI setup
+  i386:
+    needs: cabal
+    runs-on: ubuntu-latest
+    container:
+      image: i386/ubuntu:bionic
+    steps:
+    - name: Install
+      run: |
+        apt-get update -y
+        apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl libncurses5 libtinfo5 libncurses5-dev libtinfo-dev
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh
+    - uses: actions/checkout@v1
+    # ----------------
+    - name: Test
+      run: |
+        source ~/.ghcup/env
+        cabal -V
+        ghc -V
+        cabal update
+        cabal build all --write-ghc-environment-files=always
+        cabal test all --enable-tests --test-show-details=direct

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -812,18 +812,6 @@ enumFromTo_small !x !y = fromStream (Stream step (Just x)) (Exact n)
                   | otherwise = return $ Done
 
 
-#if WORD_SIZE_IN_BITS > 32
-
-{-# RULES
-
-"enumFromTo<Int32> [Bundle]"
-  enumFromTo = enumFromTo_small :: Monad m => Int32 -> Int32 -> Bundle m v Int32
-
-"enumFromTo<Word32> [Bundle]"
-  enumFromTo = enumFromTo_small :: Monad m => Word32 -> Word32 -> Bundle m v Word32   #-}
-
-#endif
-
 -- NOTE: We could implement a generic "too large" test:
 --
 -- len x y | x > y = 0
@@ -872,17 +860,6 @@ enumFromTo_intlike !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
                   | z <  y    = return $ Yield z (Just (z+1))
                   | otherwise = return $ Done
 
-{-# RULES
-#if WORD_SIZE_IN_BITS > 32
-
-"enumFromTo<Int64> [Bundle]"
-  enumFromTo = enumFromTo_intlike :: Monad m => Int64 -> Int64 -> Bundle m v Int64    #-}
-
-#else
-
-"enumFromTo<Int32> [Bundle]"
-  enumFromTo = enumFromTo_intlike :: Monad m => Int32 -> Int32 -> Bundle m v Int32    #-}
-#endif
 
 
 
@@ -905,16 +882,6 @@ enumFromTo_big_word !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
                   | z <  y    = return $ Yield z (Just (z+1))
                   | otherwise = return $ Done
 
-{-# RULES
-
-#if WORD_SIZE_IN_BITS == 32
-
-"enumFromTo<Word32> [Bundle]"
-  enumFromTo = enumFromTo_big_word
-                        :: Monad m => Word32 -> Word32 -> Bundle m v Word32
-
-#endif
-  #-}
 
 
 #if WORD_SIZE_IN_BITS > 32
@@ -1004,7 +971,20 @@ enumFromTo_double !n !m = fromStream (Stream step ini) (Max (len n lim))
 "enumFromTo<Float> [Bundle]"   enumFromTo @Float   = enumFromTo_double
   #-}
 
-
+#if WORD_SIZE_IN_BITS > 32
+-- 64bit systems
+{-# RULES
+"enumFromTo<Int32> [Bundle]"  enumFromTo @Int32  = enumFromTo_small
+"enumFromTo<Int64> [Bundle]"  enumFromTo @Int64  = enumFromTo_intlike
+"enumFromTo<Word32> [Bundle]" enumFromTo @Word32 = enumFromTo_small
+  #-}
+#else
+-- 32bit systems
+{-# RULES
+"enumFromTo<Int32> [Bundle]"  enumFromTo @Int32  = enumFromTo_intlike
+"enumFromTo<Word32> [Bundle]" enumFromTo @Word32 = enumFromTo_big_word
+  #-}
+#endif
 
 ------------------------------------------------------------------------
 

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -750,7 +750,7 @@ scanl' f = scanlM' (\a b -> return (f a b))
 -- | Haskell-style scan with strict accumulator and a monadic operator
 scanlM' :: Monad m => (a -> b -> m a) -> a -> Bundle m v b -> Bundle m v a
 {-# INLINE scanlM' #-}
-scanlM' f z s = z `seq` (z `cons` postscanlM f z s)
+scanlM' f !z s = z `cons` postscanlM f z s
 
 -- | Initial-value free scan over a 'Bundle'
 scanl1 :: Monad m => (a -> a -> a) -> Bundle m v a -> Bundle m v a
@@ -800,7 +800,7 @@ enumFromTo x y = fromList [x .. y]
 -- FIXME: add "too large" test for Int
 enumFromTo_small :: (Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_small #-}
-enumFromTo_small x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact n)
+enumFromTo_small !x !y = fromStream (Stream step (Just x)) (Exact n)
   where
     n = delay_inline max (fromIntegral y - fromIntegral x + 1) 0
 
@@ -852,7 +852,7 @@ enumFromTo_small x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact 
 
 enumFromTo_int :: forall m v. (HasCallStack, Monad m) => Int -> Int -> Bundle m v Int
 {-# INLINE_FUSED enumFromTo_int #-}
-enumFromTo_int x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (len x y))
+enumFromTo_int !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
   where
     {-# INLINE [0] len #-}
     len :: HasCallStack => Int -> Int -> Int
@@ -869,7 +869,7 @@ enumFromTo_int x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (l
 
 enumFromTo_intlike :: forall m v a. (HasCallStack, Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_intlike #-}
-enumFromTo_intlike x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (len x y))
+enumFromTo_intlike !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
   where
     {-# INLINE [0] len #-}
     len :: HasCallStack => a -> a -> Int
@@ -907,7 +907,7 @@ enumFromTo_intlike x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exac
 
 enumFromTo_big_word :: forall m v a. (HasCallStack, Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_big_word #-}
-enumFromTo_big_word x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (len x y))
+enumFromTo_big_word !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
   where
     {-# INLINE [0] len #-}
     len :: HasCallStack => a -> a -> Int
@@ -951,7 +951,7 @@ enumFromTo_big_word x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exa
 -- FIXME: the "too large" test is totally wrong
 enumFromTo_big_int :: forall m v a. (HasCallStack, Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_big_int #-}
-enumFromTo_big_int x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exact (len x y))
+enumFromTo_big_int !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
   where
     {-# INLINE [0] len #-}
     len :: HasCallStack => a -> a -> Int
@@ -980,7 +980,7 @@ enumFromTo_big_int x y = x `seq` y `seq` fromStream (Stream step (Just x)) (Exac
 
 enumFromTo_char :: Monad m => Char -> Char -> Bundle m v Char
 {-# INLINE_FUSED enumFromTo_char #-}
-enumFromTo_char x y = x `seq` y `seq` fromStream (Stream step xn) (Exact n)
+enumFromTo_char !x !y = fromStream (Stream step xn) (Exact n)
   where
     xn = ord x
     yn = ord y
@@ -1005,7 +1005,7 @@ enumFromTo_char x y = x `seq` y `seq` fromStream (Stream step xn) (Exact n)
 
 enumFromTo_double :: forall m v a. (HasCallStack, Monad m, Ord a, RealFrac a) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_double #-}
-enumFromTo_double n m = n `seq` m `seq` fromStream (Stream step ini) (Max (len n lim))
+enumFromTo_double !n !m = fromStream (Stream step ini) (Max (len n lim))
   where
     lim = m + 1/2 -- important to float out
 
@@ -1071,7 +1071,7 @@ unsafeFromList sz xs = fromStream (S.fromList xs) sz
 
 fromVector :: (Monad m, Vector v a) => v a -> Bundle m v a
 {-# INLINE_FUSED fromVector #-}
-fromVector v = v `seq` n `seq` Bundle (Stream step 0)
+fromVector !v = n `seq` Bundle (Stream step 0)
                                       (Stream vstep True)
                                       (Just v)
                                       (Exact n)

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 -- |
 -- Module      : Data.Vector.Fusion.Bundle.Monadic
 -- Copyright   : (c) Roman Leshchinskiy 2008-2010
@@ -810,21 +811,6 @@ enumFromTo_small !x !y = fromStream (Stream step (Just x)) (Exact n)
                   | z <  y    = return $ Yield z (Just (z+1))
                   | otherwise = return $ Done
 
-{-# RULES
-
-"enumFromTo<Int8> [Bundle]"
-  enumFromTo = enumFromTo_small :: Monad m => Int8 -> Int8 -> Bundle m v Int8
-
-"enumFromTo<Int16> [Bundle]"
-  enumFromTo = enumFromTo_small :: Monad m => Int16 -> Int16 -> Bundle m v Int16
-
-"enumFromTo<Word8> [Bundle]"
-  enumFromTo = enumFromTo_small :: Monad m => Word8 -> Word8 -> Bundle m v Word8
-
-"enumFromTo<Word16> [Bundle]"
-  enumFromTo = enumFromTo_small :: Monad m => Word16 -> Word16 -> Bundle m v Word16   #-}
-
-
 
 #if WORD_SIZE_IN_BITS > 32
 
@@ -887,10 +873,6 @@ enumFromTo_intlike !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
                   | otherwise = return $ Done
 
 {-# RULES
-
-"enumFromTo<Int> [Bundle]"
-  enumFromTo = enumFromTo_int :: Monad m => Int -> Int -> Bundle m v Int
-
 #if WORD_SIZE_IN_BITS > 32
 
 "enumFromTo<Int64> [Bundle]"
@@ -900,7 +882,6 @@ enumFromTo_intlike !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
 
 "enumFromTo<Int32> [Bundle]"
   enumFromTo = enumFromTo_intlike :: Monad m => Int32 -> Int32 -> Bundle m v Int32    #-}
-
 #endif
 
 
@@ -926,13 +907,6 @@ enumFromTo_big_word !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
 
 {-# RULES
 
-"enumFromTo<Word> [Bundle]"
-  enumFromTo = enumFromTo_big_word :: Monad m => Word -> Word -> Bundle m v Word
-
-"enumFromTo<Word64> [Bundle]"
-  enumFromTo = enumFromTo_big_word
-                        :: Monad m => Word64 -> Word64 -> Bundle m v Word64
-
 #if WORD_SIZE_IN_BITS == 32
 
 "enumFromTo<Word32> [Bundle]"
@@ -940,10 +914,7 @@ enumFromTo_big_word !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
                         :: Monad m => Word32 -> Word32 -> Bundle m v Word32
 
 #endif
-
-"enumFromTo<Integer> [Bundle]"
-  enumFromTo = enumFromTo_big_word
-                        :: Monad m => Integer -> Integer -> Bundle m v Integer   #-}
+  #-}
 
 
 #if WORD_SIZE_IN_BITS > 32
@@ -974,8 +945,6 @@ enumFromTo_big_int !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
 "enumFromTo<Int64> [Bundle]"
   enumFromTo = enumFromTo_big_int :: Monad m => Int64 -> Int64 -> Bundle m v Int64   #-}
 
-
-
 #endif
 
 enumFromTo_char :: Monad m => Char -> Char -> Bundle m v Char
@@ -990,11 +959,6 @@ enumFromTo_char !x !y = fromStream (Stream step xn) (Exact n)
     {-# INLINE_INNER step #-}
     step zn | zn <= yn  = return $ Yield (unsafeChr zn) (zn+1)
             | otherwise = return $ Done
-
-{-# RULES
-
-"enumFromTo<Char> [Bundle]"
-  enumFromTo = enumFromTo_char   #-}
 
 
 
@@ -1025,12 +989,20 @@ enumFromTo_double !n !m = fromStream (Stream step ini) (Max (len n lim))
              x' = x + n
 
 {-# RULES
+"enumFromTo<Int8> [Bundle]"    enumFromTo @Int8    = enumFromTo_small
+"enumFromTo<Int16> [Bundle]"   enumFromTo @Int16   = enumFromTo_small
+"enumFromTo<Word8> [Bundle]"   enumFromTo @Word8   = enumFromTo_small
+"enumFromTo<Word16> [Bundle]"  enumFromTo @Word16  = enumFromTo_small
 
-"enumFromTo<Double> [Bundle]"
-  enumFromTo = enumFromTo_double :: Monad m => Double -> Double -> Bundle m v Double
+"enumFromTo<Int> [Bundle]"     enumFromTo @Int     = enumFromTo_int
+"enumFromTo<Word> [Bundle]"    enumFromTo @Word    = enumFromTo_big_word
+"enumFromTo<Word64> [Bundle]"  enumFromTo @Word64  = enumFromTo_big_word
+"enumFromTo<Integer> [Bundle]" enumFromTo @Integer = enumFromTo_big_word
 
-"enumFromTo<Float> [Bundle]"
-  enumFromTo = enumFromTo_double :: Monad m => Float -> Float -> Bundle m v Float   #-}
+"enumFromTo<Char> [Bundle]"    enumFromTo @Char    = enumFromTo_char
+"enumFromTo<Double> [Bundle]"  enumFromTo @Double  = enumFromTo_double
+"enumFromTo<Float> [Bundle]"   enumFromTo @Float   = enumFromTo_double
+  #-}
 
 
 

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -106,15 +106,11 @@ import Prelude
   , return, fmap, otherwise, id, const, seq, max, maxBound, fromIntegral, truncate
   , (+), (-), (<), (<=), (>), (>=), (==), (/=), (&&), (.), ($), (<$), (/) )
 
-import Data.Int  ( Int8, Int16, Int32 )
+import Data.Int  ( Int8, Int16, Int32, Int64 )
 import Data.Word ( Word8, Word16, Word32, Word64 )
 
 #include "vector.h"
 #include "MachDeps.h"
-
-#if WORD_SIZE_IN_BITS > 32
-import Data.Int  ( Int64 )
-#endif
 
 data Chunk v a = Chunk Int (forall m. (PrimMonad m, Vector v a) => Mutable v (PrimState m) a -> m ())
 

--- a/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
+++ b/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs
@@ -884,8 +884,7 @@ enumFromTo_big_word !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
 
 
 
-#if WORD_SIZE_IN_BITS > 32
-
+#if WORD_SIZE_IN_BITS == 32
 -- FIXME: the "too large" test is totally wrong
 enumFromTo_big_int :: forall m v a. (HasCallStack, Integral a, Monad m) => a -> a -> Bundle m v a
 {-# INLINE_FUSED enumFromTo_big_int #-}
@@ -905,13 +904,6 @@ enumFromTo_big_int !x !y = fromStream (Stream step (Just x)) (Exact (len x y))
     step (Just z) | z == y    = return $ Yield z Nothing
                   | z <  y    = return $ Yield z (Just (z+1))
                   | otherwise = return $ Done
-
-
-{-# RULES
-
-"enumFromTo<Int64> [Bundle]"
-  enumFromTo = enumFromTo_big_int :: Monad m => Int64 -> Int64 -> Bundle m v Int64   #-}
-
 #endif
 
 enumFromTo_char :: Monad m => Char -> Char -> Bundle m v Char
@@ -983,6 +975,7 @@ enumFromTo_double !n !m = fromStream (Stream step ini) (Max (len n lim))
 {-# RULES
 "enumFromTo<Int32> [Bundle]"  enumFromTo @Int32  = enumFromTo_intlike
 "enumFromTo<Word32> [Bundle]" enumFromTo @Word32 = enumFromTo_big_word
+"enumFromTo<Int64> [Bundle]"  enumFromTo @Int64  = enumFromTo_big_int
   #-}
 #endif
 


### PR DESCRIPTION
This is a simplification of rewrite rules: use type application for compactness and group them all together.

Also I found that one of them is wrong. Rule clearly intended for 32-bit builds was enabled for 64-bit instead.

https://github.com/haskell/vector/blob/8c0039f96be60b07e2c30810fab0b96bbc9623fb/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs#L949-L980

Compare
https://github.com/haskell/vector/blob/8c0039f96be60b07e2c30810fab0b96bbc9623fb/vector/src/Data/Vector/Fusion/Bundle/Monadic.hs#L894-L899

That made me think. We notionally support 32-bit platforms, we have CPP for them, but we don't even test buildability on CI. Does anyone has ideas how to add such tests? 