### PR TITLE
Bump QuickCheck dependency

### DIFF
--- a/vector/vector.cabal
+++ b/vector/vector.cabal
@@ -202,7 +202,7 @@ common tests-common
                , deepseq
                , primitive
                , random
-               , QuickCheck >= 2.9 && < 2.16
+               , QuickCheck >= 2.9 && < 2.19
                , tasty
                , tasty-hunit
                , tasty-quickcheck


### PR DESCRIPTION
I've checked that package builds and tests pass with QC-2.16 locally

Fixes #562