### PR TITLE
Add build on 32-bit platform on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-CACHE_V4
+        key: ${{ runner.os }}-${{ matrix.ghc }}-CACHE_V5
     # ----------------
     - name: "Install PAPI"
       run: |
@@ -117,3 +117,26 @@ jobs:
       run: |
         cabal bench all
       working-directory: unpacked/
+  # Job for checking that vector is buildable and works correctly on 32-bit
+  # systems. Adapted from bitvec's CI setup
+  i386:
+    needs: cabal
+    runs-on: ubuntu-latest
+    container:
+      image: i386/ubuntu:bionic
+    steps:
+    - name: Install
+      run: |
+        apt-get update -y
+        apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl libncurses5 libtinfo5 libncurses5-dev libtinfo-dev
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh
+    - uses: actions/checkout@v1
+    # ----------------
+    - name: Test
+      run: |
+        source ~/.ghcup/env
+        cabal -V
+        ghc -V
+        cabal update
+        cabal build all --write-ghc-environment-files=always
+        cabal test all --enable-tests --test-show-details=direct


### PR DESCRIPTION
Cleanup of RULES for enumFromTo (#557) turned out more complicated that I thought. So let split CI update into  separate PR.

Setup for running on 32-bit platform is copied from bitvec

Also CI cache is reset again. GHC 9.0 is failing again with same symptoms