### PR TITLE
Deprecate reexports of unsafe functions defined in Unsafe modules

### DIFF
--- a/vector/src/Data/Vector.hs
+++ b/vector/src/Data/Vector.hs
@@ -168,20 +168,24 @@ module Data.Vector (
   toList, Data.Vector.fromList, Data.Vector.fromListN,
 
   -- ** Arrays
-  toArray, fromArray, toArraySlice, unsafeFromArraySlice,
+  toArray, fromArray, toArraySlice,
 
   -- ** Other vector types
   G.convert,
 
   -- ** Mutable vectors
-  freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy
+  freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy,
+
+  -- * Deprecated
+  unsafeFromArraySlice
 ) where
 
 import Control.Applicative (Applicative)
 import Data.Primitive.Array
 import qualified Data.Traversable as Traversable
 import Data.Vector.Mutable.Unsafe ( MVector )
-import Data.Vector.Unsafe
+import Data.Vector.Unsafe         ( Vector(..) )
+import qualified Data.Vector.Unsafe  as U
 import qualified Data.Vector.Generic as G
 
 import Control.Monad.ST ( ST )
@@ -2112,6 +2116,19 @@ unsafeCopy = G.unsafeCopy
 copy :: PrimMonad m => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
 copy = G.copy
+
+-- Deprecated
+-- ----------
+
+-- | Unsafe functions are defined in "Data.Vector.Unsafe"
+unsafeFromArraySlice ::
+     Array a -- ^ Immutable boxed array.
+  -> Int -- ^ Offset
+  -> Int -- ^ Length
+  -> Vector a
+{-# INLINE unsafeFromArraySlice #-}
+unsafeFromArraySlice = U.unsafeFromArraySlice
+{-# DEPRECATED unsafeFromArraySlice "Use 'Data.Vector.Unsafe.unsafeCast'" #-}
 
 -- $setup
 -- >>> :set -Wno-type-defaults

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -163,8 +163,10 @@ module Data.Vector.Primitive (
 ) where
 
 import           Control.Applicative (Applicative)
+import           Data.Coerce         (Coercible)
 import qualified Data.Vector.Generic           as G
-import           Data.Vector.Primitive.Unsafe  (Vector,unsafeCoerceVector,unsafeCast)
+import           Data.Vector.Primitive.Unsafe  (Vector)
+import qualified Data.Vector.Primitive.Unsafe  as U
 import           Data.Vector.Primitive.Mutable (MVector)
 import           Data.Vector.Primitive.Pattern
 
@@ -172,6 +174,7 @@ import           Data.Primitive ( Prim )
 
 import Control.Monad.ST ( ST )
 import Control.Monad.Primitive
+import GHC.Stack (HasCallStack)
 
 import Prelude
   ( Eq, Ord, Num, Enum, Monoid, Traversable, Monad, Bool, Ordering(..), Int, Maybe, Either
@@ -1903,6 +1906,18 @@ unsafeCopy = G.unsafeCopy
 copy :: (Prim a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
 copy = G.copy
+
+-- | Unsafe functions are defined in "Data.Vector.Primitive.Unsafe"
+unsafeCoerceVector :: Coercible a b => Vector a -> Vector b
+unsafeCoerceVector = U.unsafeCoerceVector
+{-# DEPRECATED unsafeCoerceVector "Use 'Data.Vector.Primitive.Unsafe.unsafeCoerceVector'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Primitive.Unsafe"
+unsafeCast :: forall a b. (HasCallStack, Prim a, Prim b) => Vector a -> Vector b
+unsafeCast = U.unsafeCast
+{-# INLINE unsafeCast #-}
+{-# DEPRECATED unsafeCast "Use 'Data.Vector.Primitive.Unsafe.unsafeCast'" #-}
+
 
 -- $setup
 -- >>> import Prelude (($), min, even, max, succ, id, Ord(..), Num(..), undefined)

--- a/vector/src/Data/Vector/Primitive.hs
+++ b/vector/src/Data/Vector/Primitive.hs
@@ -152,14 +152,16 @@ module Data.Vector.Primitive (
   toList, fromList, fromListN,
 
   -- ** Other vector types
-  G.convert, unsafeCast,
-  unsafeCoerceVector,
+  G.convert,
 
   -- ** Mutable vectors
   freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy,
 
   -- ** Re-exports
-  Prim
+  Prim,
+
+  -- * Deprecated
+  unsafeCast, unsafeCoerceVector
 ) where
 
 import           Control.Applicative (Applicative)

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -69,13 +69,15 @@ module Data.Vector.Primitive.Mutable (
   Prim, PrimMonad, PrimState, RealWorld
 ) where
 
+import           Data.Coerce (Coercible)
 import qualified Data.Vector.Generic.Mutable as G
 import           Data.Primitive ( Prim )
-import           Data.Vector.Primitive.Mutable.Unsafe
-  (MVector,unsafeCoerceMVector,unsafeCast)
+import           Data.Vector.Primitive.Mutable.Unsafe (MVector)
+import qualified Data.Vector.Primitive.Mutable.Unsafe as U
 import           Data.Vector.Primitive.Pattern
 import           Control.Monad.Primitive
 
+import GHC.Stack (HasCallStack)
 import Prelude ( Ord, Bool, Int, Maybe, Ordering(..) )
 
 #include "vector.h"
@@ -665,6 +667,17 @@ ifoldrM = G.ifoldrM
 ifoldrM' :: (PrimMonad m, Prim a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM' #-}
 ifoldrM' = G.ifoldrM'
+
+-- | Unsafe functions are defined in "Data.Vector.Primitive.Mutable.Unsafe"
+unsafeCoerceMVector :: Coercible a b => MVector s a -> MVector s b
+unsafeCoerceMVector = U.unsafeCoerceMVector
+{-# DEPRECATED unsafeCoerceMVector "Use 'Data.Vector.Primitive.Mutable.Unsafe.unsafeCoerceMVector'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Primitive.Mutable.Unsafe"
+unsafeCast :: forall a b s. (HasCallStack, Prim a, Prim b) => MVector s a -> MVector s b
+unsafeCast = U.unsafeCast
+{-# INLINE unsafeCast #-}
+{-# DEPRECATED unsafeCast "Use 'Data.Vector.Primitive.Mutable.Unsafe.unsafeCast'" #-}
 
 -- $setup
 -- >>> import Prelude (($), Num(..))

--- a/vector/src/Data/Vector/Primitive/Mutable.hs
+++ b/vector/src/Data/Vector/Primitive/Mutable.hs
@@ -63,10 +63,10 @@ module Data.Vector.Primitive.Mutable (
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
 
-  -- * Unsafe conversions
-  unsafeCoerceMVector, unsafeCast,
   -- * Re-exports
-  Prim, PrimMonad, PrimState, RealWorld
+  Prim, PrimMonad, PrimState, RealWorld,
+  -- * Deprecated
+  unsafeCoerceMVector, unsafeCast,
 ) where
 
 import           Data.Coerce (Coercible)

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -153,31 +153,34 @@ module Data.Vector.Storable (
   toList, fromList, fromListN,
 
   -- ** Other vector types
-  G.convert, unsafeCast,
-  unsafeCoerceVector,
+  G.convert,
 
   -- ** Mutable vectors
   freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy,
 
-  -- * Raw pointers
+  -- * Re-exports
+  Storable,
+  -- * Deprecated
+  unsafeCast, unsafeCoerceVector,
   unsafeFromForeignPtr, unsafeFromForeignPtr0,
   unsafeToForeignPtr,   unsafeToForeignPtr0,
-  unsafeWith,
-
-  -- * Re-exports
-  Storable
+  unsafeWith
 ) where
 
 import           Control.Applicative (Applicative)
+import           Data.Coerce
 import qualified Data.Vector.Generic          as G
 import           Data.Vector.Storable.Mutable ( MVector, pattern MVector )
-import Data.Vector.Storable.Unsafe
+import           Data.Vector.Storable.Unsafe  (Vector(..))
+import qualified Data.Vector.Storable.Unsafe  as U
 
 import Control.Monad.ST ( ST )
 import Control.Monad.Primitive
 import Foreign.Storable
+import Foreign.ForeignPtr (ForeignPtr)
+import Foreign.Ptr        (Ptr)
 import Prelude
-  ( Eq, Ord, Num, Enum, Monoid, Traversable, Monad, Bool, Ordering(..), Int, Maybe, Either
+  ( Eq,Ord,Num,Enum,Monoid,Traversable,Monad,Bool,Ordering(..),Int,Maybe,Either,IO
   , (==), (&&))
 
 #include "vector.h"
@@ -1946,9 +1949,57 @@ copy :: (Storable a, PrimMonad m) => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
 copy = G.copy
 
--- Conversions - Raw pointers
--- --------------------------
+-- Deprecated
+-- ----------
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Unsafe"
+unsafeCoerceVector :: Coercible a b => Vector a -> Vector b
+unsafeCoerceVector = U.unsafeCoerceVector
+{-# DEPRECATED unsafeCoerceVector "Use 'Data.Vector.Storable.Unsafe.unsafeCoerceVector'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Unsafe"
+unsafeCast :: forall a b. (Storable a, Storable b) => Vector a -> Vector b
+{-# INLINE unsafeCast #-}
+unsafeCast = U.unsafeCast
+{-# DEPRECATED unsafeCast "Use 'Data.Vector.Storable.Unsafe.unsafeCast'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Unsafe"
+unsafeFromForeignPtr :: Storable a
+                     => ForeignPtr a    -- ^ pointer
+                     -> Int             -- ^ offset
+                     -> Int             -- ^ length
+                     -> Vector a
+{-# INLINE unsafeFromForeignPtr #-}
+unsafeFromForeignPtr = U.unsafeFromForeignPtr
+{-# DEPRECATED unsafeFromForeignPtr "Use 'Data.Vector.Storable.Unsafe.unsafeFromForeignPtr'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Unsafe"
+unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
+                      -> Int             -- ^ length
+                      -> Vector a
+{-# INLINE unsafeFromForeignPtr0 #-}
+unsafeFromForeignPtr0 = U.unsafeFromForeignPtr0
+{-# DEPRECATED unsafeFromForeignPtr0 "Use 'Data.Vector.Storable.Unsafe.unsafeFromForeignPtr0'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Unsafe"
+unsafeToForeignPtr :: Vector a -> (ForeignPtr a, Int, Int)
+{-# INLINE unsafeToForeignPtr #-}
+unsafeToForeignPtr = U.unsafeToForeignPtr
+{-# DEPRECATED unsafeToForeignPtr "Use 'Data.Vector.Storable.Unsafe.unsafeToForeignPtr'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Unsafe"
+unsafeToForeignPtr0 :: Vector a -> (ForeignPtr a, Int)
+{-# INLINE unsafeToForeignPtr0 #-}
+unsafeToForeignPtr0 = U.unsafeToForeignPtr0
+{-# DEPRECATED unsafeToForeignPtr0 "Use 'Data.Vector.Storable.Unsafe.unsafeToForeignPtr0'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Unsafe"
+unsafeWith :: Storable a => Vector a -> (Ptr a -> IO b) -> IO b
+{-# INLINE unsafeWith #-}
+unsafeWith = U.unsafeWith
+{-# DEPRECATED unsafeWith "Use 'Data.Vector.Storable.Unsafe.unsafeWith'" #-}
+
 
 
 -- $setup
--- >>> import Prelude (Bool(..), Double, ($), (+), (/), succ, even, min, max, id, Ord(..))
+-- >>> import Prelude (Bool(..), Double, ($), (+), (/), succ, even, min, max, id, Ord(..), undefined)

--- a/vector/src/Data/Vector/Storable.hs
+++ b/vector/src/Data/Vector/Storable.hs
@@ -176,11 +176,9 @@ import Data.Vector.Storable.Unsafe
 import Control.Monad.ST ( ST )
 import Control.Monad.Primitive
 import Foreign.Storable
-import Foreign.ForeignPtr
 import Prelude
   ( Eq, Ord, Num, Enum, Monoid, Traversable, Monad, Bool, Ordering(..), Int, Maybe, Either
-  , undefined, div
-  , (*), (==), (&&))
+  , (==), (&&))
 
 #include "vector.h"
 
@@ -1884,21 +1882,6 @@ iforA_ :: (Applicative f, Storable a)
 {-# INLINE iforA_ #-}
 iforA_ = G.iforA_
 
-
--- Conversions - Unsafe casts
--- --------------------------
-
--- | /O(1)/ Unsafely cast a vector from one element type to another.
--- This operation just changes the type of the underlying pointer and does not
--- modify the elements.
---
--- The resulting vector contains as many elements as can fit into the
--- underlying memory block.
-unsafeCast :: forall a b. (Storable a, Storable b) => Vector a -> Vector b
-{-# INLINE unsafeCast #-}
-unsafeCast (UnsafeVector n fp)
-  = UnsafeVector ((n * sizeOf (undefined :: a)) `div` sizeOf (undefined :: b))
-                 (castForeignPtr fp)
 
 -- Conversions - Mutable vectors
 -- -----------------------------

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -685,7 +685,7 @@ unsafeCast :: forall a b s.
               (Storable a, Storable b) => MVector s a -> MVector s b
 {-# INLINE unsafeCast #-}
 unsafeCast = U.unsafeCast
-{-# DEPRECATED unsafeCast "Use 'Data.Vector.Storable.Unsafe.unsafeCast'" #-}
+{-# DEPRECATED unsafeCast "Use 'Data.Vector.Storable.Mutable.Unsafe.unsafeCast'" #-}
 
 -- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
 unsafeCoerceMVector :: Coercible a b => MVector s a -> MVector s b
@@ -700,7 +700,7 @@ unsafeFromForeignPtr :: Storable a
                      -> MVector s a
 {-# INLINE_FUSED unsafeFromForeignPtr #-}
 unsafeFromForeignPtr = U.unsafeFromForeignPtr
-{-# DEPRECATED unsafeFromForeignPtr "Use 'Data.Vector.Storable.Unsafe.unsafeFromForeignPtr'" #-}
+{-# DEPRECATED unsafeFromForeignPtr "Use 'Data.Vector.Storable.Mutable.Unsafe.unsafeFromForeignPtr'" #-}
 
 -- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
 unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
@@ -708,25 +708,25 @@ unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
                       -> MVector s a
 {-# INLINE unsafeFromForeignPtr0 #-}
 unsafeFromForeignPtr0 = U.unsafeFromForeignPtr0
-{-# DEPRECATED unsafeFromForeignPtr0 "Use 'Data.Vector.Storable.Unsafe.unsafeFromForeignPtr0'" #-}
+{-# DEPRECATED unsafeFromForeignPtr0 "Use 'Data.Vector.Storable.Mutable.Unsafe.unsafeFromForeignPtr0'" #-}
 
 -- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
 unsafeToForeignPtr :: MVector s a -> (ForeignPtr a, Int, Int)
 {-# INLINE unsafeToForeignPtr #-}
 unsafeToForeignPtr = U.unsafeToForeignPtr
-{-# DEPRECATED unsafeToForeignPtr "Use 'Data.Vector.Storable.Unsafe.unsafeToForeignPtr'" #-}
+{-# DEPRECATED unsafeToForeignPtr "Use 'Data.Vector.Storable.Mutable.Unsafe.unsafeToForeignPtr'" #-}
 
 -- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
 unsafeToForeignPtr0 :: MVector s a -> (ForeignPtr a, Int)
 {-# INLINE unsafeToForeignPtr0 #-}
 unsafeToForeignPtr0 = U.unsafeToForeignPtr0
-{-# DEPRECATED unsafeToForeignPtr0 "Use 'Data.Vector.Storable.Unsafe.unsafeToForeignPtr0'" #-}
+{-# DEPRECATED unsafeToForeignPtr0 "Use 'Data.Vector.Storable.Mutable.Unsafe.unsafeToForeignPtr0'" #-}
 
 -- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
 unsafeWith :: Storable a => IOVector a -> (Ptr a -> IO b) -> IO b
 {-# INLINE unsafeWith #-}
 unsafeWith = U.unsafeWith
-{-# DEPRECATED unsafeWith "Use 'Data.Vector.Storable.Unsafe.unsafeWith'" #-}
+{-# DEPRECATED unsafeWith "Use 'Data.Vector.Storable.Mutable.Unsafe.unsafeWith'" #-}
 
 
 

--- a/vector/src/Data/Vector/Storable/Mutable.hs
+++ b/vector/src/Data/Vector/Storable/Mutable.hs
@@ -65,28 +65,29 @@ module Data.Vector.Storable.Mutable(
   -- ** Filling and copying
   set, copy, move, unsafeCopy, unsafeMove,
 
-  -- * Unsafe conversions
-  unsafeCast,
-  unsafeCoerceMVector,
+  -- * Re-exports
+  Storable, PrimMonad, PrimState, RealWorld,
 
-  -- * Raw pointers
+  -- * Deprecated
+  unsafeCast, unsafeCoerceMVector,
   unsafeFromForeignPtr, unsafeFromForeignPtr0,
   unsafeToForeignPtr,   unsafeToForeignPtr0,
-  unsafeWith,
-  -- * Re-exports
-  Storable, PrimMonad, PrimState, RealWorld
+  unsafeWith
 ) where
 
+import Data.Coerce
 import qualified Data.Vector.Generic.Mutable as G
 import Data.Vector.Storable.Mutable.Unsafe(
-  MVector,IOVector,STVector,unsafeCast,unsafeWith,unsafeCoerceMVector,
-  unsafeToForeignPtr,unsafeToForeignPtr0,unsafeFromForeignPtr,unsafeFromForeignPtr0)
+  MVector,IOVector,STVector)
+import qualified Data.Vector.Storable.Mutable.Unsafe as U
 import           Data.Vector.Storable.Pattern
 import Foreign.Storable
+import Foreign.ForeignPtr (ForeignPtr)
+import Foreign.Ptr        (Ptr)
 
 import Control.Monad.Primitive
 
-import Prelude (Int, Ord, Bool, Maybe, Ordering(..) )
+import Prelude (IO, Int, Ord, Bool, Maybe, Ordering(..) )
 
 #include "vector.h"
 
@@ -674,6 +675,60 @@ ifoldrM = G.ifoldrM
 ifoldrM' :: (PrimMonad m, Storable a) => (Int -> a -> b -> m b) -> b -> MVector (PrimState m) a -> m b
 {-# INLINE ifoldrM' #-}
 ifoldrM' = G.ifoldrM'
+
+
+-- Deprecated
+-- ----------
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
+unsafeCast :: forall a b s.
+              (Storable a, Storable b) => MVector s a -> MVector s b
+{-# INLINE unsafeCast #-}
+unsafeCast = U.unsafeCast
+{-# DEPRECATED unsafeCast "Use 'Data.Vector.Storable.Unsafe.unsafeCast'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
+unsafeCoerceMVector :: Coercible a b => MVector s a -> MVector s b
+unsafeCoerceMVector = U.unsafeCoerceMVector
+{-# DEPRECATED unsafeCoerceMVector "Use 'Data.Vector.Storable.Unsafe.unsafeCoerceMVector'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
+unsafeFromForeignPtr :: Storable a
+                     => ForeignPtr a    -- ^ pointer
+                     -> Int             -- ^ offset
+                     -> Int             -- ^ length
+                     -> MVector s a
+{-# INLINE_FUSED unsafeFromForeignPtr #-}
+unsafeFromForeignPtr = U.unsafeFromForeignPtr
+{-# DEPRECATED unsafeFromForeignPtr "Use 'Data.Vector.Storable.Unsafe.unsafeFromForeignPtr'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
+unsafeFromForeignPtr0 :: ForeignPtr a    -- ^ pointer
+                      -> Int             -- ^ length
+                      -> MVector s a
+{-# INLINE unsafeFromForeignPtr0 #-}
+unsafeFromForeignPtr0 = U.unsafeFromForeignPtr0
+{-# DEPRECATED unsafeFromForeignPtr0 "Use 'Data.Vector.Storable.Unsafe.unsafeFromForeignPtr0'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
+unsafeToForeignPtr :: MVector s a -> (ForeignPtr a, Int, Int)
+{-# INLINE unsafeToForeignPtr #-}
+unsafeToForeignPtr = U.unsafeToForeignPtr
+{-# DEPRECATED unsafeToForeignPtr "Use 'Data.Vector.Storable.Unsafe.unsafeToForeignPtr'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
+unsafeToForeignPtr0 :: MVector s a -> (ForeignPtr a, Int)
+{-# INLINE unsafeToForeignPtr0 #-}
+unsafeToForeignPtr0 = U.unsafeToForeignPtr0
+{-# DEPRECATED unsafeToForeignPtr0 "Use 'Data.Vector.Storable.Unsafe.unsafeToForeignPtr0'" #-}
+
+-- | Unsafe functions are defined in "Data.Vector.Storable.Mutable.Unsafe"
+unsafeWith :: Storable a => IOVector a -> (Ptr a -> IO b) -> IO b
+{-# INLINE unsafeWith #-}
+unsafeWith = U.unsafeWith
+{-# DEPRECATED unsafeWith "Use 'Data.Vector.Storable.Unsafe.unsafeWith'" #-}
+
+
 
 -- $setup
 -- >>> import Prelude (($), Num(..))

--- a/vector/src/Data/Vector/Storable/Unsafe.hs
+++ b/vector/src/Data/Vector/Storable/Unsafe.hs
@@ -15,6 +15,7 @@
 module Data.Vector.Storable.Unsafe
   ( Vector(..)
   , unsafeCoerceVector
+  , unsafeCast
     -- * Raw pointers
   , unsafeFromForeignPtr, unsafeFromForeignPtr0
   , unsafeToForeignPtr,   unsafeToForeignPtr0
@@ -36,8 +37,8 @@ import Control.DeepSeq ( NFData(rnf), NFData1(liftRnf))
 import Control.Monad.Primitive
 
 import Prelude
-  ( Eq, Ord, Monoid, Read, Show, Ordering(..), Int, IO
-  , compare, mempty, mappend, mconcat, showsPrec, return, seq
+  ( Eq, Ord, Monoid, Read, Show, Ordering(..), Int, IO, Num(..)
+  , compare, mempty, mappend, mconcat, showsPrec, return, seq, undefined, div
   , (<), (<=), (>), (>=), (==), (/=), (.), ($) )
 
 import Data.Data      ( Data(..) )
@@ -61,6 +62,18 @@ type role Vector nominal
 -- 'Storable' instances.
 unsafeCoerceVector :: Coercible a b => Vector a -> Vector b
 unsafeCoerceVector = unsafeCoerce
+
+-- | /O(1)/ Unsafely cast a vector from one element type to another.
+-- This operation just changes the type of the underlying pointer and does not
+-- modify the elements.
+--
+-- The resulting vector contains as many elements as can fit into the
+-- underlying memory block.
+unsafeCast :: forall a b. (Storable a, Storable b) => Vector a -> Vector b
+{-# INLINE unsafeCast #-}
+unsafeCast (UnsafeVector n fp)
+  = UnsafeVector ((n * sizeOf (undefined :: a)) `div` sizeOf (undefined :: b))
+                 (castForeignPtr fp)
 
 -- | 'Storable'-based vectors.
 data Vector a = UnsafeVector

--- a/vector/src/Data/Vector/Strict.hs
+++ b/vector/src/Data/Vector/Strict.hs
@@ -168,13 +168,15 @@ module Data.Vector.Strict (
   -- ** Lazy vectors
   toLazy, fromLazy,
   -- ** Arrays
-  toArray, fromArray, toArraySlice, unsafeFromArraySlice,
+  toArray, fromArray, toArraySlice,
 
   -- ** Other vector types
   G.convert,
 
   -- ** Mutable vectors
-  freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy
+  freeze, thaw, copy, unsafeFreeze, unsafeThaw, unsafeCopy,
+  -- * Deprecated
+  unsafeFromArraySlice
 ) where
 
 import Control.Applicative (Applicative)
@@ -182,7 +184,8 @@ import Control.Monad.Primitive
 import Control.DeepSeq (NFData1(liftRnf))
 import Data.Primitive.Array
 import Data.Vector.Strict.Mutable.Unsafe  ( MVector(..) )
-import Data.Vector.Strict.Unsafe
+import Data.Vector.Strict.Unsafe          ( Vector(..) )
+import qualified Data.Vector.Strict.Unsafe as U
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector as V
 import qualified Data.Traversable as Traversable
@@ -2467,6 +2470,20 @@ unsafeCopy = G.unsafeCopy
 copy :: PrimMonad m => MVector (PrimState m) a -> Vector a -> m ()
 {-# INLINE copy #-}
 copy = G.copy
+
+-- Deprecated
+-- ----------
+
+-- | Unsafe functions are defined in "Data.Vector.Primitive.Unsafe"
+unsafeFromArraySlice ::
+     Array a -- ^ Immutable boxed array.
+  -> Int -- ^ Offset
+  -> Int -- ^ Length
+  -> Vector a
+{-# INLINE unsafeFromArraySlice #-}
+unsafeFromArraySlice = U.unsafeFromArraySlice
+{-# DEPRECATED unsafeFromArraySlice "Use 'Data.Vector.Strict.Unsafe.unsafeCast'" #-}
+
 
 -- $setup
 -- >>> :set -Wno-type-defaults

--- a/vector/src/Data/Vector/Strict/Unsafe.hs
+++ b/vector/src/Data/Vector/Strict/Unsafe.hs
@@ -27,6 +27,7 @@ import Data.Primitive.Array
 import qualified Data.Vector.Generic as G
 import Data.Vector.Generic ((!))
 import qualified Data.Vector as V
+import qualified Data.Vector.Unsafe as UV
 
 import Control.DeepSeq ( NFData(rnf), NFData1(liftRnf))
 
@@ -256,4 +257,4 @@ unsafeFromArraySlice ::
   -> Vector a
 {-# INLINE unsafeFromArraySlice #-}
 unsafeFromArraySlice arr offset len = liftRnf (`seq` ()) vec `seq` vec
-  where vec = UnsafeVector (V.unsafeFromArraySlice arr offset len)
+  where vec = UnsafeVector (UV.unsafeFromArraySlice arr offset len)


### PR DESCRIPTION
This is partial (only `Primitive` modules) implementation of stage 2 of plan described in https://github.com/haskell/vector/pull/540#issuecomment-3877255972 Once we're happy with implementation for primitive we can replicate it for other unsafe functions.

Deprecation of reexports was introduced in GHC9.8 so we have to define new functions to deprecate. Haddocks for deprecated reexports looks like this:
<img width="2472" height="525" alt="image" src="https://github.com/user-attachments/assets/c77e7b31-8740-4e3c-b3b1-e1c19d41be56" />
